### PR TITLE
Introduce flue.config.ts

### DIFF
--- a/packages/cli/bin/flue.ts
+++ b/packages/cli/bin/flue.ts
@@ -5,6 +5,7 @@ import { determineAgent } from '@vercel/detect-agent';
 import {
 	build,
 	dev,
+	loadConfig,
 	DEFAULT_DEV_PORT,
 	parseEnvFiles,
 	resolveEnvFiles,
@@ -54,9 +55,9 @@ function resolveOutputDir(explicitOutput: string | undefined): string {
 function printUsage() {
 	console.error(
 		'Usage:\n' +
-			'  flue dev   --target <node|cloudflare> [--workspace <path>] [--output <path>] [--port <number>] [--env <path>]...\n' +
-			'  flue run   <agent> --target node --id <id> [--payload <json>] [--workspace <path>] [--output <path>] [--port <number>] [--env <path>]...\n' +
-			'  flue build --target <node|cloudflare> [--workspace <path>] [--output <path>]\n' +
+			'  flue dev   [--target <node|cloudflare>] [--workspace <path>] [--output <path>] [--port <number>] [--env <path>]...\n' +
+			'  flue run   <agent> [--target node] --id <id> [--payload <json>] [--workspace <path>] [--output <path>] [--port <number>] [--env <path>]...\n' +
+			'  flue build [--target <node|cloudflare>] [--workspace <path>] [--output <path>]\n' +
 			'  flue add   [<name>|<url>] [--category <category>] [--print]\n' +
 			'\n' +
 			'Commands:\n' +
@@ -66,6 +67,7 @@ function printUsage() {
 			'  add    Install a connector. Pipes installation instructions for an AI coding agent to follow.\n' +
 			'\n' +
 			'Flags:\n' +
+			'  --target <target>    Deploy target: node or cloudflare. Overrides flue.config.ts if set.\n' +
 			'  --workspace <path>   Workspace root (containing agents/ and roles/). Default: ./.flue/ if it exists, else ./\n' +
 			'  --output <path>      Where dist/ is written. Default: current working directory\n' +
 			`  --port <number>      Port for the dev server. Default: ${DEFAULT_DEV_PORT}\n` +
@@ -76,12 +78,13 @@ function printUsage() {
 			'  --print              (flue add) Print the raw connector markdown to stdout regardless of whether the caller is an agent.\n' +
 			'\n' +
 			'Examples:\n' +
+			'  flue dev                                       # uses target from flue.config.ts\n' +
 			'  flue dev --target node\n' +
 			'  flue dev --target cloudflare --port 8787\n' +
 			'  flue dev --target node --env .env\n' +
-			'  flue run hello --target node --id test-1\n' +
+			'  flue run hello --id test-1\n' +
 			'  flue run hello --target node --id test-1 --payload \'{"name": "World"}\' --env .env\n' +
-			'  flue build --target node\n' +
+			'  flue build\n' +
 			'  flue build --target cloudflare --workspace ./.flue --output ./build\n' +
 			'  flue add\n' +
 			'  flue add daytona | claude\n' +
@@ -95,7 +98,7 @@ function printUsage() {
 interface RunArgs {
 	command: 'run';
 	agent: string;
-	target: 'node';
+	target?: 'node';
 	id: string;
 	payload: string;
 	/** Explicit --workspace value, or undefined to apply the cwd waterfall. */
@@ -109,7 +112,7 @@ interface RunArgs {
 
 interface BuildArgs {
 	command: 'build';
-	target: 'node' | 'cloudflare';
+	target?: 'node' | 'cloudflare';
 	/** Explicit --workspace value, or undefined to apply the cwd waterfall. */
 	explicitWorkspace: string | undefined;
 	/** Explicit --output value, or undefined to default to cwd. */
@@ -118,7 +121,7 @@ interface BuildArgs {
 
 interface DevArgs {
 	command: 'dev';
-	target: 'node' | 'cloudflare';
+	target?: 'node' | 'cloudflare';
 	/** Explicit --workspace value, or undefined to apply the cwd waterfall. */
 	explicitWorkspace: string | undefined;
 	/** Explicit --output value, or undefined to default to cwd. */
@@ -295,14 +298,9 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 	if (command === 'build') {
 		const flags = parseFlags(rest);
-		if (!flags.target) {
-			console.error('Missing required --target flag. Supported targets: node, cloudflare');
-			printUsage();
-			process.exit(1);
-		}
 		return {
 			command: 'build',
-			target: flags.target as 'node' | 'cloudflare',
+			target: flags.target,
 			explicitWorkspace: flags.explicitWorkspace,
 			explicitOutput: flags.explicitOutput,
 		};
@@ -310,14 +308,9 @@ function parseArgs(argv: string[]): ParsedArgs {
 
 	if (command === 'dev') {
 		const flags = parseFlags(rest);
-		if (!flags.target) {
-			console.error('Missing required --target flag. Supported targets: node, cloudflare');
-			printUsage();
-			process.exit(1);
-		}
 		return {
 			command: 'dev',
-			target: flags.target as 'node' | 'cloudflare',
+			target: flags.target,
 			explicitWorkspace: flags.explicitWorkspace,
 			explicitOutput: flags.explicitOutput,
 			port: flags.port,
@@ -328,12 +321,6 @@ function parseArgs(argv: string[]): ParsedArgs {
 	if (command === 'run' && rest.length > 0) {
 		const agent = rest[0]!;
 		const flags = parseFlags(rest.slice(1));
-
-		if (!flags.target) {
-			console.error('Missing required --target flag. `flue run` only supports --target node');
-			printUsage();
-			process.exit(1);
-		}
 
 		if (!flags.id) {
 			console.error('Missing required --id flag for run command.');
@@ -355,7 +342,7 @@ function parseArgs(argv: string[]): ParsedArgs {
 		return {
 			command: 'run',
 			agent,
-			target: flags.target,
+			target: flags.target as 'node' | undefined,
 			id: flags.id,
 			payload: flags.payload,
 			explicitWorkspace: flags.explicitWorkspace,
@@ -691,6 +678,18 @@ async function run(args: RunArgs) {
 	const outputDir = resolveOutputDir(args.explicitOutput);
 	const serverPath = path.join(outputDir, 'dist', 'server.mjs');
 
+	// Resolve target from config if not passed via CLI.
+	// `flue run` only supports Node — error if config specifies cloudflare.
+	const config = await loadConfig(workspaceDir);
+	const target = args.target ?? config.target;
+	if (target === 'cloudflare') {
+		printCloudflareRunUnsupported(args.agent, args.id, args.payload);
+	}
+	if (target && target !== 'node') {
+		console.error(`[flue] \`flue run\` only supports --target node, got "${target}".`);
+		process.exit(1);
+	}
+
 	// 0. Resolve --env paths up front so a typo errors before we kick
 	//    off a build. Resolves relative to outputDir (the project root).
 	let resolvedEnvFiles: string[];
@@ -705,9 +704,9 @@ async function run(args: RunArgs) {
 	}
 	const fileEnv = parseEnvFiles(resolvedEnvFiles);
 
-	// 1. Build
+	// 1. Build (target defaults to 'node' for `flue run`)
 	try {
-		await build({ workspaceDir, outputDir, target: args.target });
+		await build({ workspaceDir, outputDir, target: target ?? 'node' });
 	} catch (err) {
 		console.error(`[flue] Build failed:`, err instanceof Error ? err.message : String(err));
 		process.exit(1);

--- a/packages/sdk/src/build.ts
+++ b/packages/sdk/src/build.ts
@@ -5,7 +5,28 @@ import { packageUpSync } from 'package-up';
 import { parseFrontmatterFile } from './context.ts';
 import { CloudflarePlugin } from './build-plugin-cloudflare.ts';
 import { NodePlugin } from './build-plugin-node.ts';
-import type { AgentInfo, BuildContext, BuildOptions, BuildPlugin, Role } from './types.ts';
+import type { AgentInfo, BuildContext, BuildOptions, BuildPlugin, FlueConfig, Role } from './types.ts';
+
+const CONFIG_FILENAMES = ['flue.config.ts', 'flue.config.mts', 'flue.config.js', 'flue.config.mjs'];
+
+/**
+ * Find and load a `flue.config.ts` (or .js/.mts/.mjs) from a workspace directory.
+ * Returns the config object, or an empty object if no config file exists.
+ */
+export async function loadConfig(workspaceDir: string): Promise<FlueConfig> {
+	const resolved = path.resolve(workspaceDir);
+	for (const filename of CONFIG_FILENAMES) {
+		const filePath = path.join(resolved, filename);
+		if (fs.existsSync(filePath)) {
+			const fileUrl = `file://${filePath}`;
+			const mod = await import(fileUrl);
+			const config: FlueConfig = mod.default ?? {};
+			console.log(`[flue] Loaded config: ${filePath}`);
+			return config;
+		}
+	}
+	return {};
+}
 
 /**
  * Result returned by {@link build}. `changed` indicates whether any file in
@@ -30,7 +51,11 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
 	const workspaceDir = path.resolve(options.workspaceDir);
 	const outputDir = path.resolve(options.outputDir);
 
-	const plugin = resolvePlugin(options);
+	// Load project config; CLI flags (in options) override config file values.
+	const config = await loadConfig(workspaceDir);
+	const mergedTarget = options.target ?? config.target;
+	const mergedOptions = { ...options, target: mergedTarget };
+	const plugin = resolvePlugin(mergedOptions);
 
 	console.log(`[flue] Building workspace: ${workspaceDir}`);
 	console.log(`[flue] Output: ${outputDir}/dist`);
@@ -94,7 +119,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
 		roles,
 		workspaceDir,
 		outputDir,
-		options,
+		options: mergedOptions,
 	};
 
 	const serverCode = await plugin.generateEntryPoint(ctx);
@@ -195,7 +220,7 @@ function resolvePlugin(options: BuildOptions): BuildPlugin {
 
 	if (!options.target) {
 		throw new Error(
-			'[flue] No build target specified. Use --target to choose a target:\n' +
+			'[flue] No build target specified. Set `target` in flue.config.ts or pass --target:\n' +
 				'  flue build --target node\n' +
 				'  flue build --target cloudflare',
 		);

--- a/packages/sdk/src/dev.ts
+++ b/packages/sdk/src/dev.ts
@@ -37,7 +37,7 @@ import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { parseEnv } from 'node:util';
-import { build } from './build.ts';
+import { build, loadConfig } from './build.ts';
 import type { BuildOptions } from './types.ts';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -45,7 +45,7 @@ import type { BuildOptions } from './types.ts';
 export interface DevOptions {
 	workspaceDir: string;
 	outputDir: string;
-	target: 'node' | 'cloudflare';
+	target?: 'node' | 'cloudflare';
 	/** Defaults to 3583 ("FLUE" on a phone keypad). */
 	port?: number;
 	/**
@@ -115,6 +115,17 @@ export async function dev(options: DevOptions): Promise<void> {
 	const outputDir = path.resolve(options.outputDir);
 	const port = options.port ?? DEFAULT_DEV_PORT;
 
+	// Load project config; CLI flags (in options) override config file values.
+	const config = await loadConfig(workspaceDir);
+	const target = options.target ?? config.target;
+	if (!target) {
+		throw new Error(
+			'[flue] No build target specified. Set `target` in flue.config.ts or pass --target:\n' +
+				'  flue dev --target node\n' +
+				'  flue dev --target cloudflare',
+		);
+	}
+
 	// Resolve env files up front so a typo errors before we kick off a build.
 	// Resolved against outputDir so relative paths feel natural ("the path
 	// they look like from the project root").
@@ -126,10 +137,10 @@ export async function dev(options: DevOptions): Promise<void> {
 	const buildOptions: BuildOptions = {
 		workspaceDir,
 		outputDir,
-		target: options.target,
+		target,
 	};
 
-	console.error(`[flue] Starting dev server (target: ${options.target})`);
+	console.error(`[flue] Starting dev server (target: ${target})`);
 	console.error(`[flue] Watching: ${workspaceDir}`);
 	console.error(`[flue] Building...`);
 
@@ -144,7 +155,7 @@ export async function dev(options: DevOptions): Promise<void> {
 	console.error(`[flue] Built in ${Date.now() - initialStart}ms`);
 
 	const reloader: DevReloader =
-		options.target === 'node'
+		target === 'node'
 			? new NodeReloader({ outputDir, port, envFiles })
 			: await createCloudflareReloader({ outputDir, port, envFiles });
 
@@ -167,7 +178,7 @@ export async function dev(options: DevOptions): Promise<void> {
 	const watcher = createWatcher({
 		workspaceDir,
 		outputDir,
-		target: options.target,
+		target,
 		envFiles,
 		onChange: (relPath) => {
 			if (!reloader.shouldRebuildOn(relPath)) return;

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -32,9 +32,10 @@ export type {
 	AgentInfo,
 	ToolDef,
 	ToolParameters,
+	FlueConfig,
 } from './types.ts';
 
-export { build, resolveWorkspaceFromCwd } from './build.ts';
+export { build, loadConfig, resolveWorkspaceFromCwd } from './build.ts';
 export {
 	dev,
 	DEFAULT_DEV_PORT,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -517,6 +517,29 @@ export interface BuildPlugin {
 	additionalOutputs?(ctx: BuildContext): Record<string, string> | Promise<Record<string, string>>;
 }
 
+// ─── Project Config ─────────────────────────────────────────────────────────
+
+/**
+ * Project-level configuration for a Flue workspace.
+ *
+ * Lives in the workspace directory as `flue.config.ts` (or `.js`/`.mts`/`.mjs`)
+ * and is loaded at build time. CLI flags override values from this file.
+ *
+ * ```ts
+ * import type { FlueConfig } from '@flue/sdk';
+ *
+ * export default {
+ *   target: 'node',
+ * } satisfies FlueConfig;
+ * ```
+ */
+export interface FlueConfig {
+	/** The deploy target. */
+	target?: 'node' | 'cloudflare';
+}
+
+// ─── Build Options ──────────────────────────────────────────────────────────
+
 export interface BuildOptions {
 	/**
 	 * The workspace directory: the directory directly containing agents/ and


### PR DESCRIPTION
*This is only to start a discussion*

Adds project-level config file support. `--target` is now optional when `target` is set in `flue.config.ts`.

I was looking into adding `persist` as a target-level configuration but there isn't any place to do that, since target is always passed in as a flag. Proposal is to create a flue config file inside of `.flue/` which gives you a place to configure thing.

I *think* Flue had a config in an earlier version but I'm not aware of the reason for removing it.