### PR TITLE
Validate agent HTTP requests before execution

### DIFF
--- a/packages/sdk/src/build-plugin-cloudflare.ts
+++ b/packages/sdk/src/build-plugin-cloudflare.ts
@@ -108,6 +108,9 @@ import {
   InMemorySessionStore,
   bashFactoryToSessionEnv,
   resolveModel,
+  flueHttpError,
+  methodNotAllowedError,
+  readJsonRequestPayload,
 } from '@flue/sdk/internal';
 import { runWithCloudflareContext, cfSandboxToSessionEnv } from '@flue/sdk/cloudflare';
 
@@ -119,6 +122,14 @@ const roles = ${rolesJson};
 const skills = {};
 const systemPrompt = '';
 const manifest = ${manifest};
+const webhookAgents = new Set(${JSON.stringify(webhookAgents.map((a) => a.name))});
+
+function jsonErrorResponse(error) {
+  return new Response(JSON.stringify(error.body), {
+    status: error.status,
+    headers: { 'content-type': 'application/json', ...(error.headers || {}) },
+  });
+}
 
 // ─── Infrastructure ─────────────────────────────────────────────────────────
 
@@ -300,13 +311,15 @@ async function handleAgentRequest(request, doInstance, agentName, handler) {
   // Agent id is the DO "room name" set by routeAgentRequest
   const id = doInstance.name;
 
-  // Parse payload
-  let payload;
-  try {
-    payload = await request.json();
-  } catch {
-    payload = {};
+  if (request.method !== 'POST') {
+    return jsonErrorResponse(methodNotAllowedError('POST'));
   }
+
+  const payloadResult = await readJsonRequestPayload(request);
+  if (!payloadResult.ok) {
+    return jsonErrorResponse(payloadResult.error);
+  }
+  const payload = payloadResult.payload;
 
   const accept = request.headers.get('accept') || '';
   const isWebhook = request.headers.get('x-webhook') === 'true';
@@ -400,10 +413,9 @@ async function handleAgentRequest(request, doInstance, agentName, handler) {
     }
   } catch (err) {
     console.error('[flue] Agent error:', agentName, err);
-    return new Response(
-      JSON.stringify({ error: String(err) }),
-      { status: 500, headers: { 'content-type': 'application/json' } },
-    );
+    return jsonErrorResponse(flueHttpError(500, 'agent_error', String(err), {
+      agent: agentName,
+    }));
   }
 }
 
@@ -433,10 +445,48 @@ export default {
     }
 
     // Agent manifest
-    if (url.pathname === '/agents' && request.method === 'GET') {
+    if (url.pathname === '/agents') {
+      if (request.method !== 'GET') {
+        return jsonErrorResponse(methodNotAllowedError('GET'));
+      }
       return new Response(JSON.stringify(manifest), {
         headers: { 'content-type': 'application/json' },
       });
+    }
+
+    if (url.pathname.startsWith('/agents/')) {
+      const parts = url.pathname.split('/').filter(Boolean);
+      if (parts[0] === 'agents') {
+        if (request.method !== 'POST') {
+          return jsonErrorResponse(methodNotAllowedError('POST'));
+        }
+
+        if (parts.length === 2) {
+          return jsonErrorResponse(flueHttpError(
+            400,
+            'missing_agent_id',
+            'Agent id is required. Use /agents/:name/:id.',
+            { agent: parts[1] },
+          ));
+        }
+
+        if (parts.length !== 3) {
+          return jsonErrorResponse(flueHttpError(404, 'not_found', 'Not found.'));
+        }
+
+        let agentName;
+        try {
+          agentName = decodeURIComponent(parts[1]);
+        } catch {
+          return jsonErrorResponse(flueHttpError(400, 'invalid_path', 'Agent path is not valid URL encoding.'));
+        }
+
+        if (!webhookAgents.has(agentName)) {
+          return jsonErrorResponse(flueHttpError(404, 'agent_not_found', 'Agent "' + agentName + '" was not found.', {
+            agent: agentName,
+          }));
+        }
+      }
     }
 
     // Route to per-agent DOs via the Agents SDK
@@ -444,7 +494,7 @@ export default {
     const response = await routeAgentRequest(request, env);
     if (response) return response;
 
-    return new Response('Not found', { status: 404 });
+    return jsonErrorResponse(flueHttpError(404, 'not_found', 'Not found.'));
   },
 };
 `;
@@ -472,9 +522,7 @@ export default {
 		// relative paths (e.g. containers[].image) to absolute paths against
 		// the user's config dir, so the merged file stays correct after we
 		// write it to dist/.
-		const { config: userConfig, path: userConfigPath } = await this.getUserConfig(
-			ctx.outputDir,
-		);
+		const { config: userConfig, path: userConfigPath } = await this.getUserConfig(ctx.outputDir);
 		if (userConfigPath) {
 			console.log(`[flue] Merging with user wrangler config: ${userConfigPath}`);
 		}
@@ -567,4 +615,3 @@ function agentClassName(name: string): string {
 		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
 		.join('');
 }
-

--- a/packages/sdk/src/build-plugin-node.ts
+++ b/packages/sdk/src/build-plugin-node.ts
@@ -56,6 +56,9 @@ import {
   InMemorySessionStore,
   bashFactoryToSessionEnv,
   resolveModel,
+  flueHttpError,
+  methodNotAllowedError,
+  readJsonRequestPayload,
 } from '@flue/sdk/internal';
 import { randomUUID } from 'node:crypto';
 
@@ -81,6 +84,13 @@ const webhookAgents = new Set(${webhookNames});
 const isLocalMode = process.env.FLUE_MODE === 'local';
 
 const manifest = ${manifest};
+
+function jsonError(c, error) {
+  for (const [name, value] of Object.entries(error.headers || {})) {
+    c.header(name, value);
+  }
+  return c.json(error.body, error.status);
+}
 
 // ─── Infrastructure ─────────────────────────────────────────────────────────
 
@@ -144,30 +154,46 @@ app.get('/health', (c) => c.json({ status: 'ok' }));
 app.get('/agents', (c) => c.json(manifest));
 
 // Agent id is required in the URL
-app.post('/agents/:name', (c) => {
-  return c.json({
-    error: 'Agent id is required. Use /agents/:name/:id',
-  }, 400);
+app.all('/agents/:name', (c) => {
+  if (c.req.method !== 'POST') {
+    return jsonError(c, methodNotAllowedError('POST'));
+  }
+  return jsonError(c, flueHttpError(
+    400,
+    'missing_agent_id',
+    'Agent id is required. Use /agents/:name/:id.',
+    { agent: c.req.param('name') },
+  ));
 });
 
-app.post('/agents/:name/:id', async (c) => {
+app.all('/agents/:name/:id', async (c) => {
   const name = c.req.param('name');
   const id = c.req.param('id');
 
+  if (c.req.method !== 'POST') {
+    return jsonError(c, methodNotAllowedError('POST'));
+  }
+
   if (!handlers[name]) {
-    return c.json({ error: 'Agent not found' }, 404);
+    return jsonError(c, flueHttpError(404, 'agent_not_found', 'Agent "' + name + '" was not found.', {
+      agent: name,
+    }));
   }
   if (!webhookAgents.has(name) && !isLocalMode) {
-    return c.json({ error: 'Agent "' + name + '" is not web-accessible (no webhook trigger)' }, 404);
+    return jsonError(c, flueHttpError(
+      404,
+      'agent_not_accessible',
+      'Agent "' + name + '" is not web-accessible (no webhook trigger).',
+      { agent: name },
+    ));
   }
 
   const handler = handlers[name];
-  let payload;
-  try {
-    payload = await c.req.json();
-  } catch {
-    payload = {};
+  const payloadResult = await readJsonRequestPayload(c.req.raw);
+  if (!payloadResult.ok) {
+    return jsonError(c, payloadResult.error);
   }
+  const payload = payloadResult.payload;
 
   const accept = c.req.header('accept') || '';
   const isWebhook = c.req.header('x-webhook') === 'true';
@@ -236,8 +262,12 @@ app.post('/agents/:name/:id', async (c) => {
     return c.json({ result: result !== undefined ? result : null });
   } catch (err) {
     console.error('[flue] Agent error:', name, err);
-    return c.json({ error: String(err) }, 500);
+    return jsonError(c, flueHttpError(500, 'agent_error', String(err), { agent: name }));
   }
+});
+
+app.notFound((c) => {
+  return jsonError(c, flueHttpError(404, 'not_found', 'Not found.'));
 });
 
 // ─── Start ──────────────────────────────────────────────────────────────────

--- a/packages/sdk/src/internal.ts
+++ b/packages/sdk/src/internal.ts
@@ -15,6 +15,114 @@ export type { FlueContextConfig, FlueContextInternal } from './client.ts';
 export { InMemorySessionStore } from './session.ts';
 export { bashFactoryToSessionEnv } from './sandbox.ts';
 
+export interface FlueHttpErrorBody {
+	error: {
+		type: string;
+		message: string;
+		details?: Record<string, unknown>;
+	};
+}
+
+export interface FlueHttpError {
+	status: number;
+	body: FlueHttpErrorBody;
+	headers?: Record<string, string>;
+}
+
+export type JsonRequestPayloadResult =
+	| { ok: true; payload: unknown }
+	| { ok: false; error: FlueHttpError };
+
+export function flueHttpError(
+	status: number,
+	type: string,
+	message: string,
+	details?: Record<string, unknown>,
+	headers?: Record<string, string>,
+): FlueHttpError {
+	return {
+		status,
+		body: {
+			error: {
+				type,
+				message,
+				...(details ? { details } : {}),
+			},
+		},
+		...(headers ? { headers } : {}),
+	};
+}
+
+export function methodNotAllowedError(allowed: string | string[] = 'POST'): FlueHttpError {
+	const allow = Array.isArray(allowed) ? allowed.join(', ') : allowed;
+	return flueHttpError(
+		405,
+		'method_not_allowed',
+		`Method not allowed. Use ${allow}.`,
+		{ allowed: Array.isArray(allowed) ? allowed : [allowed] },
+		{ Allow: allow },
+	);
+}
+
+export async function readJsonRequestPayload(request: Request): Promise<JsonRequestPayloadResult> {
+	let body: string;
+	try {
+		body = await request.text();
+	} catch (err) {
+		return {
+			ok: false,
+			error: flueHttpError(400, 'invalid_body', 'Failed to read request body.', {
+				cause: getErrorMessage(err),
+			}),
+		};
+	}
+
+	if (body.trim().length === 0) {
+		return {
+			ok: false,
+			error: flueHttpError(
+				400,
+				'missing_body',
+				'Request body is required. Send a JSON payload such as {}.',
+			),
+		};
+	}
+
+	const contentType = request.headers.get('content-type');
+	if (!isJsonContentType(contentType)) {
+		return {
+			ok: false,
+			error: flueHttpError(
+				415,
+				'unsupported_media_type',
+				'Request Content-Type must be application/json.',
+				{ received: contentType ?? null },
+			),
+		};
+	}
+
+	try {
+		return { ok: true, payload: JSON.parse(body) };
+	} catch (err) {
+		return {
+			ok: false,
+			error: flueHttpError(400, 'invalid_json', 'Request body must be valid JSON.', {
+				cause: getErrorMessage(err),
+			}),
+		};
+	}
+}
+
+function isJsonContentType(contentType: string | null): boolean {
+	if (!contentType) return false;
+	const mediaType = contentType.split(';', 1)[0]?.trim().toLowerCase();
+	return mediaType === 'application/json' || Boolean(mediaType?.endsWith('+json'));
+}
+
+function getErrorMessage(err: unknown): string {
+	return err instanceof Error ? err.message : String(err);
+}
+
 /**
  * Resolve a `provider/model-id` string into a pi-ai `Model` object.
  * Lives here (rather than in the generated entry point) so that user


### PR DESCRIPTION
## Summary
- reject non-POST agent invocations before routing them to agent handlers
- require non-empty JSON request bodies with application/json-compatible content types
- return structured JSON error envelopes for framework-level request failures in both Node and Cloudflare generated servers

Fixes #18.

## Verification
- pnpm run build
- pnpm run check:types
- pnpm exec prettier --check packages/sdk/src/internal.ts packages/sdk/src/build-plugin-node.ts packages/sdk/src/build-plugin-cloudflare.ts
- node packages/cli/dist/flue.js build --target cloudflare --workspace examples/hello-world/.flue --output examples/hello-world
- manually probed generated Node server invalid-request cases: GET, missing body, malformed JSON, text/plain body, unknown agent