### PR TITLE
docs: add Connect Daytona guide

### DIFF
--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -493,53 +493,42 @@ const floatingSquares = [
             <svg class="relative w-10 h-10 grayscale opacity-60 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-300" viewBox="0 0 1000 963.197"><defs><style>.gl1{fill:#e24329}.gl2{fill:#fc6d26}.gl3{fill:#fca326}</style></defs><g transform="matrix(5.2068817,0,0,5.2068817,-489.30756,-507.76085)"><path class="gl1" d="m282.83 170.73-.27-.69-26.14-68.22a6.81 6.81 0 00-2.69-3.24 7 7 0 00-8 .43 7 7 0 00-2.32 3.52l-17.65 54h-71.47l-17.65-54a6.86 6.86 0 00-2.32-3.53 7 7 0 00-8-.43 6.87 6.87 0 00-2.69 3.24L97.44 170l-.26.69a48.54 48.54 0 0016.1 56.1l.09.07.24.17 39.82 29.82 19.7 14.91 12 9.06a8.07 8.07 0 009.76 0l12-9.06 19.7-14.91 40.06-30 .1-.08a48.56 48.56 0 0016.08-56.04z"/><path class="gl2" d="m282.83 170.73-.27-.69a88.3 88.3 0 00-35.15 15.8L190 229.25c19.55 14.79 36.57 27.64 36.57 27.64l40.06-30 .1-.08a48.56 48.56 0 0016.1-56.08z"/><path class="gl3" d="m153.43 256.89 19.7 14.91 12 9.06a8.07 8.07 0 009.76 0l12-9.06 19.7-14.91s-17.04-12.89-36.59-27.64c-19.55 14.75-36.57 27.64-36.57 27.64z"/><path class="gl2" d="M132.58 185.84A88.19 88.19 0 0097.44 170l-.26.69a48.54 48.54 0 0016.1 56.1l.09.07.24.17 39.82 29.82s17-12.85 36.57-27.64z"/></g></svg>
             <span class="relative inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-600 group-hover:text-gray-950 group-hover:border-gray-400 transition-colors text-center shadow-sm">GitLab CI/CD</span>
           </a>
+          <!-- Daytona — connect a remote sandbox.
+               This card sits in the centre of the 3×3 grid (lg) and is the
+               only "connect" guide alongside the deploy guides above. The
+               logo is the Daytona spiral mark only (wordmark stripped). -->
+          <a href="https://github.com/withastro/flue/blob/main/docs/connect-daytona.md" target="_blank" rel="noopener noreferrer" class="runner-cell group relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t sm:border-x border-gray-300 hover:bg-white transition-colors duration-300">
+            <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300" style="background: radial-gradient(circle at 80% 80%, rgba(22,22,22,0.08) 0%, transparent 60%);"></div>
+            <svg class="relative w-10 h-10 grayscale opacity-60 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-300" viewBox="0 0 27 26" fill="#161616" aria-hidden="true">
+              <path d="M 1.412 17.375 L 11.078 17.375 L 11.078 20.423 L 1.412 20.423 Z M 14.39 6.707 L 25.436 6.707 L 25.436 9.755 L 14.39 9.755 Z M 8.591 7.647 L 16.792 0.103 L 19.135 2.259 L 10.935 9.802 Z"/>
+              <path d="M 8.642 15.267 L 2.343 9.473 L 0 11.628 L 6.298 17.422 Z M 16.927 19.53 L 10.288 25.637 L 7.944 23.482 L 14.584 17.375 Z M 16.876 11.911 L 24.296 18.736 L 26.639 16.58 L 19.219 9.755 Z M 8.591 4.421 L 8.591 11.787 L 5.277 11.787 L 5.277 4.421 Z"/>
+              <path d="M 20.19 15.089 L 20.19 24.233 L 16.877 24.233 L 16.877 15.089 Z"/>
+            </svg>
+            <span class="relative inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-600 group-hover:text-gray-950 group-hover:border-gray-400 transition-colors text-center shadow-sm">Daytona</span>
+          </a>
           <!-- "Guide coming soon" cards. All below work today via the Node
-               target; see the `.guide-soon-*` block in <style> for the hover
-               label-swap mechanics. -->
+               target. The visual is intentionally cryptic — only the logo
+               identifies the platform. Logo opacity is muted so it's clear
+               at a glance which cards have written guides and which don't. -->
           <!-- Vercel -->
-          <button disabled aria-label="Vercel deploy guide coming soon. Works today with the Node target." class="runner-cell guide-soon-card group relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t sm:border-x border-gray-300">
+          <button disabled aria-label="Vercel deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300 cursor-default">
             <svg class="relative w-10 h-10 grayscale opacity-40" viewBox="0 0 24 24" fill="#000" aria-hidden="true"><path d="M12 1L24 22H0L12 1Z"/></svg>
-            <span class="guide-soon-pill rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">
-              <span class="guide-soon-skeleton">Vercel</span>
-              <span class="guide-soon-label-wrap guide-soon-default-wrap">Vercel</span>
-              <span class="guide-soon-label-wrap guide-soon-hover-wrap">Guide coming soon</span>
-            </span>
+            <span class="rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">Guide coming soon</span>
           </button>
           <!-- Netlify -->
-          <button disabled aria-label="Netlify deploy guide coming soon. Works today with the Node target." class="runner-cell guide-soon-card group relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300">
+          <button disabled aria-label="Netlify deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300 cursor-default">
             <svg class="relative w-10 h-10 grayscale opacity-40" viewBox="0 0 24 24" fill="#00C7B7" aria-hidden="true"><path d="M6.49 19.04h-.23L5.13 17.9v-.23l1.73-1.71h1.2l.15.15v1.2L6.5 19.04ZM5.13 6.31V6.1l1.13-1.13h.23L8.2 6.68v1.2l-.15.15h-1.2L5.13 6.31Zm9.96 9.09h-1.65l-.14-.13v-3.83c0-.68-.27-1.2-1.1-1.23-.42 0-.9 0-1.43.02l-.07.08v4.96l-.14.14H8.9l-.13-.14V8.73l.13-.14h3.7a2.6 2.6 0 0 1 2.61 2.6v4.08l-.13.14Zm-8.37-2.44H.14L0 12.82v-1.64l.14-.14h6.58l.14.14v1.64l-.14.14Zm17.14 0h-6.58l-.14-.14v-1.64l.14-.14h6.58l.14.14v1.64l-.14.14ZM11.05 6.55V1.64l.14-.14h1.65l.14.14v4.9l-.14.14h-1.65l-.14-.13Zm0 15.81v-4.9l.14-.14h1.65l.14.13v4.91l-.14.14h-1.65l-.14-.14Z"/></svg>
-            <span class="guide-soon-pill rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">
-              <span class="guide-soon-skeleton">Netlify</span>
-              <span class="guide-soon-label-wrap guide-soon-default-wrap">Netlify</span>
-              <span class="guide-soon-label-wrap guide-soon-hover-wrap">Guide coming soon</span>
-            </span>
+            <span class="rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">Guide coming soon</span>
           </button>
           <!-- Railway -->
-          <button disabled aria-label="Railway deploy guide coming soon. Works today with the Node target." class="runner-cell guide-soon-card group relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300">
+          <button disabled aria-label="Railway deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t sm:border-x border-gray-300 cursor-default">
             <svg class="relative w-10 h-10 grayscale opacity-40" viewBox="0 0 24 24" fill="#000" aria-hidden="true"><path d="M.113 10.27A13.026 13.026 0 000 11.48h18.23c-.064-.125-.15-.237-.235-.347-3.117-4.027-4.793-3.677-7.19-3.78-.8-.034-1.34-.048-4.524-.048-1.704 0-3.555.005-5.358.01-.234.63-.459 1.24-.567 1.737h9.342v1.216H.113v.002zm18.26 2.426H.009c.02.326.05.645.094.961h16.955c.754 0 1.179-.429 1.315-.96zm-17.318 4.28s2.81 6.902 10.93 7.024c4.855 0 9.027-2.883 10.92-7.024H1.056zM11.988 0C7.5 0 3.593 2.466 1.531 6.108l4.75-.005v-.002c3.71 0 3.849.016 4.573.047l.448.016c1.563.052 3.485.22 4.996 1.364.82.621 2.007 1.99 2.712 2.965.654.902.842 1.94.396 2.934-.408.914-1.289 1.458-2.353 1.458H.391s.099.42.249.886h22.748A12.026 12.026 0 0024 12.005C24 5.377 18.621 0 11.988 0z"/></svg>
-            <span class="guide-soon-pill rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">
-              <span class="guide-soon-skeleton">Railway</span>
-              <span class="guide-soon-label-wrap guide-soon-default-wrap">Railway</span>
-              <span class="guide-soon-label-wrap guide-soon-hover-wrap">Guide coming soon</span>
-            </span>
+            <span class="rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">Guide coming soon</span>
           </button>
           <!-- Render -->
-          <button disabled aria-label="Render deploy guide coming soon. Works today with the Node target." class="runner-cell guide-soon-card group relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t sm:border-x border-gray-300">
+          <button disabled aria-label="Render deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300 cursor-default">
             <svg class="relative w-10 h-10 grayscale opacity-40" viewBox="0 0 24 24" fill="#46E3B7" aria-hidden="true"><path d="M18.263.007c-3.121-.147-5.744 2.109-6.192 5.082-.018.138-.045.272-.067.405-.696 3.703-3.936 6.507-7.827 6.507-1.388 0-2.691-.356-3.825-.979a.2024.2024 0 0 0-.302.178V24H12v-8.999c0-1.656 1.338-3 2.987-3h2.988c3.382 0 6.103-2.817 5.97-6.244-.12-3.084-2.61-5.603-5.682-5.75"/></svg>
-            <span class="guide-soon-pill rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">
-              <span class="guide-soon-skeleton">Render</span>
-              <span class="guide-soon-label-wrap guide-soon-default-wrap">Render</span>
-              <span class="guide-soon-label-wrap guide-soon-hover-wrap">Guide coming soon</span>
-            </span>
-          </button>
-          <!-- Fly.io -->
-          <button disabled aria-label="Fly.io deploy guide coming soon. Works today with the Node target." class="runner-cell guide-soon-card group relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300">
-            <svg class="relative w-10 h-10 grayscale opacity-40" viewBox="0 0 24 24" fill="#7B3BE2" aria-hidden="true"><path d="M11.987 0c-2.45-.01-5.002.925-6.541 2.897-1.17 1.502-1.664 3.474-1.49 5.356.29 2.112 1.476 3.96 2.676 5.672a41.5 41.5 0 0 0 4.216 4.831c-1.063.832-1.943 2.286-1.357 3.644.821 2.32 4.665 2.05 5.122-.372.39-1.288-.694-2.533-1.428-3.309 2.388-2.431 4.706-5.036 6.17-8.145.595-1.32.902-2.802.614-4.24-.28-2.341-1.823-4.473-3.967-5.46C14.76.266 13.364.016 11.987 0m-.236 1.577v15.534C9.881 13.483 7.724 9.266 8.73 5.069c.35-1.539 1.253-3.309 3.02-3.492m1.996.04c1.534.357 3.031 1.096 3.906 2.48 1.3 1.93 1.318 4.55.1 6.521-1.268 2.395-3.06 4.463-4.916 6.415 1.472-2.974 3.074-6.106 3.182-9.5-.043-2.08-.438-4.612-2.272-5.916M11.97 20.103c.848.342 1.597 1.983.153 2.173-.664.15-1.367-.599-.995-1.222.213-.355.488-.73.842-.95"/></svg>
-            <span class="guide-soon-pill rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">
-              <span class="guide-soon-skeleton">Fly.io</span>
-              <span class="guide-soon-label-wrap guide-soon-default-wrap">Fly.io</span>
-              <span class="guide-soon-label-wrap guide-soon-hover-wrap">Guide coming soon</span>
-            </span>
+            <span class="rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">Guide coming soon</span>
           </button>
         </div>
         <div class="mt-8 text-center">
@@ -677,44 +666,6 @@ const floatingSquares = [
         copyPromptBtn.addEventListener('click', copyPrompt);
       }
 
-      // --- Guide-soon pill width measurement ---------------------------------
-      // Each .guide-soon-pill needs --w-default / --w-hover CSS vars set to the
-      // rendered widths of its two labels (platform name vs "Guide coming
-      // soon"). We measure both via an offscreen span that inherits the pill's
-      // font, then add the pill's own padding + border to get the full width.
-      // Re-runs after font load and on resize (debounced).
-      function measureGuideSoonPills() {
-        const pills = document.querySelectorAll<HTMLElement>('.guide-soon-pill');
-        if (pills.length === 0) return;
-        // Parent the measurer inside the first pill so it inherits the exact
-        // font-family/size/weight used by the rendered labels.
-        const measurer = document.createElement('span');
-        measurer.style.cssText = 'position:absolute;visibility:hidden;white-space:nowrap;left:-99999px;top:-99999px;';
-        pills[0].appendChild(measurer);
-        pills.forEach((pill) => {
-          const defText = pill.querySelector('.guide-soon-default-wrap')?.textContent ?? '';
-          const hovText = pill.querySelector('.guide-soon-hover-wrap')?.textContent ?? '';
-          const cs = getComputedStyle(pill);
-          const chromeX =
-            parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight) +
-            parseFloat(cs.borderLeftWidth) + parseFloat(cs.borderRightWidth);
-          measurer.textContent = defText;
-          const defW = measurer.getBoundingClientRect().width + chromeX;
-          measurer.textContent = hovText;
-          const hovW = measurer.getBoundingClientRect().width + chromeX;
-          pill.style.setProperty('--w-default', `${defW}px`);
-          pill.style.setProperty('--w-hover', `${hovW}px`);
-        });
-        measurer.remove();
-      }
-      measureGuideSoonPills();
-      document.fonts?.ready.then(measureGuideSoonPills);
-      let resizeTimer: ReturnType<typeof setTimeout> | undefined;
-      window.addEventListener('resize', () => {
-        clearTimeout(resizeTimer);
-        resizeTimer = setTimeout(measureGuideSoonPills, 150);
-      });
-
       // --- Architecture cards: staggered entrance pulse ----------------------
       // Fires once when the architecture diagram scrolls into view.
       const archSection = document.querySelector('.pattern-layer')?.closest('section');
@@ -749,44 +700,6 @@ const floatingSquares = [
         animation: cardPulse 600ms ease-out forwards;
       }
 
-      /* "Guide coming soon" hover swap for disabled deploy-card buttons.
-
-         Technique: each pill has two CSS custom properties — `--w-default`
-         (width when showing platform name) and `--w-hover` (width when
-         showing "Guide coming soon") — set by a tiny inline script that
-         measures both labels at page load. The pill transitions `width`
-         between these two explicit px values, which IS interpolatable,
-         so the width animates smoothly. Both labels are stacked via
-         absolute positioning inside a height-reserving skeleton, and
-         cross-fade via opacity. */
-      .guide-soon-pill {
-        position: relative;
-        display: inline-block;
-        /* Fallback width before JS measures: auto-fits default label. */
-        width: var(--w-default, max-content);
-        transition: width 300ms ease;
-      }
-      .guide-soon-card:hover .guide-soon-pill {
-        width: var(--w-hover, max-content);
-      }
-      /* Skeleton reserves height; both labels sit on top absolutely. */
-      .guide-soon-skeleton {
-        visibility: hidden;
-        white-space: nowrap;
-      }
-      .guide-soon-label-wrap {
-        position: absolute;
-        inset: 0;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        white-space: nowrap;
-        transition: opacity 200ms ease;
-        opacity: 1;
-      }
-      .guide-soon-hover-wrap { opacity: 0; }
-      .guide-soon-card:hover .guide-soon-default-wrap { opacity: 0; }
-      .guide-soon-card:hover .guide-soon-hover-wrap { opacity: 1; }
     </style>
 
   </body>

--- a/docs/connect-daytona.md
+++ b/docs/connect-daytona.md
@@ -1,0 +1,138 @@
+# Connect a Daytona Sandbox
+
+This guide takes a working Flue agent and connects it to a [Daytona](https://www.daytona.io/) remote sandbox so each session gets a fully isolated Linux environment — git, Node.js, Python, system packages, the lot.
+
+## Prerequisites
+
+You should already have a Flue project that builds and runs. If you don't yet, start with one of the deploy guides — whichever target you're using or prefer:
+
+- [Deploy on Node.js](./deploy-node.md)
+- [Deploy on GitHub Actions](./deploy-github-actions.md)
+- [Deploy on GitLab CI/CD](./deploy-gitlab-ci.md)
+- [Deploy on Cloudflare](./deploy-cloudflare.md)
+
+Each leaves you with a working Hello World agent, a verified run loop, and no remote sandbox wired up yet. That's the starting point.
+
+## Sign up for Daytona
+
+Sign up at [daytona.io](https://www.daytona.io/) and grab an API key from your dashboard. Then set `DAYTONA_API_KEY` in the same place you already set your model provider key (your `.env` file, your CI secrets, or your Cloudflare secrets bundle — whichever the prerequisite guide had you set up).
+
+The SDK also reads optional `DAYTONA_API_URL` and `DAYTONA_TARGET` if you need them — see [Daytona's environment configuration docs](https://www.daytona.io/docs/en/configuration/).
+
+## Install the connector
+
+Install the Daytona connector with `flue add`. Always pass `--print` — it's the safe default whether you're a human pasting the output into your coding agent of choice, or an agent running this command yourself:
+
+```bash
+# Print the install instructions and let your agent (or you) handle the rest
+flue add daytona --print
+
+# Or pipe directly to a coding agent
+flue add daytona --print | claude
+```
+
+This drops a `connectors/daytona.ts` file into your workspace (under `.flue/connectors/` if you're using the `.flue/` layout, or `connectors/` at the project root otherwise) and reminds you to install Daytona's TypeScript SDK:
+
+```bash
+npm install @daytona/sdk
+```
+
+The connector is a TypeScript adapter that wraps a Daytona sandbox into Flue's `SandboxFactory` interface — see the [sandbox connector spec](./sandbox-connector-spec.md) for the contract.
+
+## Use Daytona in your agent
+
+Instead of letting `init()` spin up a default virtual sandbox, create a Daytona sandbox yourself and pass it to `init()`. Three things change in your agent file:
+
+1. Import `Daytona` from `@daytona/sdk` and `daytona` from your connector file.
+2. Create a Daytona client and sandbox.
+3. Pass `sandbox: daytona(sandbox)` to `init()`.
+
+Applied to the Hello World agent from the deploy guides:
+
+```typescript
+import type { FlueContext } from '@flue/sdk/client';
+import { Daytona } from '@daytona/sdk';
+import { daytona } from '../connectors/daytona';
+
+export const triggers = { webhook: true };
+
+export default async function ({ init, env }: FlueContext) {
+  const client = new Daytona({ apiKey: env.DAYTONA_API_KEY });
+  const sandbox = await client.create();
+
+  const agent = await init({
+    sandbox: daytona(sandbox, { cleanup: true }),
+    model: 'anthropic/claude-sonnet-4-6',
+  });
+  const session = await agent.session();
+
+  return await session.shell('uname -a');
+}
+```
+
+`cleanup: true` tells Flue to delete the sandbox when the session ends. The default is `false` (you manage the lifecycle), and you can also pass a function for custom teardown.
+
+## Advanced: Sharing a sandbox across sessions
+
+If your agent needs the sandbox in a specific state before prompting — a repo cloned, dependencies installed, config files written — do the setup in one session, then spin up a second `init()` for the working session with the right `cwd`:
+
+```typescript
+import type { FlueContext } from '@flue/sdk/client';
+import { Daytona } from '@daytona/sdk';
+import { daytona } from '../connectors/daytona';
+
+export const triggers = { webhook: true };
+
+export default async function ({ init, payload, env }: FlueContext) {
+  const client = new Daytona({ apiKey: env.DAYTONA_API_KEY });
+  const sandbox = await client.create();
+
+  // Setup session — clone the repo and install dependencies.
+  const setupAgent = await init({
+    sandbox: daytona(sandbox, { cleanup: true }),
+    model: 'anthropic/claude-sonnet-4-6',
+  });
+  const setup = await setupAgent.session();
+  await setup.shell(`git clone ${payload.repo} /workspace/project`);
+  await setup.shell('npm install', { cwd: '/workspace/project' });
+
+  // Working session — same sandbox, but rooted at the project directory.
+  const projectAgent = await init({
+    id: 'project',
+    sandbox: daytona(sandbox),
+    cwd: '/workspace/project',
+    model: 'anthropic/claude-sonnet-4-6',
+  });
+  const session = await projectAgent.session();
+
+  return await session.prompt(payload.prompt);
+}
+```
+
+Both `init()` calls share the same Daytona sandbox. Only the first carries `cleanup: true` so the sandbox is torn down when the working session ends. The second passes `cwd` so the agent's tools operate inside the project directory.
+
+## Configuring the sandbox
+
+Anything you'd configure on a Daytona sandbox — image, region, env vars, volumes — happens in your code against the Daytona SDK, before you hand the sandbox to `daytona()`. A few common knobs:
+
+- **Image or snapshot.** `client.create()` boots from Daytona's default snapshot. To use a different snapshot, pass `client.create({ snapshot: 'my-snapshot-id' })`. To boot from a Docker image, pass `client.create({ image: 'debian:12.9' })` — Daytona builds a snapshot from the image on first use. For declarative image builds, see [Daytona's snapshots docs](https://www.daytona.io/docs/en/snapshots) and [declarative builder docs](https://www.daytona.io/docs/en/declarative-builder).
+- **Region / target.** Pass `target: 'us'` or `target: 'eu'` to the `Daytona` client constructor (or set `DAYTONA_TARGET` in your environment). See [Daytona's regions docs](https://www.daytona.io/docs/en/regions).
+- **Env vars on the sandbox.** Pass `envVars` at sandbox creation time — for example, `client.create({ envVars: { NODE_ENV: 'development' } })`.
+
+For anything beyond this, treat [Daytona's documentation](https://www.daytona.io/docs/en/typescript-sdk/daytona/) as the source of truth.
+
+## Run it
+
+Once your agent is wired up and `DAYTONA_API_KEY` is set, the dev command from your prerequisite guide just works — no Daytona-specific runtime flags to remember. The first sandbox creation may take a few seconds while Daytona provisions; subsequent runs against cached images are faster.
+
+## Troubleshooting
+
+If you run into anything specific to the Daytona side of this setup — sandbox provisioning, image builds, regions, account or billing questions — the Daytona team and community are the best place to go:
+
+- [Daytona docs](https://www.daytona.io/docs/) — full reference.
+- [TypeScript SDK reference](https://www.daytona.io/docs/en/typescript-sdk/daytona/) — for the SDK calls used in this guide.
+- [Daytona Slack community](https://go.daytona.io/slack) — fastest way to ask questions and reach the team.
+- [daytonaio/daytona on GitHub](https://github.com/daytonaio/daytona) — issues and source.
+- [Daytona status](https://status.app.daytona.io/) — service health.
+
+For Flue-specific questions (the connector, the SDK, agent wiring), open an issue on [withastro/flue](https://github.com/withastro/flue).

--- a/docs/connect-daytona.md
+++ b/docs/connect-daytona.md
@@ -64,17 +64,13 @@ export default async function ({ init, env }: FlueContext) {
     sandbox: daytona(sandbox, { cleanup: true }),
     model: 'anthropic/claude-sonnet-4-6',
   });
+  const session = await agent.session();
 
-  try {
-    const session = await agent.session();
-    return await session.shell('uname -a');
-  } finally {
-    await agent.destroy();
-  }
+  return await session.shell('uname -a');
 }
 ```
 
-`cleanup: true` tells Flue to delete the sandbox when `agent.destroy()` is called. Wrap the session work in `try/finally` for request-scoped sandboxes so cleanup runs even if something throws. The default is `false` (you manage the lifecycle), and you can also pass a function for custom teardown.
+`cleanup: true` tells Flue to delete the sandbox when the request finishes. The default is `false` (you manage the lifecycle), and you can also pass a function for custom teardown.
 
 ## Advanced: Sharing a sandbox across sessions
 
@@ -91,35 +87,29 @@ export default async function ({ init, payload, env }: FlueContext) {
   const client = new Daytona({ apiKey: env.DAYTONA_API_KEY });
   const sandbox = await client.create();
 
-  try {
-    // Setup session — clone the repo and install dependencies.
-    const setupAgent = await init({
-      sandbox: daytona(sandbox),
-      model: 'anthropic/claude-sonnet-4-6',
-    });
-    const setup = await setupAgent.session();
-    await setup.shell(`git clone ${payload.repo} /workspace/project`);
-    await setup.shell('npm install', { cwd: '/workspace/project' });
+  // Setup session — clone the repo and install dependencies.
+  const setupAgent = await init({
+    sandbox: daytona(sandbox, { cleanup: true }),
+    model: 'anthropic/claude-sonnet-4-6',
+  });
+  const setup = await setupAgent.session();
+  await setup.shell(`git clone ${payload.repo} /workspace/project`);
+  await setup.shell('npm install', { cwd: '/workspace/project' });
 
-    // Working session — same sandbox, but rooted at the project directory.
-    const projectAgent = await init({
-      id: 'project',
-      sandbox: daytona(sandbox),
-      cwd: '/workspace/project',
-      model: 'anthropic/claude-sonnet-4-6',
-    });
-    const session = await projectAgent.session();
+  // Working session — same sandbox, but rooted at the project directory.
+  const projectAgent = await init({
+    id: 'project',
+    sandbox: daytona(sandbox),
+    cwd: '/workspace/project',
+    model: 'anthropic/claude-sonnet-4-6',
+  });
+  const session = await projectAgent.session();
 
-    return await session.prompt(payload.prompt);
-  } finally {
-    // Both `init()` calls share the same sandbox, so we delete it directly
-    // here instead of relying on a per-agent `cleanup` hook.
-    await sandbox.delete();
-  }
+  return await session.prompt(payload.prompt);
 }
 ```
 
-Both `init()` calls share the same Daytona sandbox, with the second passing `cwd` so the agent's tools operate inside the project directory. Because two agents share the sandbox, the cleanest pattern is to manage its lifecycle directly with the Daytona SDK in `finally` rather than attaching `cleanup: true` to one of the agents.
+Both `init()` calls share the same Daytona sandbox. Only the first carries `cleanup: true` so the sandbox is torn down when the request finishes. The second passes `cwd` so the agent's tools operate inside the project directory.
 
 ## Configuring the sandbox
 

--- a/docs/connect-daytona.md
+++ b/docs/connect-daytona.md
@@ -64,13 +64,17 @@ export default async function ({ init, env }: FlueContext) {
     sandbox: daytona(sandbox, { cleanup: true }),
     model: 'anthropic/claude-sonnet-4-6',
   });
-  const session = await agent.session();
 
-  return await session.shell('uname -a');
+  try {
+    const session = await agent.session();
+    return await session.shell('uname -a');
+  } finally {
+    await agent.destroy();
+  }
 }
 ```
 
-`cleanup: true` tells Flue to delete the sandbox when the session ends. The default is `false` (you manage the lifecycle), and you can also pass a function for custom teardown.
+`cleanup: true` tells Flue to delete the sandbox when `agent.destroy()` is called. Wrap the session work in `try/finally` for request-scoped sandboxes so cleanup runs even if something throws. The default is `false` (you manage the lifecycle), and you can also pass a function for custom teardown.
 
 ## Advanced: Sharing a sandbox across sessions
 
@@ -87,29 +91,35 @@ export default async function ({ init, payload, env }: FlueContext) {
   const client = new Daytona({ apiKey: env.DAYTONA_API_KEY });
   const sandbox = await client.create();
 
-  // Setup session — clone the repo and install dependencies.
-  const setupAgent = await init({
-    sandbox: daytona(sandbox, { cleanup: true }),
-    model: 'anthropic/claude-sonnet-4-6',
-  });
-  const setup = await setupAgent.session();
-  await setup.shell(`git clone ${payload.repo} /workspace/project`);
-  await setup.shell('npm install', { cwd: '/workspace/project' });
+  try {
+    // Setup session — clone the repo and install dependencies.
+    const setupAgent = await init({
+      sandbox: daytona(sandbox),
+      model: 'anthropic/claude-sonnet-4-6',
+    });
+    const setup = await setupAgent.session();
+    await setup.shell(`git clone ${payload.repo} /workspace/project`);
+    await setup.shell('npm install', { cwd: '/workspace/project' });
 
-  // Working session — same sandbox, but rooted at the project directory.
-  const projectAgent = await init({
-    id: 'project',
-    sandbox: daytona(sandbox),
-    cwd: '/workspace/project',
-    model: 'anthropic/claude-sonnet-4-6',
-  });
-  const session = await projectAgent.session();
+    // Working session — same sandbox, but rooted at the project directory.
+    const projectAgent = await init({
+      id: 'project',
+      sandbox: daytona(sandbox),
+      cwd: '/workspace/project',
+      model: 'anthropic/claude-sonnet-4-6',
+    });
+    const session = await projectAgent.session();
 
-  return await session.prompt(payload.prompt);
+    return await session.prompt(payload.prompt);
+  } finally {
+    // Both `init()` calls share the same sandbox, so we delete it directly
+    // here instead of relying on a per-agent `cleanup` hook.
+    await sandbox.delete();
+  }
 }
 ```
 
-Both `init()` calls share the same Daytona sandbox. Only the first carries `cleanup: true` so the sandbox is torn down when the working session ends. The second passes `cwd` so the agent's tools operate inside the project directory.
+Both `init()` calls share the same Daytona sandbox, with the second passing `cwd` so the agent's tools operate inside the project directory. Because two agents share the sandbox, the cleanest pattern is to manage its lifecycle directly with the Daytona SDK in `finally` rather than attaching `cleanup: true` to one of the agents.
 
 ## Configuring the sandbox
 

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -250,6 +250,8 @@ The examples above all run on virtual sandboxes — no container needed. But for
 
 Cloudflare has native container support via [`@cloudflare/sandbox`](https://developers.cloudflare.com/containers/). Each session gets its own isolated container with a persistent filesystem, shell, and full Linux userspace.
 
+If you'd rather connect to an external provider — e.g. Daytona — instead of running the sandbox on Cloudflare, see [Connect a Daytona Sandbox](./connect-daytona.md).
+
 ### Setup
 
 You own the container config. That means three things:

--- a/docs/deploy-node.md
+++ b/docs/deploy-node.md
@@ -280,54 +280,11 @@ Per-call `commands` still work and are merged on top of the agent list. If a per
 
 ## Connecting a remote sandbox
 
-The examples above use either the default virtual sandbox or the local sandbox. But when you need full isolation per session — each user gets their own Linux environment with git, Node.js, Python, etc. — you want a remote sandbox.
+The examples above use either the default virtual sandbox or the local sandbox. When you need full isolation per session — each user gets their own Linux environment with git, Node.js, Python, etc. — you want a remote sandbox.
 
-Install a sandbox connector with `flue add <name> | <your-agent>` (e.g. `flue add daytona | claude`). Run `flue add` with no arguments to see what's available, or run `flue add <url> --category sandbox` to have your agent build one for an unsupported provider.
+Flue connects to remote sandboxes through small adapter files called connectors, installed with `flue add`. Run `flue add` with no arguments to see what's currently supported, or `flue add <url> --category sandbox` to have your coding agent build a connector for an unsupported provider against the [sandbox connector spec](./sandbox-connector-spec.md).
 
-Here's an example using [Daytona](https://www.daytona.io/):
-
-`.flue/agents/code.ts`:
-
-```typescript
-import type { FlueContext } from '@flue/sdk/client';
-import { Daytona } from '@daytona/sdk';
-import { daytona } from '../connectors/daytona';
-
-export const triggers = { webhook: true };
-
-export default async function ({ init, payload, env }: FlueContext) {
-  const client = new Daytona({ apiKey: env.DAYTONA_API_KEY });
-  const sandbox = await client.create();
-  const setupAgent = await init({
-    sandbox: daytona(sandbox, { cleanup: true }),
-    model: 'openai/gpt-5.5',
-  });
-  const setup = await setupAgent.session();
-
-  await setup.shell(`git clone ${payload.repo} /workspace/project`);
-  await setup.shell('npm install', { cwd: '/workspace/project' });
-
-  const projectAgent = await init({
-    id: 'project',
-    sandbox: daytona(sandbox),
-    cwd: '/workspace/project',
-    model: 'openai/gpt-5.5',
-  });
-  const session = await projectAgent.session();
-
-  return await session.prompt(payload.prompt);
-}
-```
-
-Daytona is one of many possible sandbox providers. Any provider that implements Flue's `SandboxFactory` interface works — the connector is just an adapter.
-
-### A note on secrets and remote sandbox security
-
-When your agent runs in a remote sandbox, be aware that environment variables and mounted secrets are accessible to the LLM. If the agent is compromised or the model behaves unexpectedly, those secrets could be exfiltrated.
-
-For virtual and local sandboxes, Flue's `defineCommand` pattern already solves this — secrets live in the host process and are never exposed to the sandbox. But for remote sandboxes, the agent has a full Linux environment and can make arbitrary network requests.
-
-Some remote sandbox providers offer egress proxy features that let you inject credentials at the network level without exposing them to the sandbox (for example, [Cloudflare Sandboxes](https://blog.cloudflare.com/sandbox-auth/) support this natively). If your workload handles sensitive secrets and you need egress protection, look for a provider that supports this. Daytona does not currently offer an equivalent feature.
+We've written a full walkthrough for one provider — [Connect a Daytona Sandbox](./connect-daytona.md) — that covers installing the connector, wiring it into an agent, and configuring the sandbox. Other connectors follow the same shape.
 
 ### When to use a remote sandbox
 
@@ -432,6 +389,6 @@ Here's the progression of sandbox types available on Node.js, from simplest to m
 1. **Empty virtual sandbox** — `init({ model: 'openai/gpt-5.5' })`. Fast, cheap, stateless. Good for prompt-and-response agents.
 2. **Virtual sandbox with shell setup** — Use `session.shell()` to write files and configure the workspace. Still fast and cheap, good for agents that need small amounts of static context.
 3. **Local sandbox** — `init({ sandbox: 'local', model: 'anthropic/claude-sonnet-4-6' })`. Mounts the host filesystem at `/workspace`. Ideal for self-hosted agents, CI tasks, and dev tooling.
-4. **Remote sandbox** — Full isolated Linux environment via Daytona or other providers. For multi-tenant agents, coding sandboxes, and anything that needs per-session isolation.
+4. **Remote sandbox** — Full isolated Linux environment via a sandbox connector. For multi-tenant agents, coding sandboxes, and anything that needs per-session isolation.
 
 Start simple. Move up when you need to.


### PR DESCRIPTION
Adds `docs/connect-daytona.md` — a walkthrough for connecting a Daytona remote sandbox to a Flue agent, picking up from any of the existing deploy guides.

Also trims the now-duplicated remote-sandbox content out of `deploy-node.md` and adds a short pointer from `deploy-cloudflare.md`.
