### PR TITLE
feat(sdk): add OpenAI Codex auth support (chatgpt pro)

### DIFF
--- a/packages/sdk/src/openai-codex.ts
+++ b/packages/sdk/src/openai-codex.ts
@@ -1,0 +1,197 @@
+import { refreshOpenAICodexToken } from '@mariozechner/pi-ai/oauth';
+import * as v from 'valibot';
+import type { SessionEnv } from './types.ts';
+
+export const OPENAI_CODEX_PROVIDER = 'openai-codex';
+export const OPENAI_CODEX_AUTH_PATH = './.flue/auth/openai-codex.json';
+
+const OPENAI_CODEX_AUTH_DIR = './.flue/auth';
+const OPENAI_CODEX_AUTH_ENV = 'FLUE_OPENAI_CODEX_AUTH_JSON';
+const OPENAI_CODEX_ACCESS_TOKEN_ENV = 'FLUE_OPENAI_CODEX_AUTH_ACCESS_TOKEN';
+const OPENAI_CODEX_REFRESH_TOKEN_ENV = 'FLUE_OPENAI_CODEX_AUTH_REFRESH_TOKEN';
+const OPENAI_CODEX_ACCOUNT_ID_ENV = 'FLUE_OPENAI_CODEX_AUTH_ACCOUNT_ID';
+const OPENAI_CODEX_REFRESH_SKEW_MS = 60 * 1000;
+
+const openAICodexFlatAuthSchema = v.object({
+	access_token: v.string(),
+	refresh_token: v.string(),
+	account_id: v.string(),
+	expires_at: v.number(),
+	last_refresh: v.string(),
+});
+
+export type OpenAICodexAuth = v.InferOutput<typeof openAICodexFlatAuthSchema>;
+
+const openAICodexBootstrapAuthSchema = v.object({
+	auth_mode: v.optional(v.string()),
+	OPENAI_API_KEY: v.optional(v.nullable(v.string())),
+	tokens: v.optional(
+		v.object({
+			id_token: v.optional(v.string()),
+			access_token: v.string(),
+			refresh_token: v.string(),
+			account_id: v.string(),
+		}),
+	),
+	last_refresh: v.optional(v.string()),
+});
+
+export async function openAICodexLoadAuth(env: SessionEnv): Promise<OpenAICodexAuth | undefined> {
+	const fileAuth = await openAICodexReadAuthFile(env);
+	if (fileAuth) return fileAuth;
+
+	const bootstrapAuth = openAICodexLoadBootstrapAuthFromEnv();
+	if (bootstrapAuth) return bootstrapAuth;
+
+	return openAICodexLoadAuthFromSeparateEnv();
+}
+
+export async function openAICodexRefreshAuth(auth: OpenAICodexAuth): Promise<OpenAICodexAuth> {
+	if (!openAICodexShouldRefreshAuth(auth)) return auth;
+
+	const refreshed = await refreshOpenAICodexToken(auth.refresh_token);
+	return {
+		...auth,
+		access_token: refreshed.access,
+		refresh_token: refreshed.refresh,
+		account_id: openAICodexGetAccountId(refreshed.access) ?? auth.account_id,
+		expires_at: refreshed.expires,
+		last_refresh: new Date().toISOString(),
+	};
+}
+
+export async function openAICodexSaveAuth(env: SessionEnv, auth: OpenAICodexAuth): Promise<void> {
+	await env.mkdir(OPENAI_CODEX_AUTH_DIR, { recursive: true });
+	await env.writeFile(OPENAI_CODEX_AUTH_PATH, JSON.stringify(auth, null, 2));
+}
+
+export function openAICodexProtectAuthPath(env: SessionEnv): SessionEnv {
+	const authPath = env.resolvePath(OPENAI_CODEX_AUTH_PATH);
+	const isAuthPath = (path: string) => env.resolvePath(path) === authPath;
+	const deny = () => {
+		throw new Error('[flue] Access denied');
+	};
+
+	return {
+		...env,
+		async readFile(path) {
+			if (isAuthPath(path)) deny();
+			return env.readFile(path);
+		},
+		async readFileBuffer(path) {
+			if (isAuthPath(path)) deny();
+			return env.readFileBuffer(path);
+		},
+		async writeFile(path, content) {
+			if (isAuthPath(path)) deny();
+			return env.writeFile(path, content);
+		},
+		async stat(path) {
+			if (isAuthPath(path)) deny();
+			return env.stat(path);
+		},
+		async exists(path) {
+			if (isAuthPath(path)) return false;
+			return env.exists(path);
+		},
+		async rm(path, options) {
+			if (isAuthPath(path)) deny();
+			return env.rm(path, options);
+		},
+		async scope(options) {
+			const scoped = env.scope ? await env.scope(options) : env;
+			return openAICodexProtectAuthPath(scoped);
+		},
+	};
+}
+
+async function openAICodexReadAuthFile(env: SessionEnv): Promise<OpenAICodexAuth | undefined> {
+	try {
+		const raw = await env.readFile(OPENAI_CODEX_AUTH_PATH);
+		return openAICodexParseFlatAuth(raw);
+	} catch {
+		return undefined;
+	}
+}
+
+function openAICodexLoadBootstrapAuthFromEnv(): OpenAICodexAuth | undefined {
+	const raw = process.env[OPENAI_CODEX_AUTH_ENV];
+	if (!raw) return undefined;
+	try {
+		const parsed = v.parse(openAICodexBootstrapAuthSchema, JSON.parse(raw));
+		if (!parsed.tokens) return undefined;
+		const expiresAt = openAICodexGetJwtExpiryMs(parsed.tokens.access_token);
+		if (expiresAt === undefined) return undefined;
+
+		return {
+			access_token: parsed.tokens.access_token,
+			refresh_token: parsed.tokens.refresh_token,
+			account_id: parsed.tokens.account_id,
+			expires_at: expiresAt,
+			last_refresh: parsed.last_refresh ?? new Date().toISOString(),
+		};
+	} catch {
+		return undefined;
+	}
+}
+
+function openAICodexLoadAuthFromSeparateEnv(): OpenAICodexAuth | undefined {
+	const accessToken = process.env[OPENAI_CODEX_ACCESS_TOKEN_ENV];
+	const refreshToken = process.env[OPENAI_CODEX_REFRESH_TOKEN_ENV];
+	if (!accessToken || !refreshToken) return undefined;
+	const accountId =
+		process.env[OPENAI_CODEX_ACCOUNT_ID_ENV] ?? openAICodexGetAccountId(accessToken);
+	const expiresAt = openAICodexGetJwtExpiryMs(accessToken);
+	if (!accountId || expiresAt === undefined) return undefined;
+
+	return {
+		access_token: accessToken,
+		refresh_token: refreshToken,
+		account_id: accountId,
+		expires_at: expiresAt,
+		last_refresh: new Date().toISOString(),
+	};
+}
+
+function openAICodexParseFlatAuth(raw: string): OpenAICodexAuth | undefined {
+	try {
+		return v.parse(openAICodexFlatAuthSchema, JSON.parse(raw));
+	} catch {
+		return undefined;
+	}
+}
+
+function openAICodexShouldRefreshAuth(auth: OpenAICodexAuth): boolean {
+	return Date.now() >= auth.expires_at - OPENAI_CODEX_REFRESH_SKEW_MS;
+}
+
+function openAICodexGetJwtExpiryMs(token: string | undefined): number | undefined {
+	const payload = openAICodexDecodeJwtPayload(token);
+	return typeof payload?.exp === 'number' ? payload.exp * 1000 : undefined;
+}
+
+function openAICodexGetAccountId(token: string | undefined): string | undefined {
+	const payload = openAICodexDecodeJwtPayload(token);
+	const auth = payload?.['https://api.openai.com/auth'];
+	const accountId =
+		auth && typeof auth === 'object'
+			? (auth as Record<string, unknown>).chatgpt_account_id
+			: undefined;
+	return typeof accountId === 'string' && accountId.length > 0 ? accountId : undefined;
+}
+
+function openAICodexDecodeJwtPayload(
+	token: string | undefined,
+): Record<string, unknown> | undefined {
+	if (!token) return undefined;
+	try {
+		const [, payload] = token.split('.');
+		if (!payload) return undefined;
+		const normalized = payload.replace(/-/g, '+').replace(/_/g, '/');
+		const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+		const decoded = JSON.parse(globalThis.atob(padded));
+		return decoded && typeof decoded === 'object' ? decoded : undefined;
+	} catch {
+		return undefined;
+	}
+}

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -1,6 +1,7 @@
 /** Internal session implementation. Not exported publicly — wrapped by FlueSession. */
-import { Agent } from '@mariozechner/pi-agent-core';
+
 import type { AgentMessage, AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core';
+import { Agent } from '@mariozechner/pi-agent-core';
 import type { AssistantMessage, Model } from '@mariozechner/pi-ai';
 import type * as v from 'valibot';
 import {
@@ -10,14 +11,24 @@ import {
 	type TaskToolResultDetails,
 } from './agent.ts';
 import {
+	type CompactionSettings,
 	calculateContextTokens,
 	compact,
 	DEFAULT_COMPACTION_SETTINGS,
 	isContextOverflow,
 	prepareCompaction,
 	shouldCompact,
-	type CompactionSettings,
 } from './compaction.ts';
+import { loadSkillByPath } from './context.ts';
+import { mergeCommands, createScopedEnv as scopeSessionEnv } from './env-utils.ts';
+import {
+	OPENAI_CODEX_PROVIDER,
+	type OpenAICodexAuth,
+	openAICodexLoadAuth,
+	openAICodexProtectAuthPath,
+	openAICodexRefreshAuth,
+	openAICodexSaveAuth,
+} from './openai-codex.ts';
 import {
 	buildPromptText,
 	buildResultExtractionPrompt,
@@ -25,14 +36,12 @@ import {
 	extractResult,
 	ResultExtractionError,
 } from './result.ts';
-import { loadSkillByPath } from './context.ts';
-import { createScopedEnv as scopeSessionEnv, mergeCommands } from './env-utils.ts';
 import {
 	assertRoleExists,
 	resolveEffectiveRole as resolveEffectiveRoleName,
 	resolveRoleModel,
 } from './roles.ts';
-import { SessionHistory, type ContextEntry, type MessageSource } from './session-history.ts';
+import { type ContextEntry, type MessageSource, SessionHistory } from './session-history.ts';
 import type {
 	AgentConfig,
 	Command,
@@ -149,6 +158,10 @@ export class Session implements FlueSession {
 	private createTaskSession: CreateTaskSession | undefined;
 	private onDelete: (() => void) | undefined;
 
+	// basic in-memory cache
+	private openAICodexAuth: OpenAICodexAuth | undefined;
+	private openAICodexApiKeyPromise: Promise<string | undefined> | undefined;
+
 	constructor(options: SessionInitOptions) {
 		this.id = options.id;
 		this.storageKey = options.storageKey;
@@ -180,7 +193,9 @@ export class Session implements FlueSession {
 		assertRoleExists(this.config.roles, this.sessionRole);
 
 		const tools = [
-			...this.createBuiltinTools(this.env, this.agentCommands, []),
+			// for least-priviledge/defense-in-depth
+			// wrap tools to block direct read/writes to openai auth file (.flue/auth/openai-codex.json)
+			...this.createBuiltinTools(this.createToolEnv(this.env), this.agentCommands, []),
 			...this.createCustomTools(this.agentTools),
 		];
 
@@ -194,6 +209,7 @@ export class Session implements FlueSession {
 				messages: previousMessages,
 			},
 			toolExecution: 'parallel',
+			getApiKey: (provider) => this.getApiKey(provider),
 		});
 
 		this.eventCallback = options.onAgentEvent;
@@ -492,12 +508,42 @@ export class Session implements FlueSession {
 		});
 	}
 
+	private createToolEnv(env: SessionEnv): SessionEnv {
+		// for least-priviledge/defense-in-depth protection
+		// we block `SessionEnv.read/write/rm` tools access to openai-codex.json auth file
+		return openAICodexProtectAuthPath(env);
+	}
+
+	private async getApiKey(provider: string): Promise<string | undefined> {
+		if (provider !== OPENAI_CODEX_PROVIDER) return undefined;
+
+		if (this.openAICodexApiKeyPromise) return this.openAICodexApiKeyPromise;
+
+		this.openAICodexApiKeyPromise = this.openAICodexResolveApiKey().finally(() => {
+			this.openAICodexApiKeyPromise = undefined;
+		});
+		return this.openAICodexApiKeyPromise;
+	}
+
+	private async openAICodexResolveApiKey(): Promise<string | undefined> {
+		let auth = this.openAICodexAuth ?? (await openAICodexLoadAuth(this.env));
+		if (!auth) return undefined;
+		if (!auth.access_token || !auth.refresh_token) return undefined;
+
+		auth = await openAICodexRefreshAuth(auth);
+
+		await openAICodexSaveAuth(this.env, auth);
+		this.openAICodexAuth = auth;
+		return auth.access_token;
+	}
+
 	private async withScopedRuntime<T>(
 		options: RuntimeScopeOptions,
 		fn: () => Promise<T>,
 	): Promise<T> {
 		const customTools = this.createCustomTools([...this.agentTools, ...options.tools]);
 		const scopedEnv = await scopeSessionEnv(this.env, options.commands);
+		const toolEnv = this.createToolEnv(scopedEnv);
 		const previousTools = this.harness.state.tools;
 		const previousModel = this.harness.state.model;
 		const previousSystemPrompt = this.harness.state.systemPrompt;
@@ -510,7 +556,7 @@ export class Session implements FlueSession {
 		this.harness.state.systemPrompt = this.buildSystemPrompt(options.role);
 		this.harness.state.tools = [
 			...this.createBuiltinTools(
-				scopedEnv,
+				toolEnv,
 				options.commands,
 				options.tools,
 				options.role,


### PR DESCRIPTION
## Summary
- add sandbox-backed OpenAI Codex auth resolution for `openai-codex` auth & models
- persist refreshed auth in the `SessionEnv` environment and support env-based bootstrap from `~/.codex/auth.json` format through `FLUE_OPENAI_CODEX_AUTH_JSON`, or separate env vars for `access_token`, `refresh_token`, and `account_id`
- protect the Codex auth file stored at `./.flue/auth/openai-codex.json` from built-in file tool access
- validates incoming `FLUE_OPENAI_CODEX_AUTH_JSON` again Codex's auth.json format
- supports any "backend" - node, cloudflare, and any sandbox, because we based it on `SessionEnv`

The idea is that, you either provide separate env vars, or have codex-auth-compatible `FLUE_OPENAI_CODEX_AUTH_JSON` provided 

```
FLUE_OPENAI_CODEX_AUTH_JSON="$(cat ~/.codex/auth.json)" flue dev --target node
```

the type of auth.json is 

```ts
type OpenAICodexBootstrapAuthType = {
    auth_mode?: string | undefined;
    OPENAI_API_KEY?: string | null | undefined;
    tokens?: {
        id_token?: string | undefined;
        access_token: string;
        refresh_token: string;
        account_id: string;
    } | undefined;
    last_refresh?: string | undefined;
}
```

On subsequent requests/runs it tries to load the sandbox openai-codex.json file, or from in-memory.

## Usage demo

1. go to `examples/hello-world`
2. change `model: 'openai-codex/gpt-5.4'`
3. run `FLUE_OPENAI_CODEX_AUTH_JSON="$(cat ~/.codex/auth.json)" flue dev --target node`
4. curl

## Validation
- `pnpm run check:types` in `packages/sdk`
- `pnpm run build` in `packages/sdk`

Didn't ran `format:style` because it was going to introduce a lot of noise.