### PR TITLE
feat: add option for shell commands to throw

### DIFF
--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -35,9 +35,10 @@ Run a shell command in the target environment. Returns `{ stdout, stderr, exitCo
 ```ts
 const result = await flue.shell('pnpm test');
 const result = await flue.shell('cat -', { stdin: 'hello' });
+await flue.shell('pnpm test', { throwOnError: true });
 ```
 
-Options: `env`, `stdin`, `cwd`, `timeout`
+Options: `env`, `stdin`, `cwd`, `timeout`, `throwOnError`
 
 ### `flue.skill(name, options?)`
 

--- a/packages/client/src/errors.ts
+++ b/packages/client/src/errors.ts
@@ -17,3 +17,31 @@ export class SkillOutputError extends Error {
 		this.validationErrors = opts.validationErrors;
 	}
 }
+
+/**
+ * Error thrown when a shell command exits with a non-zero code and
+ * `throwOnError` is enabled.
+ */
+export class ShellCommandError extends Error {
+	command: string;
+	stdout: string;
+	stderr: string;
+	exitCode: number;
+
+	constructor(
+		command: string,
+		opts: { stdout: string; stderr: string; exitCode: number },
+	) {
+		const details = opts.stderr.trim() || opts.stdout.trim();
+		super(
+			details
+				? `[flue] Shell command failed with exit code ${opts.exitCode}: ${command}\n${details}`
+				: `[flue] Shell command failed with exit code ${opts.exitCode}: ${command}`,
+		);
+		this.name = 'ShellCommandError';
+		this.command = command;
+		this.stdout = opts.stdout;
+		this.stderr = opts.stderr;
+		this.exitCode = opts.exitCode;
+	}
+}

--- a/packages/client/src/flue.ts
+++ b/packages/client/src/flue.ts
@@ -1,5 +1,6 @@
 import { createOpencodeClient, type OpencodeClient } from '@opencode-ai/sdk';
 import type * as v from 'valibot';
+import { ShellCommandError } from './errors.ts';
 import { buildProxyInstructions, buildResultInstructions, HEADLESS_PREAMBLE } from './prompt.ts';
 import { runPrompt, runSkill } from './skill.ts';
 import type {
@@ -95,7 +96,11 @@ export class FlueClient {
 
 	/** Execute a shell command with scoped environment variables. */
 	async shell(command: string, options?: ShellOptions): Promise<ShellResult> {
-		return this.shellFn(command, { ...options, cwd: options?.cwd ?? this.workdir });
+		const result = await this.shellFn(command, { ...options, cwd: options?.cwd ?? this.workdir });
+		if (options?.throwOnError && result.exitCode !== 0) {
+			throw new ShellCommandError(command, result);
+		}
+		return result;
 	}
 
 	/** Close the OpenCode client connection. */

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,4 +1,4 @@
-export { SkillOutputError } from './errors.ts';
+export { ShellCommandError, SkillOutputError } from './errors.ts';
 export { type FlueEvent, transformEvent } from './events.ts';
 export { FlueClient } from './flue.ts';
 export type { PolicyRule, ProxyPolicy, ProxyPresetResult, ProxyService } from './proxies/types.ts';

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -47,6 +47,8 @@ export interface ShellOptions {
 	cwd?: string;
 	/** Timeout in milliseconds. */
 	timeout?: number;
+	/** Throw a ShellCommandError when the command exits non-zero. */
+	throwOnError?: boolean;
 }
 
 export interface ShellResult {

--- a/skills/flue/SKILL.md
+++ b/skills/flue/SKILL.md
@@ -31,9 +31,12 @@ const issue = JSON.parse(result.stdout);
 
 // With stdin
 await flue.shell('gh issue comment 123 --body-file -', { stdin: commentBody });
+
+// Throw when the command exits non-zero
+await flue.shell('pnpm test', { throwOnError: true });
 ```
 
-**Options:** `env`, `stdin`, `cwd`, `timeout`
+**Options:** `env`, `stdin`, `cwd`, `timeout`, `throwOnError`
 
 ### `flue.prompt(text, options?)`
 


### PR DESCRIPTION
Had to write a helper function to wrap shell calls to have them throw when the shell command returned a non-zero exit code. 

Thought this would be a good addition as a QoL option. 

LMK if you feel otherwise.