### PR TITLE
Fix flue run signal cleanup

### DIFF
--- a/packages/cli/bin/flue.ts
+++ b/packages/cli/bin/flue.ts
@@ -629,6 +629,7 @@ function stopServer(child: ChildProcess) {
 	if (!child.killed) {
 		child.kill('SIGTERM');
 	}
+	if (serverProcess === child) serverProcess = undefined;
 }
 
 // ─── Find Available Port ────────────────────────────────────────────────────
@@ -719,6 +720,10 @@ async function run(args: RunArgs) {
 	// 3. Start server
 	console.error(`[flue] Starting server on port ${port}...`);
 	const child = startServer(serverPath, port, fileEnv, outputDir);
+	serverProcess = child;
+	child.once('exit', () => {
+		if (serverProcess === child) serverProcess = undefined;
+	});
 
 	// Pipe server stdout/stderr for visibility
 	const pipeServerOutput = (data: Buffer) => {


### PR DESCRIPTION
## Summary

- wire the spawned `flue run` server process into the existing SIGINT/SIGTERM cleanup handle
- clear the global handle when the child exits or is stopped manually

Addresses the first item in #50 without closing the whole tracker.

## Verification

- pnpm run check:types
- git diff --check

Note: `pnpm exec biome check packages/cli/bin/flue.ts` still reports pre-existing lint debt in this CLI file, unrelated to this patch.