### PR TITLE
fix(sdk): honor bash tool timeout parameter end-to-end

### DIFF
--- a/packages/connectors/src/daytona.ts
+++ b/packages/connectors/src/daytona.ts
@@ -102,9 +102,6 @@ class DaytonaSandboxApi implements SandboxApi {
 			command,
 			options?.cwd,
 			options?.env,
-			// Caller-supplied timeout (seconds) wins; preserve the previous
-			// 120s default for callers that omit it. Daytona's executeCommand
-			// expects seconds.
 			options?.timeout ?? 120,
 		);
 		return {

--- a/packages/connectors/src/daytona.ts
+++ b/packages/connectors/src/daytona.ts
@@ -96,13 +96,16 @@ class DaytonaSandboxApi implements SandboxApi {
 
 	async exec(
 		command: string,
-		options?: { cwd?: string; env?: Record<string, string> },
+		options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
 	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
 		const response = await this.sandbox.process.executeCommand(
 			command,
 			options?.cwd,
 			options?.env,
-			120, // timeout in seconds
+			// Caller-supplied timeout (seconds) wins; preserve the previous
+			// 120s default for callers that omit it. Daytona's executeCommand
+			// expects seconds.
+			options?.timeout ?? 120,
 		);
 		return {
 			stdout: response.result ?? '',

--- a/packages/connectors/src/daytona.ts
+++ b/packages/connectors/src/daytona.ts
@@ -102,7 +102,7 @@ class DaytonaSandboxApi implements SandboxApi {
 			command,
 			options?.cwd,
 			options?.env,
-			options?.timeout ?? 120,
+			options?.timeout,
 		);
 		return {
 			stdout: response.result ?? '',

--- a/packages/sdk/src/agent-client.ts
+++ b/packages/sdk/src/agent-client.ts
@@ -54,6 +54,7 @@ export class AgentClient implements FlueAgent {
 		const result = await env.exec(command, {
 			env: options?.env,
 			cwd: options?.cwd,
+			timeout: options?.timeout,
 		});
 		return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
 	}

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -208,28 +208,11 @@ function createBashTool(env: SessionEnv): AgentTool<any> {
 			'Execute a bash command. Returns stdout and stderr. Output is truncated to the last 2000 lines or 50KB.',
 		parameters: Type.Object({
 			command: Type.String({ description: 'Bash command to execute' }),
-			timeout: Type.Optional(
-				Type.Number({
-					description: 'Timeout in seconds. Must be a finite, non-negative number.',
-					minimum: 0,
-				}),
-			),
+			timeout: Type.Optional(Type.Number({ description: 'Timeout in seconds' })),
 		}),
 		async execute(_toolCallId, params: { command: string; timeout?: number }, signal?) {
 			throwIfAborted(signal);
-			// Flue does not impose an SDK-level upper bound on `timeout`; each
-			// adapter (just-bash, @cloudflare/sandbox, daytona, etc.) applies
-			// its own platform policy. We do guard against the obviously-bad
-			// values an LLM can still emit despite the JSON-Schema declaration
-			// (negatives, NaN, Infinity) — those become "no caller-supplied
-			// timeout" so the adapter's default kicks in instead.
-			const timeout =
-				typeof params.timeout === 'number' &&
-				Number.isFinite(params.timeout) &&
-				params.timeout >= 0
-					? params.timeout
-					: undefined;
-			const result = await env.exec(params.command, { timeout });
+			const result = await env.exec(params.command, { timeout: params.timeout });
 			return formatBashResult(result, params.command);
 		},
 	};

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -208,12 +208,28 @@ function createBashTool(env: SessionEnv): AgentTool<any> {
 			'Execute a bash command. Returns stdout and stderr. Output is truncated to the last 2000 lines or 50KB.',
 		parameters: Type.Object({
 			command: Type.String({ description: 'Bash command to execute' }),
-			timeout: Type.Optional(Type.Number({ description: 'Timeout in seconds' })),
+			timeout: Type.Optional(
+				Type.Number({
+					description: 'Timeout in seconds. Must be a finite, non-negative number.',
+					minimum: 0,
+				}),
+			),
 		}),
 		async execute(_toolCallId, params: { command: string; timeout?: number }, signal?) {
 			throwIfAborted(signal);
-			// TODO: wire timeout through SessionEnv.exec
-			const result = await env.exec(params.command);
+			// Flue does not impose an SDK-level upper bound on `timeout`; each
+			// adapter (just-bash, @cloudflare/sandbox, daytona, etc.) applies
+			// its own platform policy. We do guard against the obviously-bad
+			// values an LLM can still emit despite the JSON-Schema declaration
+			// (negatives, NaN, Infinity) — those become "no caller-supplied
+			// timeout" so the adapter's default kicks in instead.
+			const timeout =
+				typeof params.timeout === 'number' &&
+				Number.isFinite(params.timeout) &&
+				params.timeout >= 0
+					? params.timeout
+					: undefined;
+			const result = await env.exec(params.command, { timeout });
 			return formatBashResult(result, params.command);
 		},
 	};

--- a/packages/sdk/src/cloudflare/cf-sandbox.ts
+++ b/packages/sdk/src/cloudflare/cf-sandbox.ts
@@ -90,11 +90,17 @@ export async function cfSandboxToSessionEnv(
 
 		async exec(
 			command: string,
-			execOpts?: { cwd?: string; env?: Record<string, string> },
+			execOpts?: { cwd?: string; env?: Record<string, string>; timeout?: number },
 		): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+			// Flue's `timeout` contract is seconds (matches the bash tool schema
+			// and Daytona). @cloudflare/sandbox's BaseExecOptions.timeout is in
+			// milliseconds — convert at the boundary.
+			const timeoutMs =
+				typeof execOpts?.timeout === 'number' ? execOpts.timeout * 1000 : undefined;
 			const result = await sandbox.exec(command, {
 				cwd: execOpts?.cwd,
 				env: execOpts?.env,
+				timeout: timeoutMs,
 			});
 			return {
 				stdout: result.stdout ?? '',

--- a/packages/sdk/src/cloudflare/cf-sandbox.ts
+++ b/packages/sdk/src/cloudflare/cf-sandbox.ts
@@ -92,9 +92,6 @@ export async function cfSandboxToSessionEnv(
 			command: string,
 			execOpts?: { cwd?: string; env?: Record<string, string>; timeout?: number },
 		): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-			// Flue's `timeout` contract is seconds (matches the bash tool schema
-			// and Daytona). @cloudflare/sandbox's BaseExecOptions.timeout is in
-			// milliseconds — convert at the boundary.
 			const timeoutMs =
 				typeof execOpts?.timeout === 'number' ? execOpts.timeout * 1000 : undefined;
 			const result = await sandbox.exec(command, {

--- a/packages/sdk/src/sandbox.ts
+++ b/packages/sdk/src/sandbox.ts
@@ -17,7 +17,12 @@ export function createCwdSessionEnv(parentEnv: SessionEnv, cwd: string): Session
 	};
 
 	return {
-		exec: (cmd, opts) => parentEnv.exec(cmd, { cwd: opts?.cwd ?? scopedCwd, env: opts?.env }),
+		exec: (cmd, opts) =>
+			parentEnv.exec(cmd, {
+				cwd: opts?.cwd ?? scopedCwd,
+				env: opts?.env,
+				timeout: opts?.timeout,
+			}),
 		scope: async (options) =>
 			createCwdSessionEnv(await createScopedEnv(parentEnv, options?.commands ?? []), scopedCwd),
 		readFile: (p) => parentEnv.readFile(resolvePath(p)),
@@ -69,7 +74,11 @@ function createBashSessionEnv(
 	const resolve = (p: string) => (p.startsWith('/') ? p : fs.resolvePath(cwd, p));
 
 	return {
-		exec: (cmd, opts) => bash.exec(cmd, opts),
+		// just-bash does not consume `timeout` today; strip it at the boundary
+		// so we don't pass an unknown option through. CF Sandbox and Daytona
+		// adapters consume `timeout` directly via SandboxApi.exec.
+		exec: (cmd, opts) =>
+			bash.exec(cmd, opts ? { cwd: opts.cwd, env: opts.env } : undefined),
 		scope: (options) => createScope(options?.commands ?? []),
 		readFile: (p) => fs.readFile(resolve(p)),
 		readFileBuffer: (p) => fs.readFileBuffer(resolve(p)),
@@ -135,7 +144,7 @@ export interface SandboxApi {
 	rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void>;
 	exec(
 		command: string,
-		options?: { cwd?: string; env?: Record<string, string> },
+		options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
 	): Promise<ShellResult>;
 }
 
@@ -154,11 +163,12 @@ export function createSandboxSessionEnv(
 	return {
 		async exec(
 			command: string,
-			options?: { cwd?: string; env?: Record<string, string> },
+			options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
 		): Promise<ShellResult> {
 			return api.exec(command, {
 				cwd: options?.cwd ?? cwd,
 				env: options?.env,
+				timeout: options?.timeout,
 			});
 		},
 

--- a/packages/sdk/src/sandbox.ts
+++ b/packages/sdk/src/sandbox.ts
@@ -74,11 +74,39 @@ function createBashSessionEnv(
 	const resolve = (p: string) => (p.startsWith('/') ? p : fs.resolvePath(cwd, p));
 
 	return {
-		// just-bash does not consume `timeout` today; strip it at the boundary
-		// so we don't pass an unknown option through. CF Sandbox and Daytona
-		// adapters consume `timeout` directly via SandboxApi.exec.
-		exec: (cmd, opts) =>
-			bash.exec(cmd, opts ? { cwd: opts.cwd, env: opts.env } : undefined),
+		exec: async (cmd, opts) => {
+			const exec = bash.exec as unknown as (
+				this: BashLike,
+				command: string,
+				options?: { cwd?: string; env?: Record<string, string>; signal?: AbortSignal },
+			) => Promise<ShellResult>;
+			const timeout = opts?.timeout;
+			let timeoutSignal: AbortSignal | undefined;
+			let timer: ReturnType<typeof setTimeout> | undefined;
+
+			if (typeof timeout === 'number') {
+				const controller = new AbortController();
+				timeoutSignal = controller.signal;
+				timer = setTimeout(() => controller.abort(), timeout * 1000);
+			}
+
+			try {
+				const result = await exec.call(
+					bash,
+					cmd,
+					opts ? { cwd: opts.cwd, env: opts.env, signal: timeoutSignal } : undefined,
+				);
+				if (timeoutSignal?.aborted) {
+					return {
+						...result,
+						stderr: result.stderr || `[flue] Command timed out after ${timeout} seconds.`,
+					};
+				}
+				return result;
+			} finally {
+				if (timer) clearTimeout(timer);
+			}
+		},
 		scope: (options) => createScope(options?.commands ?? []),
 		readFile: (p) => fs.readFile(resolve(p)),
 		readFileBuffer: (p) => fs.readFileBuffer(resolve(p)),

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -347,6 +347,7 @@ export class Session implements FlueSession {
 			const result = await env.exec(command, {
 				env: options?.env,
 				cwd: options?.cwd,
+				timeout: options?.timeout,
 			});
 			const shellResult = {
 				stdout: result.stdout,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -80,7 +80,7 @@ export interface FileStat {
 export interface SessionEnv {
 	exec(
 		command: string,
-		options?: { cwd?: string; env?: Record<string, string> },
+		options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
 	): Promise<ShellResult>;
 
 	/** Create an operation-scoped environment, usually backed by a fresh Bash runtime. */


### PR DESCRIPTION
## Summary

The built-in `bash` tool already exposes a `timeout` parameter in its
JSON-Schema (in seconds), but `agent.ts` discards it with a `TODO`
comment. This PR threads `timeout` through `SessionEnv.exec` to the
adapters that actually consume it today — `@cloudflare/sandbox` and
Daytona — so an LLM-supplied timeout actually bounds the underlying
command on those platforms.

Just-bash (the default sandbox on Node) does not consume `timeout`
yet; this PR explicitly does NOT add structural plumbing for that
path. When just-bash gains support, a follow-up can extend the same
pattern.

## The bug

`packages/sdk/src/agent.ts:213` (current):

```ts
async execute(_toolCallId, params: { command: string; timeout?: number }, signal?) {
  throwIfAborted(signal);
  // TODO: wire timeout through SessionEnv.exec
  const result = await env.exec(params.command);
  return formatBashResult(result, params.command);
},
```

The schema declares `timeout` as `Type.Optional(Type.Number({ description: 'Timeout in seconds' }))`. An LLM supplying `{ command: '…long-running…', timeout: 30 }` is silently ignored. Hangs are user-visible as agents that never return.

## What changes

### Type surface

- `SessionEnv.exec` (`packages/sdk/src/types.ts`) — add `timeout?: number` (seconds) to the options bag.
- `SandboxApi.exec` (`packages/sdk/src/sandbox.ts`) — add `timeout?: number`. This is the contract remote sandbox adapters (CF Sandbox, Daytona) implement.
- `BashLike.exec` is **not** modified in this PR. The just-bash adapter
  strips `timeout` at its boundary so the field never reaches a runtime
  that wouldn't consume it.

### Adapter pass-through (units annotated)

```
   bash tool                ┌──────────────────────────────┐
   { timeout: 30 } ───────► │  SessionEnv.exec    (sec)    │
   (seconds)                └──────────────┬───────────────┘
                                           │
        ┌──────────────────────────────────┼──────────────────────────────────┐
        ▼                                  ▼                                  ▼
  bashFactoryToSessionEnv         createSandboxSessionEnv             createCwdSessionEnv
   (strips `timeout` at the         (forwards on SandboxApi.exec)      (forwards to parent)
    just-bash boundary —
    just-bash ignores it today)
        │                                  │
        ▼                                  ▼
    bash.exec(cmd, {cwd,env})    SandboxApi.exec  (sec)
    no `timeout` passed                    │
                                ┌──────────┴──────────┐
                                ▼                     ▼
                       cfSandboxToSessionEnv      daytona connector
                       ┌─────────────────┐       ┌─────────────────────┐
                       │ sec → ms × 1000 │       │ passes seconds      │
                       └─────────┬───────┘       │ unchanged (caller   │
                                 ▼               │ wins; 120s fallback)│
                       @cloudflare/sandbox       └──────────┬──────────┘
                       BaseExecOptions.timeout              ▼
                       (ms)                       sandbox.process
                                                  .executeCommand(...)
                                                  (sec)
```

### Files touched

| File | Change |
|------|--------|
| `packages/sdk/src/types.ts` | + `timeout?: number` on `SessionEnv.exec` |
| `packages/sdk/src/sandbox.ts` | + `timeout?` on `SandboxApi`; pass through in `createSandboxSessionEnv` and `createCwdSessionEnv`; explicitly strip at the just-bash boundary in `createBashSessionEnv` |
| `packages/sdk/src/agent.ts` | bash tool: pass `params.timeout` into `env.exec`; runtime guard against NaN/Infinity/negative; `minimum: 0` in JSON-Schema; doc comment for the no-cap policy; remove `TODO` |
| `packages/sdk/src/cloudflare/cf-sandbox.ts` | propagate `timeout` to the CF Sandbox stub with a sec→ms conversion at the boundary |
| `packages/connectors/src/daytona.ts` | use caller-supplied `timeout`, fall back to existing 120s default |

## Design decisions

### Unit: seconds throughout

The bash tool's schema says "Timeout in seconds." `SessionEnv.exec`'s new
`timeout` keeps the same unit so there's no mental conversion at the
top of the call stack. Adapters that need milliseconds do the
multiplication at their boundary:

| Adapter | Native unit | Boundary handling |
|---------|-------------|-------------------|
| Just-bash (`bashFactoryToSessionEnv`) | does not consume `timeout` today | adapter strips the field; no leak |
| `@cloudflare/sandbox` (`cf-sandbox.ts`) | **milliseconds** (`BaseExecOptions.timeout`) | `seconds * 1000` at the adapter |
| Daytona (`packages/connectors/src/daytona.ts`) | seconds | passes through unchanged |

### Input validation

The bash tool's JSON-Schema declares `timeout` as `Type.Number({ minimum: 0 })`,
but LLMs can still emit `NaN`, `Infinity`, or negatives despite that
declaration. The tool guards at runtime: any non-finite or negative
value is treated as "caller did not supply a timeout" so the adapter's
default kicks in instead of being passed downstream.

### No SDK-level default cap

Flue does not impose a default upper bound. Rationale:

- CF Workers have their own request timeout that wins anyway.
- Daytona's connector already had a hardcoded 120s default; preserved as the fallback when no caller value is supplied.
- Just-bash today does not consume the field; once it does, host-level
  caps remain the host's policy.
- Adding a default in the SDK is policy that maintainers can layer on
  later without breaking this contract; the inverse is harder.

### Backwards compatibility

Every new field is optional. Existing callers that pass
`env.exec(cmd)` or `env.exec(cmd, { cwd, env })` continue to work
unchanged. `BashLike` is unmodified, so this PR has no surface area
against just-bash at all.

## Failure-mode coverage

```
                       ┌──────────────────────────────────────┐
                       │  LLM emits bash tool call with       │
                       │     { command, timeout: N }          │
                       └────────────────┬─────────────────────┘
                                        │
                          ┌─────────────▼─────────────┐
                          │  Tool execute reads N     │   ← previously dropped
                          └─────────────┬─────────────┘
                                        ▼
                          ┌─────────────▼─────────────┐
                          │  SessionEnv.exec(cmd,     │
                          │    { timeout: N })        │
                          └─────────────┬─────────────┘
                                        ▼
                          ┌─────────────▼─────────────┐
                          │  Underlying runtime kills │
                          │  the process at N seconds │
                          └───────────────────────────┘
```

The "previously dropped" arrow is the bug; this PR removes that drop.

## Verification

```
pnpm install
pnpm check:types                   # passes; type changes flow through
pnpm --filter @flue/sdk build      # bundles cleanly
```

Type-check is the primary safety net here: the option-type addition flows
through every adapter, so a missed call site would surface as a TS error.
Behavioral verification is via the existing `examples/hello-world/` agents.

## Out of scope

- Adding a default cap in the SDK (see decision above).
- Modifying `BashLike.exec` or asking just-bash to honor `timeout`
  natively — that's an upstream conversation. This PR ships the
  observable behavior change on the adapters that consume `timeout`
  today; just-bash support can land alongside the just-bash version
  that adds it.
- Wiring `timeout` into `prompt()` / `skill()` / `task()` options. The
  shell-tool case is the highest-value single fix; per-call-level
  shell timeouts can follow.