### PR TITLE
Fix check task ordering

### DIFF
--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -15,7 +15,7 @@
 		"build": {},
 		"//#check:lint": {},
 		"check:types": {
-			"dependsOn": ["^build", "^check:types"],
+			"dependsOn": ["build", "^build", "^check:types"],
 			"outputLogs": "errors-only"
 		},
 		"//#format:lint": {},


### PR DESCRIPTION
## Summary
- make package `check:types` tasks depend on that package’s own `build` task
- prevents `pnpm run check` from running `tsc --noEmit` while `tsdown` is cleaning/regenerating `dist`

## Why
After syncing main, `pnpm run check` could fail intermittently/deterministically with TypeScript `TS6053` errors for files under `packages/sdk/dist/*` because Turbo scheduled `build` and `check:types` in the same run without an own-package dependency edge.

## Verification
- `pnpm run check`
- `git diff --check`

Note: Biome still reports existing warnings, but exits successfully; this PR only fixes the task-ordering failure.