### PR TITLE
fix: use real proxy token with cloudflare

### DIFF
--- a/packages/client/src/proxies/github.ts
+++ b/packages/client/src/proxies/github.ts
@@ -65,7 +65,7 @@ export function github(opts?: { policy?: string | ProxyPolicy }): ProxyFactory<{
 			policy: resolvedPolicy,
 			setup: [
 				'git config --global url."{{proxyUrl}}/".insteadOf "https://github.com/"',
-				'git config --global http.{{proxyUrl}}/.extraheader "Authorization: Bearer proxy-placeholder"',
+				'git config --global http.{{proxyUrl}}/.extraheader "Authorization: Bearer {{proxyToken}}"',
 			],
 			denyResponse,
 		};
@@ -106,8 +106,8 @@ function resolveGitHubPolicy(policy?: string | ProxyPolicy): ProxyPolicy {
 					// gh CLI uses POST /graphql for most read operations
 					{ method: 'POST', path: '/graphql', body: githubBody.graphql() },
 					// git clone / fetch
-					{ method: 'POST', path: '/*/git-upload-pack' },
-					{ method: 'GET', path: '/*/info/refs' },
+					{ method: 'POST', path: '/**/git-upload-pack' },
+					{ method: 'GET', path: '/**/info/refs' },
 					...userAllow,
 				],
 				deny: userDeny,

--- a/packages/cloudflare/src/runner.ts
+++ b/packages/cloudflare/src/runner.ts
@@ -15,6 +15,7 @@ export class FlueRuntime {
 	private readonly sessionId: string;
 	private opencodeServer: OpencodeServer | null = null;
 	private resolvedProxies: ProxyService[] = [];
+	private proxyToken: string | null = null;
 	private _client: FlueClient | null = null;
 	private setupComplete = false;
 
@@ -71,7 +72,7 @@ export class FlueRuntime {
 			await this.setupProxies();
 		}
 
-		const opencodeConfig = this.buildOpencodeConfig();
+		const opencodeConfig = await this.buildOpencodeConfig();
 		console.log(`[flue] setup: starting OpenCode server (workdir: ${this.workdir})`);
 		const result = await createOpencode(this.sandbox, {
 			port: 48765,
@@ -123,7 +124,7 @@ export class FlueRuntime {
 		if (!secret) throw new Error('[flue] gateway.secret is required when proxies are configured');
 		if (!kv) throw new Error('[flue] gateway.kv is required when proxies are configured');
 
-		const proxyToken = await generateProxyToken(secret, this.sessionId);
+		const proxyToken = await this.getOrCreateProxyToken();
 		const envVars: Record<string, string> = {};
 
 		for (const proxy of proxies) {
@@ -207,7 +208,7 @@ export class FlueRuntime {
 	/**
 	 * Build OpenCode config, routing model providers through proxies when available.
 	 */
-	private buildOpencodeConfig(): object {
+	private async buildOpencodeConfig(): Promise<object> {
 		const gateway = this.options.gateway;
 		const proxies = this.resolvedProxies;
 
@@ -216,6 +217,7 @@ export class FlueRuntime {
 		}
 
 		const providerConfig: Record<string, object> = {};
+		const proxyToken = await this.getOrCreateProxyToken();
 		for (const proxy of proxies) {
 			if (proxy.isModelProvider && proxy.providerConfig) {
 				const { providerKey, options = {} } = proxy.providerConfig;
@@ -224,6 +226,7 @@ export class FlueRuntime {
 					options: {
 						baseURL: `${proxyUrl}/v1`,
 						...options,
+						apiKey: proxyToken,
 					},
 				};
 			}
@@ -237,6 +240,22 @@ export class FlueRuntime {
 			...(this.options.opencodeConfig as Record<string, unknown> | undefined),
 			provider: providerConfig,
 		};
+	}
+
+	/**
+	 * Lazily create a proxy token and reuse it across setup phases.
+	 */
+	private async getOrCreateProxyToken(): Promise<string> {
+		if (this.proxyToken) return this.proxyToken;
+
+		const gateway = this.options.gateway;
+		const secret = gateway?.secret;
+		if (!secret) {
+			throw new Error('[flue] gateway.secret is required when proxies are configured');
+		}
+
+		this.proxyToken = await generateProxyToken(secret, this.sessionId);
+		return this.proxyToken;
 	}
 }
 

--- a/packages/cloudflare/src/worker.ts
+++ b/packages/cloudflare/src/worker.ts
@@ -134,7 +134,7 @@ export class FlueWorker<E extends Record<string, any>> extends Hono<{ Bindings: 
 				return c.json({ error: 'proxy not configured' }, 500);
 			}
 
-			const token = extractBearerToken(c.req.header('Authorization'));
+			const token = extractBearerToken(c.req.header('Authorization')) ?? c.req.header('x-api-key') ?? null;
 			if (!token || !(await validateProxyToken(secret, sessionId, token))) {
 				return c.json({ error: 'invalid proxy token' }, 401);
 			}


### PR DESCRIPTION
Fixed three Cloudflare proxy integration issues that surfaced with real gateway auth/policy behavior:

- Updated `github()` git setup to use `{{proxyToken}}` in `http.extraheader` instead of the literal placeholder.  
  - Why: Cloudflare proxy endpoints validate bearer tokens; the hardcoded placeholder caused git smart-HTTP auth failures.

- Corrected default GitHub allow-read git path rules from single-segment to multi-segment globs (`/*/...` -> `/**/...`).  
  - Why: real GitHub git endpoints are `/<owner>/<repo>.git/...`; with `*` semantics (one segment), `git-upload-pack`/`info/refs` never matched and POSTs were denied by base `allow-read`.

- Changed Cloudflare `FlueRuntime` OpenCode provider config generation to inject the generated proxy token as provider `apiKey` for model-provider proxies (with token reuse across setup).  
  - Why: provider presets carry dummy keys for local proxy mode; in Cloudflare those values were sent as bearer tokens to the gateway and rejected. Using the real proxy token aligns OpenCode auth with gateway expectations.