### PR TITLE
feat: add MiniMax-M2.7 provider support and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,30 @@ const agent = await init({
 });
 ```
 
+**MiniMax-M2.7** is available as a first-class provider via `minimax/MiniMax-M2.7`
+(and `minimax/MiniMax-M2.7-highspeed` for the faster variant). MiniMax uses an
+Anthropic-compatible messages API, so all Flue features — streaming, tools, tasks,
+context compaction, and roles — work out of the box.
+
+```ts
+// Set MINIMAX_API_KEY in the environment, or pass it via providers:
+const agent = await init({
+  model: 'minimax/MiniMax-M2.7',
+  providers: {
+    minimax: {
+      // Explicit key — useful in Cloudflare Workers where env vars are
+      // request-scoped bindings rather than process-global variables.
+      apiKey: env.MINIMAX_API_KEY,
+    },
+  },
+});
+const session = await agent.session();
+const result = await session.prompt('Explain how large language models work.');
+```
+
+If `MINIMAX_API_KEY` is already set as a process environment variable, the
+`providers` block is optional — omit it and Flue picks up the key automatically.
+
 ### Custom Virtual Sandboxes
 
 For most agents, use the built-in virtual sandbox or `sandbox: 'local'`. If you need to customize just-bash directly, pass a Bash factory. The factory must return a fresh Bash-like runtime each time; share the filesystem object in the closure to persist files across sessions and prompts.

--- a/examples/hello-world/.flue/agents/with-minimax.ts
+++ b/examples/hello-world/.flue/agents/with-minimax.ts
@@ -1,0 +1,56 @@
+import type { FlueContext } from '@flue/sdk/client';
+import * as v from 'valibot';
+
+export const triggers = { webhook: true };
+
+/**
+ * MiniMax-M2.7 example.
+ *
+ * Demonstrates using MiniMax as the model provider via the `minimax` provider
+ * key. MiniMax-M2.7 uses an Anthropic-compatible messages API and supports
+ * extended thinking / reasoning.
+ *
+ * Set the `MINIMAX_API_KEY` environment variable, or pass the key at runtime:
+ *
+ *   await init({
+ *     model: 'minimax/MiniMax-M2.7',
+ *     providers: { minimax: { apiKey: env.MINIMAX_API_KEY } },
+ *   });
+ *
+ * Both forms work — env var is the simpler path for local dev; `providers`
+ * is the right approach for Cloudflare Workers where `env` bindings are
+ * scoped to the request rather than available globally.
+ *
+ * Run with:
+ *   flue run with-minimax --target node \
+ *     --payload '{"text":"Hello, world!","language":"French"}'
+ */
+export default async function ({ init, payload, env }: FlueContext) {
+	const agent = await init({
+		model: 'minimax/MiniMax-M2.7',
+		// Pass the API key explicitly so it works in environments where
+		// MINIMAX_API_KEY cannot be set as a process-global env var (e.g. Cloudflare).
+		// When MINIMAX_API_KEY is already set in the environment, the `providers`
+		// block is optional — omitting it falls back to the env var automatically.
+		providers: {
+			minimax: {
+				apiKey: env.MINIMAX_API_KEY,
+			},
+		},
+	});
+	const session = await agent.session();
+
+	const result = await session.prompt(
+		`Translate this to ${payload.language ?? 'French'}: "${payload.text ?? 'Hello, world!'}"`,
+		{
+			result: v.object({
+				translation: v.string(),
+				confidence: v.picklist(['low', 'medium', 'high']),
+			}),
+		},
+	);
+
+	console.log('[with-minimax] translation:', result.translation);
+	console.log('[with-minimax] confidence:', result.confidence);
+	return result;
+}

--- a/packages/sdk/src/internal.ts
+++ b/packages/sdk/src/internal.ts
@@ -64,7 +64,9 @@ export function resolveModel(
 		throw new Error(
 			`[flue] Unknown model "${modelString}". ` +
 				`Provider "${provider}" / model id "${modelId}" ` +
-				`is not registered with @mariozechner/pi-ai.`,
+				`is not registered with @mariozechner/pi-ai. ` +
+				`Supported providers include: anthropic, openai, openrouter, minimax, minimax-cn, ` +
+				`google, mistral, groq, and more. Check @mariozechner/pi-ai for the full list.`,
 		);
 	}
 	return applyProviderSettings(resolved, providers?.[provider]);
@@ -78,6 +80,10 @@ function applyProviderSettings<TApi extends Api>(
 
 	const hasBaseUrl = providerSettings.baseUrl !== undefined;
 	const hasHeaders = providerSettings.headers !== undefined;
+	// Note: providerSettings.apiKey is intentionally not applied to the model object —
+	// it is surfaced to the agent runtime via the getApiKey() callback in session.ts,
+	// which pi-agent-core uses when making API requests. This keeps credential handling
+	// out of the serialisable model config.
 	if (!hasBaseUrl && !hasHeaders) return model;
 
 	return {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -131,9 +131,21 @@ export interface ProviderSettings {
 	 */
 	headers?: Record<string, string>;
 	/**
-	 * API key returned to the underlying agent runtime for this provider.
-	 * Useful when the gateway requires a dummy key or when credentials should
-	 * come from the agent's runtime env instead of process-global env vars.
+	 * API key passed to the underlying agent runtime for this provider.
+	 *
+	 * Use this to supply credentials at runtime instead of relying on a
+	 * process-global environment variable. For example, to use MiniMax without
+	 * setting `MINIMAX_API_KEY` globally:
+	 *
+	 * ```ts
+	 * await init({
+	 *   model: 'minimax/MiniMax-M2.7',
+	 *   providers: { minimax: { apiKey: env.MINIMAX_API_KEY } },
+	 * });
+	 * ```
+	 *
+	 * When routing through a proxy that expects a synthetic key, pass `'dummy'`
+	 * alongside a custom `baseUrl`.
 	 */
 	apiKey?: string;
 }


### PR DESCRIPTION
## Summary

MiniMax-M2.7 (and MiniMax-M2.7-highspeed) are registered in `@mariozechner/pi-ai` as a first-class provider using the Anthropic Messages API, but Flue had no documentation or examples showing how to use them.

- **README.md**: document `minimax/MiniMax-M2.7` usage in the Provider Settings section, covering both env-var and explicit `providers.minimax.apiKey` forms
- **`packages/sdk/src/types.ts`**: improve `ProviderSettings.apiKey` JSDoc with a concrete MiniMax example
- **`packages/sdk/src/internal.ts`**: improve the unknown-provider error message to enumerate known providers (including minimax/minimax-cn); add a comment explaining the apiKey design
- **`examples/hello-world/.flue/agents/with-minimax.ts`**: new example agent demonstrating MiniMax-M2.7

## Test plan

- [x] Type-check passes (`pnpm run check:types`)
- [x] Lint passes with no new errors (`pnpm run check:lint`)