### PR TITLE
Add Vercel Sandbox connector

### DIFF
--- a/packages/connectors/package.json
+++ b/packages/connectors/package.json
@@ -7,6 +7,10 @@
 		"./daytona": {
 			"types": "./dist/daytona.d.mts",
 			"import": "./dist/daytona.mjs"
+		},
+		"./vercel": {
+			"types": "./dist/vercel.d.mts",
+			"import": "./dist/vercel.mjs"
 		}
 	},
 	"files": [
@@ -21,15 +25,20 @@
 		"@flue/sdk": "workspace:*"
 	},
 	"peerDependencies": {
-		"@daytona/sdk": "*"
+		"@daytona/sdk": "*",
+		"@vercel/sandbox": "^1.10.0"
 	},
 	"peerDependenciesMeta": {
 		"@daytona/sdk": {
+			"optional": true
+		},
+		"@vercel/sandbox": {
 			"optional": true
 		}
 	},
 	"devDependencies": {
 		"@daytona/sdk": "*",
+		"@vercel/sandbox": "^1.10.0",
 		"tsdown": "^0.20.3"
 	}
 }

--- a/packages/connectors/src/vercel.ts
+++ b/packages/connectors/src/vercel.ts
@@ -1,0 +1,173 @@
+/**
+ * Vercel Sandbox connector for Flue.
+ *
+ * Adapts an initialized Vercel Sandbox to Flue's SandboxFactory interface.
+ * Create and configure the sandbox with the Vercel SDK, then pass it to
+ * init({ sandbox }) through this connector.
+ *
+ * @example
+ * ```typescript
+ * import { Sandbox } from '@vercel/sandbox';
+ * import { vercel } from '@flue/connectors/vercel';
+ *
+ * const sandbox = await Sandbox.create({ runtime: 'node24' });
+ * const agent = await init({ sandbox: vercel(sandbox) });
+ * const session = await agent.session();
+ * ```
+ */
+import { createSandboxSessionEnv } from '@flue/sdk/sandbox';
+import type { SandboxApi, SandboxFactory, SessionEnv, FileStat } from '@flue/sdk/sandbox';
+import type { Sandbox as VercelSandbox } from '@vercel/sandbox';
+
+const DEFAULT_VERCEL_CWD = '/vercel/sandbox';
+
+function isAbortError(err: unknown, signal: AbortSignal): boolean {
+	if (err === signal.reason) {
+		return true;
+	}
+
+	return err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError');
+}
+
+// ─── Options ────────────────────────────────────────────────────────────────
+
+export interface VercelConnectorOptions {
+	/**
+	 * Working directory to use when Flue does not receive an explicit cwd.
+	 *
+	 * Vercel sandboxes default to /vercel/sandbox.
+	 */
+	cwd?: string;
+
+	/**
+	 * Cleanup behavior when the owning Flue agent is destroyed.
+	 *
+	 * - `false` (default): No cleanup. User code manages the sandbox lifecycle.
+	 * - `true`: Calls `sandbox.stop({ blocking: true })` on agent destroy.
+	 * - Function: Calls the provided function on agent destroy.
+	 */
+	cleanup?: boolean | (() => Promise<void>);
+}
+
+// ─── VercelSandboxApi ───────────────────────────────────────────────────────
+
+/** Implements SandboxApi by wrapping the Vercel Sandbox SDK. */
+class VercelSandboxApi implements SandboxApi {
+	constructor(private sandbox: VercelSandbox) {}
+
+	async readFile(path: string): Promise<string> {
+		return this.sandbox.fs.readFile(path, 'utf8');
+	}
+
+	async readFileBuffer(path: string): Promise<Uint8Array> {
+		const buffer = await this.sandbox.fs.readFile(path);
+		return new Uint8Array(buffer);
+	}
+
+	async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+		await this.sandbox.fs.writeFile(path, content);
+	}
+
+	async stat(path: string): Promise<FileStat> {
+		const stat = await this.sandbox.fs.stat(path);
+		return {
+			isFile: stat.isFile(),
+			isDirectory: stat.isDirectory(),
+			isSymbolicLink: stat.isSymbolicLink(),
+			size: stat.size,
+			mtime: stat.mtime,
+		};
+	}
+
+	async readdir(path: string): Promise<string[]> {
+		return this.sandbox.fs.readdir(path);
+	}
+
+	async exists(path: string): Promise<boolean> {
+		return this.sandbox.fs.exists(path);
+	}
+
+	async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+		await this.sandbox.fs.mkdir(path, options);
+	}
+
+	async rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void> {
+		await this.sandbox.fs.rm(path, options);
+	}
+
+	async exec(
+		command: string,
+		options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
+	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+		let signal: AbortSignal | undefined;
+
+		if (typeof options?.timeout === 'number') {
+			signal = AbortSignal.timeout(options.timeout * 1000);
+		}
+
+		try {
+			const response = await this.sandbox.runCommand({
+				cmd: 'bash',
+				args: ['-c', command],
+				cwd: options?.cwd,
+				env: options?.env,
+				signal,
+			});
+
+			const [stdout, stderr] = await Promise.all([
+				response.stdout({ signal }),
+				response.stderr({ signal }),
+			]);
+
+			return {
+				stdout,
+				stderr,
+				exitCode: response.exitCode,
+			};
+		} catch (err) {
+			if (signal?.aborted && isAbortError(err, signal)) {
+				return {
+					stdout: '',
+					stderr: `[flue:vercel] Command timed out after ${options?.timeout} seconds.`,
+					exitCode: 124,
+				};
+			}
+
+			throw err;
+		}
+	}
+}
+
+// ─── Connector ──────────────────────────────────────────────────────────────
+
+/**
+ * Create a Flue sandbox factory from an initialized Vercel Sandbox.
+ *
+ * The returned factory can be passed directly to `init({ sandbox })`.
+ *
+ * @param sandbox - An initialized Vercel Sandbox instance.
+ * @param options - Connector options.
+ */
+export function vercel(sandbox: VercelSandbox, options?: VercelConnectorOptions): SandboxFactory {
+	return {
+		async createSessionEnv({ cwd }: { id: string; cwd?: string }): Promise<SessionEnv> {
+			const sandboxCwd = cwd ?? options?.cwd ?? DEFAULT_VERCEL_CWD;
+			const api = new VercelSandboxApi(sandbox);
+
+			let cleanup: (() => Promise<void>) | undefined;
+			if (options?.cleanup === true) {
+				cleanup = async () => {
+					try {
+						await sandbox.stop({ blocking: true });
+					} catch (err) {
+						console.error('[flue:vercel] Failed to stop sandbox:', err);
+					}
+				};
+			} else if (typeof options?.cleanup === 'function') {
+				cleanup = options.cleanup;
+			}
+
+			return createSandboxSessionEnv(api, sandboxCwd, cleanup);
+		},
+	};
+}

--- a/packages/connectors/tsdown.config.ts
+++ b/packages/connectors/tsdown.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsdown';
 
 export default defineConfig({
-	entry: ['src/daytona.ts'],
+	entry: ['src/daytona.ts', 'src/vercel.ts'],
 	format: ['esm'],
 	dts: true,
 	clean: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ importers:
       '@daytona/sdk':
         specifier: '*'
         version: 0.164.0(ws@8.18.0)
+      '@vercel/sandbox':
+        specifier: ^1.10.0
+        version: 1.10.0
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(typescript@5.9.3)
@@ -2233,6 +2236,16 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/sandbox@1.10.0':
+    resolution: {integrity: sha512-rGA8KJB5ZwQeygzsndgrbHsys3HGWKHQaRQlmyIEHce2BFuTfQUgivHDj5DCZhWiyjjSEodLHpoJkZBd95K0/Q==}
+
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
@@ -2361,6 +2374,9 @@ packages:
   async-lock@1.4.1:
     resolution: {integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==}
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -2378,12 +2394,28 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.8.2:
+    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
@@ -2896,6 +2928,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
@@ -2936,6 +2971,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -3357,6 +3395,9 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   just-bash@2.14.2:
     resolution: {integrity: sha512-9Na1rH03Ta5ydHTNotJ7dms1iZwb2kToOnKbnS29AlrCvi1CQ21Fm2lfu4S4rfwDGHYi4E4evgTDC/DcDx8tuQ==}
@@ -3816,6 +3857,10 @@ packages:
         optional: true
       zod:
         optional: true
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   p-limit@6.2.0:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
@@ -4302,6 +4347,9 @@ packages:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
 
+  streamx@2.25.0:
+    resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -4362,9 +4410,15 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
   tar@7.5.13:
     resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
     engines: {node: '>=18'}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   thenify-all@1.6.0:
     resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
@@ -4793,6 +4847,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
 
@@ -4867,6 +4929,9 @@ packages:
     peerDependencies:
       typescript: ^4.9.4 || ^5.0.2
       zod: ^3
+
+  zod@3.24.4:
+    resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -7320,6 +7385,26 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/sandbox@1.10.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.24.8
+      xdg-app-paths: 5.1.0
+      zod: 3.24.4
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@workflow/serde@4.1.0-beta.2': {}
+
   abort-controller@3.0.0:
     dependencies:
       event-target-shim: 5.0.1
@@ -7527,6 +7612,10 @@ snapshots:
 
   async-lock@1.4.1: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   asynckit@0.4.0: {}
 
   available-typed-arrays@1.0.7:
@@ -7545,9 +7634,13 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.8.2: {}
 
   base-64@1.0.0: {}
 
@@ -8047,6 +8140,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.8.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   events@3.3.0: {}
 
   eventsource-parser@3.0.6: {}
@@ -8113,6 +8212,8 @@ snapshots:
       - supports-color
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -8602,6 +8703,8 @@ snapshots:
   json-schema@0.4.0: {}
 
   json5@2.2.3: {}
+
+  jsonlines@0.1.1: {}
 
   just-bash@2.14.2:
     dependencies:
@@ -9207,6 +9310,8 @@ snapshots:
     optionalDependencies:
       ws: 8.18.0
       zod: 3.25.76
+
+  os-paths@4.4.0: {}
 
   p-limit@6.2.0:
     dependencies:
@@ -9851,6 +9956,15 @@ snapshots:
 
   streamsearch@1.1.0: {}
 
+  streamx@2.25.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -9926,6 +10040,15 @@ snapshots:
       readable-stream: 3.6.2
     optional: true
 
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.25.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   tar@7.5.13:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
@@ -9933,6 +10056,12 @@ snapshots:
       minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   thenify-all@1.6.0:
     dependencies:
@@ -10283,6 +10412,14 @@ snapshots:
 
   ws@8.18.0: {}
 
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xxhash-wasm@1.1.0: {}
 
   y18n@5.0.8: {}
@@ -10362,6 +10499,8 @@ snapshots:
     dependencies:
       typescript: 5.9.3
       zod: 3.25.76
+
+  zod@3.24.4: {}
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
## Summary

Adds `@flue/connectors/vercel`, an adapter that lets a Vercel Sandbox be passed to `init({ sandbox })`.

User code creates and configures the sandbox with the Vercel SDK, then passes it to Flue.

```ts
import { Sandbox } from '@vercel/sandbox';
import { vercel } from '@flue/connectors/vercel';

const sandbox = await Sandbox.create({ runtime: 'node24' });
const agent = await init({ sandbox: vercel(sandbox, { cleanup: true }) });
```

The connector adapts an `@vercel/sandbox` instance. Vercel owns sandbox creation, auth, runtime selection, ports, and network policy.

## Changes

- Adds `packages/connectors/src/vercel.ts`
- Adds `@flue/connectors/vercel` package export
- Adds peer/dev dependency on `@vercel/sandbox`
- Adds `src/vercel.ts` to the connectors build entries

## Verification

- `pnpm --filter @flue/connectors check:types`
- `pnpm --filter @flue/connectors build`
- `git diff --check`
- Tested against Vercel Sandbox using `init({ sandbox: vercel(sandbox) })`, shell execution, file IO, timeout handling, and cleanup
