### PR TITLE
Docs/render deploy guide

### DIFF
--- a/apps/www/src/pages/index.astro
+++ b/apps/www/src/pages/index.astro
@@ -507,6 +507,12 @@ const floatingSquares = [
             </svg>
             <span class="relative inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-600 group-hover:text-gray-950 group-hover:border-gray-400 transition-colors text-center shadow-sm">Daytona</span>
           </a>
+          <!-- Render -->
+          <a href="https://github.com/withastro/flue/blob/main/docs/deploy-render.md" target="_blank" rel="noopener noreferrer" class="runner-cell group relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300 hover:bg-white transition-colors duration-300">
+            <div class="absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300" style="background: radial-gradient(circle at 80% 80%, rgba(139,92,246,0.1) 0%, transparent 60%);"></div>
+            <svg class="relative w-10 h-10 grayscale opacity-60 group-hover:grayscale-0 group-hover:opacity-100 transition-all duration-300" viewBox="0 0 24 24" fill="#8b5cf6" aria-hidden="true"><path d="M18.263.007c-3.121-.147-5.744 2.109-6.192 5.082-.018.138-.045.272-.067.405-.696 3.703-3.936 6.507-7.827 6.507-1.388 0-2.691-.356-3.825-.979a.2024.2024 0 0 0-.302.178V24H12v-8.999c0-1.656 1.338-3 2.987-3h2.988c3.382 0 6.103-2.817 5.97-6.244-.12-3.084-2.61-5.603-5.682-5.75"/></svg>
+            <span class="relative inline-flex items-center gap-1.5 rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-600 group-hover:text-gray-950 group-hover:border-gray-400 transition-colors text-center shadow-sm">Render</span>
+          </a>
           <!-- "Guide coming soon" cards. All below work today via the Node
                target. The visual is intentionally cryptic — only the logo
                identifies the platform. Logo opacity is muted so it's clear
@@ -517,18 +523,13 @@ const floatingSquares = [
             <span class="rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">Guide coming soon</span>
           </button>
           <!-- Netlify -->
-          <button disabled aria-label="Netlify deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300 cursor-default">
+          <button disabled aria-label="Netlify deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t sm:border-x border-gray-300 cursor-default">
             <svg class="relative w-10 h-10 grayscale opacity-40" viewBox="0 0 24 24" fill="#00C7B7" aria-hidden="true"><path d="M6.49 19.04h-.23L5.13 17.9v-.23l1.73-1.71h1.2l.15.15v1.2L6.5 19.04ZM5.13 6.31V6.1l1.13-1.13h.23L8.2 6.68v1.2l-.15.15h-1.2L5.13 6.31Zm9.96 9.09h-1.65l-.14-.13v-3.83c0-.68-.27-1.2-1.1-1.23-.42 0-.9 0-1.43.02l-.07.08v4.96l-.14.14H8.9l-.13-.14V8.73l.13-.14h3.7a2.6 2.6 0 0 1 2.61 2.6v4.08l-.13.14Zm-8.37-2.44H.14L0 12.82v-1.64l.14-.14h6.58l.14.14v1.64l-.14.14Zm17.14 0h-6.58l-.14-.14v-1.64l.14-.14h6.58l.14.14v1.64l-.14.14ZM11.05 6.55V1.64l.14-.14h1.65l.14.14v4.9l-.14.14h-1.65l-.14-.13Zm0 15.81v-4.9l.14-.14h1.65l.14.13v4.91l-.14.14h-1.65l-.14-.14Z"/></svg>
             <span class="rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">Guide coming soon</span>
           </button>
           <!-- Railway -->
-          <button disabled aria-label="Railway deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t sm:border-x border-gray-300 cursor-default">
+          <button disabled aria-label="Railway deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300 cursor-default">
             <svg class="relative w-10 h-10 grayscale opacity-40" viewBox="0 0 24 24" fill="#000" aria-hidden="true"><path d="M.113 10.27A13.026 13.026 0 000 11.48h18.23c-.064-.125-.15-.237-.235-.347-3.117-4.027-4.793-3.677-7.19-3.78-.8-.034-1.34-.048-4.524-.048-1.704 0-3.555.005-5.358.01-.234.63-.459 1.24-.567 1.737h9.342v1.216H.113v.002zm18.26 2.426H.009c.02.326.05.645.094.961h16.955c.754 0 1.179-.429 1.315-.96zm-17.318 4.28s2.81 6.902 10.93 7.024c4.855 0 9.027-2.883 10.92-7.024H1.056zM11.988 0C7.5 0 3.593 2.466 1.531 6.108l4.75-.005v-.002c3.71 0 3.849.016 4.573.047l.448.016c1.563.052 3.485.22 4.996 1.364.82.621 2.007 1.99 2.712 2.965.654.902.842 1.94.396 2.934-.408.914-1.289 1.458-2.353 1.458H.391s.099.42.249.886h22.748A12.026 12.026 0 0024 12.005C24 5.377 18.621 0 11.988 0z"/></svg>
-            <span class="rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">Guide coming soon</span>
-          </button>
-          <!-- Render -->
-          <button disabled aria-label="Render deploy guide coming soon. Works today with the Node target." class="runner-cell relative overflow-hidden flex flex-col items-center justify-center gap-4 py-10 px-6 border-t border-gray-300 cursor-default">
-            <svg class="relative w-10 h-10 grayscale opacity-40" viewBox="0 0 24 24" fill="#46E3B7" aria-hidden="true"><path d="M18.263.007c-3.121-.147-5.744 2.109-6.192 5.082-.018.138-.045.272-.067.405-.696 3.703-3.936 6.507-7.827 6.507-1.388 0-2.691-.356-3.825-.979a.2024.2024 0 0 0-.302.178V24H12v-8.999c0-1.656 1.338-3 2.987-3h2.988c3.382 0 6.103-2.817 5.97-6.244-.12-3.084-2.61-5.603-5.682-5.75"/></svg>
             <span class="rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-medium text-gray-400 text-center shadow-sm">Guide coming soon</span>
           </button>
         </div>

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -2,6 +2,8 @@
 
 Build and deploy Flue agents on Cloudflare Workers. This guide walks you through the different kinds of agents you can build — from simple prompt-and-response endpoints to full coding agents backed by persistent storage and remote sandboxes.
 
+By the end, you will have a Flue agent running on Cloudflare Workers, and you will know how to add roles, R2-backed context, Cloudflare sandboxes, and Durable Object-backed sessions.
+
 ## Project layout
 
 Flue looks for your workspace in one of two places:

--- a/docs/deploy-github-actions.md
+++ b/docs/deploy-github-actions.md
@@ -2,6 +2,8 @@
 
 Build and run Flue agents in GitHub Actions. This guide walks you through creating your first agent, running it locally with the CLI, and wiring it into a CI workflow.
 
+By the end, you will have a Flue agent running inside GitHub Actions, and you will know how to use local sandbox context, commands, roles, skills, and typed results to build CI workflows.
+
 ## Hello World
 
 A minimal agent that runs in CI whenever an issue is opened.

--- a/docs/deploy-gitlab-ci.md
+++ b/docs/deploy-gitlab-ci.md
@@ -2,6 +2,8 @@
 
 Build and run Flue agents in GitLab CI/CD pipelines. This guide walks you through creating your first agent, running it locally with the CLI, and wiring it into a pipeline.
 
+By the end, you will have a Flue agent running inside GitLab CI/CD, and you will know how to use local sandbox context, commands, roles, skills, and typed results to build CI workflows.
+
 ## Hello World
 
 A minimal agent that runs in CI whenever an issue is opened.

--- a/docs/deploy-node.md
+++ b/docs/deploy-node.md
@@ -2,6 +2,8 @@
 
 Build and deploy Flue agents as a Node.js server. This guide walks you through creating your first agent, running it locally, and deploying it anywhere you can run Node.js — a VPS, Docker, Railway, Fly.io, or any cloud platform.
 
+By the end, you will have a Flue agent running as a Node.js server, and you will know how to add roles, sandbox context, commands, remote sandboxes, and durable session storage when your agent needs them.
+
 ## Project layout
 
 Flue looks for your workspace in one of two places:

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -11,7 +11,7 @@ By the end, you will have a live Render Web Service running Flue agents, and you
 
 ## What you'll build
 
-You will take the template from one-click deploy to a working Flue service you can call from any HTTP client:
+Starting from the template, you'll ship a live Flue agent on Render that you can call from any HTTP client:
 
 1. Deploy a Flue Web Service on Render.
 2. Send real requests to the `translate` and `assistant` agents.
@@ -20,7 +20,7 @@ You will take the template from one-click deploy to a working Flue service you c
 
 ## 1. Deploy the template
 
-Open the [Flue template](https://render.com/templates/flue) and start the one-click flow. Render walks you through:
+Open the [Flue template](https://render.com/templates/flue) and click **Deploy to Render**. Render walks you through:
 
 1. Authorizing Render's GitHub OAuth app.
 2. Copying the template repo to your GitHub account.

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -109,21 +109,9 @@ This is the Render side of what the Node guide already covers:
 - `buildCommand` compiles Flue's Node target.
 - `startCommand` runs the generated server, which binds to `PORT` and serves agents at `/agents/<name>/<id>`.
 - `healthCheckPath` lets Render verify each deploy before it shifts traffic.
-- `sync: false` tells Render to prompt for the secret instead of reading it from Git.
+- `sync: false` keeps the secret out of the Blueprint. Render prompts for the value on first deploy and stores it on the service.
 
-If you ever move this setup into a different repo, drop the same `render.yaml` at its root and open the Blueprint flow with that repo's URL:
-
-```txt
-https://dashboard.render.com/blueprint/new?repo=https://github.com/<user>/<repo>
-```
-
-If the Render CLI is installed, you can validate before pushing:
-
-```bash
-render blueprints validate
-```
-
-The snippets in this guide validate against Render's public schema at `https://render.com/schema/render.yaml.json`.
+If you ever move this setup into a different repo, drop the same `render.yaml` at its root, then create a new Blueprint from the Render Dashboard (**New > Blueprint**) and pick that repo.
 
 > You can now read the Blueprint and know what each Render-facing field does.
 
@@ -148,7 +136,7 @@ envVars:
 Once the next deploy goes live, call the translation agent again:
 
 ```bash
-curl https://<service>.onrender.com/agents/translate/model-test \
+curl https://<service>.onrender.com/agents/translate/verify \
   -H "Content-Type: application/json" \
   -d '{"text": "Good morning", "language": "Spanish"}'
 ```
@@ -159,9 +147,7 @@ A successful response means the new env values reached the running service and F
 
 ## 5. Add session persistence
 
-Skip this section if your agents are stateless or if in-memory sessions are enough. Otherwise, jump in.
-
-In-memory sessions disappear on every deploy or restart, and they don't help once you scale beyond one instance. To make conversations durable, implement a Flue `SessionStore` in your app and back it with a Render data store.
+In-memory sessions disappear on every deploy or restart, and they don't help once you scale beyond one instance. If your agents need conversations that survive that, back them with a Render data store by implementing a Flue `SessionStore`.
 
 Render Postgres is the best default for durable session history. Extend the template's `render.yaml` with a database and wire `DATABASE_URL` into the Web Service:
 
@@ -187,21 +173,30 @@ services:
         sync: false
 ```
 
-Once your app reads `DATABASE_URL` in its `SessionStore`, redeploy and replay the assistant test with the same session ID. Trigger a manual deploy and call the same session again. If it remembers the earlier turn, persistence is working.
+To verify persistence end to end, run a fact-recall test that survives a process restart:
+
+1. Commit the updated `render.yaml` and wait for the new database-aware deploy to go live.
+2. Update your `SessionStore` to read `DATABASE_URL`.
+3. Plant a fact in a fresh session:
+
+   ```bash
+   curl https://<service>.onrender.com/agents/assistant/persist-test \
+     -H "Content-Type: application/json" \
+     -d '{"message": "Remember this number for me: 42."}'
+   ```
+
+4. Restart the service from the Render Dashboard (**Manual Deploy > Restart Service**) so the in-memory state of the previous process is gone.
+5. Once the service is healthy, ask for the fact back:
+
+   ```bash
+   curl https://<service>.onrender.com/agents/assistant/persist-test \
+     -H "Content-Type: application/json" \
+     -d '{"message": "What number did I ask you to remember?"}'
+   ```
+
+If the response references `42`, your `SessionStore` is reading and writing through Postgres correctly. If the agent has no idea, persistence isn't being read on session resume.
 
 > Your sessions now survive deploys, restarts, and scale-out.
-
-If you only need lightweight session-style storage, Render Key Value can stand in for Postgres. Replace the `databases` block with a `keyvalue` service and wire `REDIS_URL` into the Web Service via `fromService` (see the [Key Value docs](https://render.com/docs/key-value)).
-
-To verify persistence end to end:
-
-1. Commit the updated `render.yaml` and let Render apply the new data store.
-2. Update your `SessionStore` to read `DATABASE_URL` or `REDIS_URL`.
-3. Call the `assistant` agent with a fresh session ID and ask a question.
-4. Trigger a manual deploy from the Render Dashboard.
-5. Call the same session ID again. The agent should still remember the earlier turn.
-
-If the conversation context survives the redeploy, persistence is wired up correctly.
 
 ## 6. Add a scheduled agent
 

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -1,6 +1,6 @@
-# Deploy Flue Agents on Render
+# Deploy Agents on Render
 
-Run Flue's Node.js build output on Render, starting from the [Flue template](https://render.com/templates/flue). This guide builds on [Deploy Agents on Node.js](./deploy-node.md) and focuses on the Render-specific setup.
+Deploy Flue agents to Render as a Node.js web service. This guide starts from the [Flue template](https://render.com/templates/flue), builds on [Deploy Agents on Node.js](./deploy-node.md), and focuses on the Render-specific setup: Blueprints, service configuration, environment variables, and managed persistence.
 
 By the end, you will have a live Render web service running Flue agents, and you will know how to add Render-managed persistence on top.
 
@@ -8,15 +8,6 @@ By the end, you will have a live Render web service running Flue agents, and you
 
 - Familiarity with the [Deploy Agents on Node.js](./deploy-node.md) guide.
 - An API key for your model provider. The template prompts for `ANTHROPIC_API_KEY` by default.
-
-## What you'll build
-
-Starting from the template, you'll ship a live Flue agent on Render that you can call from any HTTP client:
-
-1. Deploy a Flue web service on Render.
-2. Send real requests to the `translate` and `assistant` agents.
-3. Read the `render.yaml` that makes the deploy work.
-4. Add durable sessions when your agent needs them.
 
 ## 1. Deploy the template
 
@@ -32,8 +23,6 @@ On the deploy page, paste your AI provider API key when prompted, then click **D
 The template uses `plan: free` so first-time deploys cost nothing. Free instances spin down after 15 minutes of inactivity, and the next request pays a multi-second cold start while the Node process restarts. For agents that see sporadic traffic in production, bump the service to `starter` or higher in `render.yaml` (or from the Render Dashboard) to keep it warm.
 
 When the deploy finishes, copy your service URL from the Render Dashboard. The rest of this guide uses `https://<service>.onrender.com`.
-
-> Your Flue agents are live on Render and ready to take requests.
 
 ## 2. Test the live service
 
@@ -64,8 +53,6 @@ The response should match the agent's structured output, like:
 
 The translation itself can vary by model. The shape is what matters.
 
-> The web service is live, the Flue server started correctly, and your provider key is reaching the model at runtime.
-
 Try a short conversation with the `assistant` agent:
 
 ```bash
@@ -74,7 +61,7 @@ curl https://<service>.onrender.com/agents/assistant/session-1 \
   -d '{"message": "What is the capital of Japan?"}'
 ```
 
-Then send a follow-up using the same agent ID:
+Then send a follow-up using the same session ID:
 
 ```bash
 curl https://<service>.onrender.com/agents/assistant/session-1 \
@@ -86,9 +73,7 @@ Reusing the ID keeps Flue's session scope stable. On Node.js, that session state
 
 Render closes idle HTTP connections after about 100 seconds. Most prompt-and-response agents finish well inside that window, but if you build agents that run long tool chains or large multi-step prompts, plan for either streamed responses or a scheduled / background runner (see [Going further](#going-further)) instead of a single blocking request.
 
-> **A conversational session works end to end.**
->
-> If you only need webhook-triggered agents with in-memory sessions, you can stop here.
+If you only need webhook-triggered agents with in-memory sessions, you can stop here.
 
 ## 3. Review the web service config
 
@@ -117,8 +102,6 @@ This is the Render side of what the Node guide already covers:
 
 If you ever move this setup into a different repo, drop the same `render.yaml` at its root, then create a new Blueprint from the Render Dashboard (**New > Blueprint**) and pick that repo.
 
-> You can now read the Blueprint and know what each Render-facing field does.
-
 ## 4. Change model configuration
 
 Provider keys belong in environment variables, either in the Render Dashboard or in `render.yaml` with `sync: false`. Common choices:
@@ -146,8 +129,6 @@ curl https://<service>.onrender.com/agents/translate/verify \
 ```
 
 A successful response means the new env values reached the running service and Flue can still talk to the provider.
-
-> You can swap models and providers without touching the rest of the Render setup.
 
 ## 5. Add session persistence
 
@@ -275,8 +256,6 @@ To verify persistence end to end, run a fact-recall test that survives a process
 
 If the response references `42`, your `SessionStore` is reading and writing through Postgres correctly. If the agent has no idea, persistence isn't being read on session resume.
 
-> Your sessions now survive deploys, restarts, and scale-out.
-
 ## Going further
 
 A few patterns this guide doesn't cover yet:
@@ -290,10 +269,9 @@ For more, see Render's [Cron Jobs](https://render.com/docs/cron-jobs), [Backgrou
 
 When a step doesn't behave as expected, run through these quick checks:
 
-| Symptom | Check |
-| --- | --- |
-| Health check fails | Make sure `startCommand` is `node dist/server.mjs` and that the build produced `dist/server.mjs`. |
-| Agent call returns a provider error | Confirm the matching provider key is set in the service's environment variables. |
-| Build can't find `flue` | Make sure `@flue/cli` is installed and available during the build or start command. |
-| Agent forgets context after a deploy | Wire up a custom `SessionStore` backed by Postgres or Key Value. |
-
+| Symptom                              | Check                                                                                             |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| Health check fails                   | Make sure `startCommand` is `node dist/server.mjs` and that the build produced `dist/server.mjs`. |
+| Agent call returns a provider error  | Confirm the matching provider key is set in the service's environment variables.                  |
+| Build can't find `flue`              | Make sure `@flue/cli` is installed and available during the build or start command.               |
+| Agent forgets context after a deploy | Wire up a custom `SessionStore` backed by Postgres or Key Value.                                  |

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -2,7 +2,7 @@
 
 Run Flue's Node.js build output on Render, starting from the [Flue template](https://render.com/templates/flue). This guide builds on [Deploy Agents on Node.js](./deploy-node.md) and focuses on the Render-specific setup.
 
-By the end, you will have a live Render Web Service running Flue agents, and you will know how to add Render-managed persistence and scheduled agent runs.
+By the end, you will have a live Render web service running Flue agents, and you will know how to add Render-managed persistence and scheduled agent runs.
 
 ## Prerequisites
 
@@ -13,7 +13,7 @@ By the end, you will have a live Render Web Service running Flue agents, and you
 
 Starting from the template, you'll ship a live Flue agent on Render that you can call from any HTTP client:
 
-1. Deploy a Flue Web Service on Render.
+1. Deploy a Flue web service on Render.
 2. Send real requests to the `translate` and `assistant` agents.
 3. Read the `render.yaml` that makes the deploy work.
 4. Add durable sessions or scheduled runs when your agent needs them.
@@ -27,11 +27,13 @@ Open the [Flue template](https://render.com/templates/flue) and click **Deploy t
 3. Returning to Render and creating a free account if you are not signed in.
 4. Opening the Blueprint deploy page for the new repo.
 
-On the deploy page, paste your AI provider API key when prompted, then click **Deploy**. The Blueprint provisions a Node.js Web Service that runs `npm ci && npx flue build --target node`, starts it with `node dist/server.mjs`, and uses `/health` for health checks.
+On the deploy page, paste your AI provider API key when prompted, then click **Deploy**. The Blueprint provisions a Node.js web service that runs `npm ci && npx flue build --target node`, starts it with `node dist/server.mjs`, and uses `/health` for health checks.
+
+The template uses `plan: free` so first-time deploys cost nothing. Free instances spin down after 15 minutes of inactivity, and the next request pays a multi-second cold start while the Node process restarts. For agents that see sporadic traffic in production, bump the service to `starter` or higher in `render.yaml` (or from the Render Dashboard) to keep it warm.
 
 When the deploy finishes, copy your service URL from the Render Dashboard. The rest of this guide uses `https://<service>.onrender.com`.
 
-> You have a live Render Web Service with a Flue server behind it.
+> Your Flue agents are live on Render and ready to take requests.
 
 ## 2. Test the live service
 
@@ -41,7 +43,7 @@ Start with the health endpoint:
 curl https://<service>.onrender.com/health
 ```
 
-A successful response confirms Render is forwarding traffic to the process started by `node dist/server.mjs`.
+A successful response confirms Render is forwarding traffic to the process started by `node dist/server.mjs`. If a call hangs or returns an error, open your service in the Render Dashboard and watch the **Logs** tab while you re-run the request. Every Flue agent invocation prints there.
 
 Now call the `translate` agent:
 
@@ -62,7 +64,7 @@ The response should match the agent's structured output, like:
 
 The translation itself can vary by model. The shape is what matters.
 
-> The Web Service is live, the Flue server started correctly, and your provider key is reaching the model at runtime.
+> The web service is live, the Flue server started correctly, and your provider key is reaching the model at runtime.
 
 Try a short conversation with the `assistant` agent:
 
@@ -82,13 +84,15 @@ curl https://<service>.onrender.com/agents/assistant/session-1 \
 
 Reusing the ID keeps Flue's session scope stable. On Node.js, that session state lives in memory unless you wire up a custom store.
 
+Render closes idle HTTP connections after about 100 seconds. Most prompt-and-response agents finish well inside that window, but if you build agents that run long tool chains or large multi-step prompts, plan for either streamed responses or the cron pattern in section 6 instead of a single blocking request.
+
 > **A conversational session works end to end.**
 >
 > If you only need webhook-triggered agents with in-memory sessions, you can stop here.
 
-## 3. Review the Web Service config
+## 3. Review the web service config
 
-Open the template's `render.yaml`. Its Web Service follows this shape:
+Open the template's `render.yaml`. Its web service follows this shape:
 
 ```yaml
 services:
@@ -147,9 +151,9 @@ A successful response means the new env values reached the running service and F
 
 ## 5. Add session persistence
 
-In-memory sessions disappear on every deploy or restart, and they don't help once you scale beyond one instance. If your agents need conversations that survive that, back them with a Render data store by implementing a Flue `SessionStore`.
+In-memory sessions disappear on every deploy or restart, and they don't help once you scale beyond one instance. If your agents need conversations that survive that, back them with a Render data store by implementing a Flue `SessionStore`. The Node guide's [Session persistence](./deploy-node.md#session-persistence) section covers the `SessionStore` interface (`save`, `load`, `delete`) and how to pass it via `init({ persist })`.
 
-Render Postgres is the best default for durable session history. Extend the template's `render.yaml` with a database and wire `DATABASE_URL` into the Web Service:
+Render Postgres is the best default for durable session history. Extend the template's `render.yaml` with a database and wire `DATABASE_URL` into the web service:
 
 ```yaml
 databases:
@@ -173,11 +177,84 @@ services:
         sync: false
 ```
 
+Add the Postgres client and wire up a `SessionStore` that reads `DATABASE_URL`:
+
+```bash
+npm install pg
+npm install -D @types/pg
+```
+
+`.flue/session-store.ts`:
+
+```typescript
+import type { SessionStore, SessionData } from '@flue/sdk/client';
+import { Pool } from 'pg';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+let ready: Promise<void> | null = null;
+async function ensureTable() {
+  if (!ready) {
+    ready = pool
+      .query(
+        `CREATE TABLE IF NOT EXISTS flue_sessions (
+           id         text PRIMARY KEY,
+           data       jsonb NOT NULL,
+           updated_at timestamptz NOT NULL DEFAULT now()
+         )`,
+      )
+      .then(() => undefined);
+    // Reset on failure so the next call can retry instead of replaying
+    // the original rejection forever.
+    ready.catch(() => {
+      ready = null;
+    });
+  }
+  await ready;
+}
+
+export const sessionStore: SessionStore = {
+  async save(id, data) {
+    await ensureTable();
+    await pool.query(
+      `INSERT INTO flue_sessions (id, data, updated_at)
+       VALUES ($1, $2::jsonb, now())
+       ON CONFLICT (id) DO UPDATE SET data = EXCLUDED.data, updated_at = now()`,
+      [id, JSON.stringify(data)],
+    );
+  },
+  async load(id) {
+    await ensureTable();
+    const { rows } = await pool.query<{ data: SessionData }>(
+      `SELECT data FROM flue_sessions WHERE id = $1`,
+      [id],
+    );
+    return rows[0]?.data ?? null;
+  },
+  async delete(id) {
+    await ensureTable();
+    await pool.query(`DELETE FROM flue_sessions WHERE id = $1`, [id]);
+  },
+};
+```
+
+Pass the store to the `assistant` agent's `init()`:
+
+```typescript
+import { sessionStore } from '../session-store';
+
+const agent = await init({
+  model: 'anthropic/claude-sonnet-4-6',
+  persist: sessionStore,
+});
+```
+
+The `connectionString` from `fromDatabase` is Render's internal Postgres URL, which doesn't require SSL. If you ever swap to the external connection string, add `ssl: { rejectUnauthorized: false }` to the `Pool` config.
+
 To verify persistence end to end, run a fact-recall test that survives a process restart:
 
-1. Commit the updated `render.yaml` and wait for the new database-aware deploy to go live.
-2. Update your `SessionStore` to read `DATABASE_URL`.
-3. Plant a fact in a fresh session:
+1. Commit the updated `render.yaml` and the new `SessionStore`, then wait for the database-aware deploy to go live.
+2. Plant a fact in a fresh session:
 
    ```bash
    curl https://<service>.onrender.com/agents/assistant/persist-test \
@@ -185,8 +262,8 @@ To verify persistence end to end, run a fact-recall test that survives a process
      -d '{"message": "Remember this number for me: 42."}'
    ```
 
-4. Restart the service from the Render Dashboard (**Manual Deploy > Restart Service**) so the in-memory state of the previous process is gone.
-5. Once the service is healthy, ask for the fact back:
+3. Restart the service from the Render Dashboard (**Manual Deploy > Restart Service**) so the in-memory state of the previous process is gone.
+4. Once the service is healthy, ask for the fact back:
 
    ```bash
    curl https://<service>.onrender.com/agents/assistant/persist-test \
@@ -200,9 +277,9 @@ If the response references `42`, your `SessionStore` is reading and writing thro
 
 ## 6. Add a scheduled agent
 
-Some agents shouldn't sit behind an HTTP endpoint. Nightly summaries, weekly reports, periodic audits, API syncs, and cache refreshes work better as scheduled jobs. Render Cron Jobs run a command on a schedule and exit when the work is done, which is a clean fit for agents you invoke with `flue run`.
+Some agents shouldn't sit behind an HTTP endpoint. Nightly summaries, weekly reports, periodic audits, API syncs, and cache refreshes work better as scheduled jobs. Render cron jobs run a command on a schedule and exit when the work is done, which is a clean fit for agents you invoke with `flue run`.
 
-Add a cron service to the template's `render.yaml`:
+Add a cron service to the template's `render.yaml`. The example below assumes a `digest` agent in `.flue/agents/`. Swap in any agent name from your workspace:
 
 ```yaml
 services:
@@ -220,8 +297,8 @@ services:
 
 Two things to remember:
 
-- Cron schedules use UTC. Quote the `schedule` value so YAML doesn't parse `*` as an alias.
-- The cron runs the start command each time it fires. If your install prunes dev dependencies, keep `@flue/cli` available at runtime.
+- Cron schedules use UTC. Quote the `schedule` value so YAML doesn't try to parse a leading `*` as an alias.
+- The cron runs `buildCommand` and then `startCommand` on every fire. If your install prunes dev dependencies, keep `@flue/cli` available at runtime so `npx flue run` can resolve.
 
 To verify the cron without waiting for the schedule:
 
@@ -237,7 +314,7 @@ If the run completes cleanly, your scheduled agent is ready for production.
 
 ## Going further
 
-For continuous, queue-backed agents, reach for a Render Background Worker. A common setup: a Web Service enqueues a job, a Background Worker pulls it from Render Key Value, the worker invokes a Flue agent, and the result lands in your data store. When Key Value is backing a queue, set `maxmemoryPolicy: noeviction` so jobs are never evicted.
+For continuous, queue-backed agents, reach for a Render background worker. A common setup: a web service enqueues a job, a background worker pulls it from Render Key Value, the worker invokes a Flue agent, and the result lands in your data store. When Key Value is backing a queue, set `maxmemoryPolicy: noeviction` so jobs are never evicted.
 
 For more, see Render's [Background Workers](https://render.com/docs/background-workers) docs and the [Blueprint reference](https://render.com/docs/blueprint-spec).
 
@@ -251,5 +328,5 @@ When a step doesn't behave as expected, run through these quick checks:
 | Agent call returns a provider error | Confirm the matching provider key is set in the service's environment variables. |
 | Build can't find `flue` | Make sure `@flue/cli` is installed and available during the build or start command. |
 | Agent forgets context after a deploy | Wire up a custom `SessionStore` backed by Postgres or Key Value. |
-| Cron Job doesn't run when you expect | Re-check the `schedule` value: it must be quoted and is evaluated in UTC. |
+| Cron job doesn't run when you expect | Re-check the `schedule` value: quote it (so YAML doesn't try to alias a leading `*`) and remember it's evaluated in UTC. |
 

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -1,0 +1,266 @@
+# Deploy Agents on Render
+
+Deploy Flue's Node.js build output on Render. This guide builds on [Deploy Agents on Node.js](./deploy-node.md): it assumes you understand Flue agents, sessions, roles, skills, sandboxes, and the `flue` CLI. Here, you start from the Render template, deploy it, test it, and then extend its Render configuration.
+
+By the end, you will have a live Render Web Service running Flue agents. You will also know how to add Render-managed persistence, scheduled agent runs, and queue-backed workers.
+
+## 1. Deploy the template
+
+Use the [Flue template](https://render.com/templates/flue) as the starter for this guide. It gives you a working Render Web Service and a `render.yaml` Blueprint that you can inspect, edit, and extend.
+
+The template already configures:
+
+- A Node.js Web Service.
+- A `render.yaml` Blueprint.
+- `flue build --target node` as the build step.
+- `node dist/server.mjs` as the start command.
+- `/health` as the health check path.
+- Provider key setup, starting with `ANTHROPIC_API_KEY`.
+
+Deploy the template from Render and provide your `ANTHROPIC_API_KEY` when prompted. If you deploy from the template page, you do not need to create another Blueprint. Use the template's `render.yaml` as the file you edit when you add services or change settings.
+
+After the first deploy finishes, copy your service URL from the Render Dashboard. The examples below use `https://<service>.onrender.com`.
+
+## 2. Test the live service
+
+First, check the health endpoint:
+
+```bash
+curl https://<service>.onrender.com/health
+```
+
+Then call the template's translation agent:
+
+```bash
+curl https://<service>.onrender.com/agents/translate/demo \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Hello world", "language": "French"}'
+```
+
+You should receive a JSON response with a translation and a confidence value. This confirms the Web Service is live, the Flue server started correctly, and your provider key is available at runtime.
+
+Next, test a conversational session:
+
+```bash
+curl https://<service>.onrender.com/agents/assistant/session-1 \
+  -H "Content-Type: application/json" \
+  -d '{"message": "What is the capital of Japan?"}'
+```
+
+Send a follow-up with the same agent ID:
+
+```bash
+curl https://<service>.onrender.com/agents/assistant/session-1 \
+  -H "Content-Type: application/json" \
+  -d '{"message": "How many people live there?"}'
+```
+
+Using the same ID gives Flue a stable runtime scope for the conversation. On the Node.js target, that default session state is in memory unless you add a custom persistence store.
+
+## 3. Review the Web Service config
+
+Open the template's `render.yaml`. Its Web Service should follow this shape:
+
+```yaml
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+services:
+  - type: web
+    name: flue-agents
+    runtime: node
+    plan: free
+    buildCommand: npm ci && npx flue build --target node
+    startCommand: node dist/server.mjs
+    healthCheckPath: /health
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false
+```
+
+These fields are the Render-specific bridge from the Node guide to production:
+
+- `runtime: node` tells Render to build and run the project with Node.js.
+- `buildCommand` installs dependencies and builds Flue's Node target.
+- `startCommand` runs the generated Flue server.
+- `healthCheckPath: /health` lets Render verify each deploy before it serves traffic.
+- `sync: false` tells Render to prompt for the provider key instead of reading it from Git.
+
+Flue's Node target reads Render's `PORT` environment variable, exposes `/health`, and serves agents at `/agents/<name>/<id>`.
+
+If you copy the template into a different repo, keep this configuration in that repo's root `render.yaml`. If you are deploying your own repo instead of the hosted template, open the Blueprint flow with your repo URL:
+
+```txt
+https://dashboard.render.com/blueprint/new?repo=https://github.com/<user>/<repo>
+```
+
+If you have the Render CLI installed, validate the Blueprint before you push:
+
+```bash
+render blueprints validate
+```
+
+The examples in this guide use Render's public Blueprint schema at `https://render.com/schema/render.yaml.json`.
+
+## 4. Change model configuration
+
+The template uses environment variables for provider configuration. Add any provider keys your agents need in the Render Dashboard or in `render.yaml` with `sync: false`:
+
+- `ANTHROPIC_API_KEY` for Anthropic models.
+- `OPENAI_API_KEY` for OpenAI models.
+- `OPENROUTER_API_KEY` for OpenRouter models.
+
+If your app reads a model ID from the environment, add `MODEL_ID` alongside the matching provider key:
+
+```yaml
+envVars:
+  - key: MODEL_ID
+    value: anthropic/claude-sonnet-4-6
+  - key: ANTHROPIC_API_KEY
+    sync: false
+```
+
+After the next deploy, call the translation agent again:
+
+```bash
+curl https://<service>.onrender.com/agents/translate/model-test \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Good morning", "language": "Spanish"}'
+```
+
+If the request succeeds, Render deployed the updated environment and Flue can still reach the model provider.
+
+## 5. Add session persistence
+
+On Node.js, Flue's default session storage is in memory. That is useful for development and stateless agents, but it is not durable across Render deploys, restarts, or multiple service instances.
+
+For durable conversations, implement a Flue `SessionStore` in your app and back it with a Render data store. The Render-specific part is wiring that data store into the existing Web Service.
+
+Render Postgres is the best default for durable session history. To use it, extend the template's `render.yaml` with a database and add `DATABASE_URL` to the existing Web Service:
+
+```yaml
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+databases:
+  - name: flue-db
+    plan: basic-256mb
+
+services:
+  - type: web
+    name: flue-agents
+    runtime: node
+    plan: free
+    buildCommand: npm ci && npx flue build --target node
+    startCommand: node dist/server.mjs
+    healthCheckPath: /health
+    envVars:
+      - key: DATABASE_URL
+        fromDatabase:
+          name: flue-db
+          property: connectionString
+      - key: ANTHROPIC_API_KEY
+        sync: false
+```
+
+After your app uses `DATABASE_URL` in its `SessionStore`, redeploy and repeat the assistant test with the same session ID. Then trigger a manual deploy and call the same session again. If the agent keeps the conversation context after the deploy, persistence is working.
+
+Render Key Value can work for lightweight session-style storage. Use Postgres when you need long-term history, querying, or backups. To use Key Value, add the Key Value service and wire `REDIS_URL` into the existing Web Service:
+
+```yaml
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+services:
+  - type: keyvalue
+    name: flue-sessions
+    plan: starter
+    ipAllowList: []
+
+  - type: web
+    name: flue-agents
+    runtime: node
+    plan: free
+    buildCommand: npm ci && npx flue build --target node
+    startCommand: node dist/server.mjs
+    healthCheckPath: /health
+    envVars:
+      - key: REDIS_URL
+        fromService:
+          type: keyvalue
+          name: flue-sessions
+          property: connectionString
+      - key: ANTHROPIC_API_KEY
+        sync: false
+```
+
+## 6. Add a scheduled agent
+
+Use a Render Cron Job when an agent should run on a schedule and exit when it finishes. Common examples include nightly summaries, weekly reports, periodic audits, external API syncs, and cache refreshes.
+
+Cron Jobs are a good fit for agents you invoke with `flue run` instead of an HTTP request. Add a cron service to the template's `render.yaml`:
+
+```yaml
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+services:
+  - type: cron
+    name: nightly-digest
+    runtime: node
+    plan: starter
+    schedule: "0 8 * * *"
+    buildCommand: npm ci
+    startCommand: npx flue run digest --target node --id nightly-digest --payload '{"date":"today"}'
+    envVars:
+      - key: ANTHROPIC_API_KEY
+        sync: false
+```
+
+Cron schedules are evaluated in UTC. Quote the `schedule` value so YAML does not parse `*` as an alias.
+
+After Render creates the Cron Job, use **Trigger Run** in the Dashboard to run it immediately. Check the logs for the final `flue run` result. This gives you a quick feedback loop without waiting for the next scheduled run.
+
+Cron Jobs run the start command each time the schedule fires. If your install prunes dev dependencies, make sure `@flue/cli` is available at runtime.
+
+## 7. Add a queue worker
+
+Use a Render Background Worker when a process should consume jobs from a queue continuously. The worker does not receive HTTP traffic. It connects to a queue, pulls a job, invokes a Flue agent, writes the result, and repeats.
+
+For Redis-compatible queues, add Render Key Value and a worker service to `render.yaml`. Use `maxmemoryPolicy: noeviction` so queue keys are not evicted:
+
+```yaml
+# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
+services:
+  - type: keyvalue
+    name: flue-jobs
+    plan: starter
+    ipAllowList: []
+    maxmemoryPolicy: noeviction
+
+  - type: worker
+    name: flue-worker
+    runtime: node
+    plan: starter
+    buildCommand: npm ci
+    startCommand: node worker.js
+    maxShutdownDelaySeconds: 120
+    envVars:
+      - key: REDIS_URL
+        fromService:
+          type: keyvalue
+          name: flue-jobs
+          property: connectionString
+      - key: ANTHROPIC_API_KEY
+        sync: false
+```
+
+After the worker deploys, enqueue one test job and watch the worker logs. A useful first test is a job that asks the worker to invoke the translation agent with a small payload and write the result to logs or Postgres.
+
+Handle `SIGTERM` in long-running workers. Render sends `SIGTERM` before stopping an instance, then waits up to `maxShutdownDelaySeconds` before forcing shutdown.
+
+## Choose the right Render service
+
+Use this mapping when deciding how to extend the template:
+
+| Need | Render service | Configuration |
+| --- | --- | --- |
+| Public HTTP agent | Web Service | `flue build --target node`, then `node dist/server.mjs` |
+| Scheduled agent run | Cron Job | `flue run` in the start command |
+| Continuous queue consumer | Background Worker | Worker process invokes Flue from queue jobs |
+| Durable session history | Postgres | `DATABASE_URL` from `fromDatabase` |
+| Lightweight session storage | Key Value | `REDIS_URL` from `fromService` |
+
+The template starts with a Web Service. Add persistence when conversations need to survive deploys and restarts. Add Cron Jobs or Background Workers only when your agent needs scheduled or queue-backed execution.

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -153,6 +153,8 @@ A successful response means the new env values reached the running service and F
 
 In-memory sessions disappear on every deploy or restart, and they don't help once you scale beyond one instance. If your agents need conversations that survive that, back them with a Render data store by implementing a Flue `SessionStore`. The Node guide's [Session persistence](./deploy-node.md#session-persistence) section covers the `SessionStore` interface (`save`, `load`, `delete`) and how to pass it via `init({ persist })`.
 
+> **Starting fresh and want persistence built in?** Deploy the [Flue + Postgres template](https://render.com/templates/flue-with-postgresql) instead of the base template. It ships everything in this section preconfigured: a Render Postgres database wired into the web service via `DATABASE_URL`, a Postgres-backed `SessionStore` at `.flue/session-store.ts`, and the assistant agent already calling `init({ persist })`. The walkthrough below is for adding the same setup to a service you've already deployed from the base template.
+
 Render Postgres is the best default for durable session history. Extend the template's `render.yaml` with a database and wire `DATABASE_URL` into the web service:
 
 ```yaml

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -1,35 +1,49 @@
-# Deploy Agents on Render
+# Deploy Flue Agents on Render
 
-Deploy Flue's Node.js build output on Render. This guide builds on [Deploy Agents on Node.js](./deploy-node.md): it assumes you understand Flue agents, sessions, roles, skills, sandboxes, and the `flue` CLI. Here, you start from the Render template, deploy it, test it, and then extend its Render configuration.
+Run Flue's Node.js build output on Render, starting from the [Flue template](https://render.com/templates/flue). This guide builds on [Deploy Agents on Node.js](./deploy-node.md) and focuses on the Render-specific setup.
 
-By the end, you will have a live Render Web Service running Flue agents. You will also know how to add Render-managed persistence, scheduled agent runs, and queue-backed workers.
+By the end, you will have a live Render Web Service running Flue agents, and you will know how to add Render-managed persistence and scheduled agent runs.
+
+## Prerequisites
+
+- Comfort with the concepts in [Deploy Agents on Node.js](./deploy-node.md).
+- An API key for your model provider. The template prompts for `ANTHROPIC_API_KEY` by default.
+
+## What you'll build
+
+You will take the template from one-click deploy to a working Flue service you can call from any HTTP client:
+
+1. Deploy a Flue Web Service on Render.
+2. Send real requests to the `translate` and `assistant` agents.
+3. Read the `render.yaml` that makes the deploy work.
+4. Add durable sessions or scheduled runs when your agent needs them.
 
 ## 1. Deploy the template
 
-Use the [Flue template](https://render.com/templates/flue) as the starter for this guide. It gives you a working Render Web Service and a `render.yaml` Blueprint that you can inspect, edit, and extend.
+Open the [Flue template](https://render.com/templates/flue) and start the one-click flow. Render walks you through:
 
-The template already configures:
+1. Authorizing Render's GitHub OAuth app.
+2. Copying the template repo to your GitHub account.
+3. Returning to Render and creating a free account if you are not signed in.
+4. Opening the Blueprint deploy page for the new repo.
 
-- A Node.js Web Service.
-- A `render.yaml` Blueprint.
-- `flue build --target node` as the build step.
-- `node dist/server.mjs` as the start command.
-- `/health` as the health check path.
-- Provider key setup, starting with `ANTHROPIC_API_KEY`.
+On the deploy page, paste your AI provider API key when prompted, then click **Deploy**. The Blueprint provisions a Node.js Web Service that runs `npm ci && npx flue build --target node`, starts it with `node dist/server.mjs`, and uses `/health` for health checks.
 
-Deploy the template from Render and provide your `ANTHROPIC_API_KEY` when prompted. If you deploy from the template page, you do not need to create another Blueprint. Use the template's `render.yaml` as the file you edit when you add services or change settings.
+When the deploy finishes, copy your service URL from the Render Dashboard. The rest of this guide uses `https://<service>.onrender.com`.
 
-After the first deploy finishes, copy your service URL from the Render Dashboard. The examples below use `https://<service>.onrender.com`.
+> You have a live Render Web Service with a Flue server behind it.
 
 ## 2. Test the live service
 
-First, check the health endpoint:
+Start with the health endpoint:
 
 ```bash
 curl https://<service>.onrender.com/health
 ```
 
-Then call the template's translation agent:
+A successful response confirms Render is forwarding traffic to the process started by `node dist/server.mjs`.
+
+Now call the `translate` agent:
 
 ```bash
 curl https://<service>.onrender.com/agents/translate/demo \
@@ -37,9 +51,20 @@ curl https://<service>.onrender.com/agents/translate/demo \
   -d '{"text": "Hello world", "language": "French"}'
 ```
 
-You should receive a JSON response with a translation and a confidence value. This confirms the Web Service is live, the Flue server started correctly, and your provider key is available at runtime.
+The response should match the agent's structured output, like:
 
-Next, test a conversational session:
+```json
+{
+  "translation": "Bonjour le monde",
+  "confidence": "high"
+}
+```
+
+The translation itself can vary by model. The shape is what matters.
+
+> The Web Service is live, the Flue server started correctly, and your provider key is reaching the model at runtime.
+
+Try a short conversation with the `assistant` agent:
 
 ```bash
 curl https://<service>.onrender.com/agents/assistant/session-1 \
@@ -47,7 +72,7 @@ curl https://<service>.onrender.com/agents/assistant/session-1 \
   -d '{"message": "What is the capital of Japan?"}'
 ```
 
-Send a follow-up with the same agent ID:
+Then send a follow-up using the same agent ID:
 
 ```bash
 curl https://<service>.onrender.com/agents/assistant/session-1 \
@@ -55,14 +80,17 @@ curl https://<service>.onrender.com/agents/assistant/session-1 \
   -d '{"message": "How many people live there?"}'
 ```
 
-Using the same ID gives Flue a stable runtime scope for the conversation. On the Node.js target, that default session state is in memory unless you add a custom persistence store.
+Reusing the ID keeps Flue's session scope stable. On Node.js, that session state lives in memory unless you wire up a custom store.
+
+> **A conversational session works end to end.**
+>
+> If you only need webhook-triggered agents with in-memory sessions, you can stop here.
 
 ## 3. Review the Web Service config
 
-Open the template's `render.yaml`. Its Web Service should follow this shape:
+Open the template's `render.yaml`. Its Web Service follows this shape:
 
 ```yaml
-# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
 services:
   - type: web
     name: flue-agents
@@ -76,39 +104,38 @@ services:
         sync: false
 ```
 
-These fields are the Render-specific bridge from the Node guide to production:
+This is the Render side of what the Node guide already covers:
 
-- `runtime: node` tells Render to build and run the project with Node.js.
-- `buildCommand` installs dependencies and builds Flue's Node target.
-- `startCommand` runs the generated Flue server.
-- `healthCheckPath: /health` lets Render verify each deploy before it serves traffic.
-- `sync: false` tells Render to prompt for the provider key instead of reading it from Git.
+- `buildCommand` compiles Flue's Node target.
+- `startCommand` runs the generated server, which binds to `PORT` and serves agents at `/agents/<name>/<id>`.
+- `healthCheckPath` lets Render verify each deploy before it shifts traffic.
+- `sync: false` tells Render to prompt for the secret instead of reading it from Git.
 
-Flue's Node target reads Render's `PORT` environment variable, exposes `/health`, and serves agents at `/agents/<name>/<id>`.
-
-If you copy the template into a different repo, keep this configuration in that repo's root `render.yaml`. If you are deploying your own repo instead of the hosted template, open the Blueprint flow with your repo URL:
+If you ever move this setup into a different repo, drop the same `render.yaml` at its root and open the Blueprint flow with that repo's URL:
 
 ```txt
 https://dashboard.render.com/blueprint/new?repo=https://github.com/<user>/<repo>
 ```
 
-If you have the Render CLI installed, validate the Blueprint before you push:
+If the Render CLI is installed, you can validate before pushing:
 
 ```bash
 render blueprints validate
 ```
 
-The examples in this guide use Render's public Blueprint schema at `https://render.com/schema/render.yaml.json`.
+The snippets in this guide validate against Render's public schema at `https://render.com/schema/render.yaml.json`.
+
+> You can now read the Blueprint and know what each Render-facing field does.
 
 ## 4. Change model configuration
 
-The template uses environment variables for provider configuration. Add any provider keys your agents need in the Render Dashboard or in `render.yaml` with `sync: false`:
+Provider keys belong in environment variables, either in the Render Dashboard or in `render.yaml` with `sync: false`. Common choices:
 
-- `ANTHROPIC_API_KEY` for Anthropic models.
-- `OPENAI_API_KEY` for OpenAI models.
-- `OPENROUTER_API_KEY` for OpenRouter models.
+- `ANTHROPIC_API_KEY` for Anthropic.
+- `OPENAI_API_KEY` for OpenAI.
+- `OPENROUTER_API_KEY` for OpenRouter.
 
-If your app reads a model ID from the environment, add `MODEL_ID` alongside the matching provider key:
+If your app reads a model ID from the environment, set it next to the matching provider key:
 
 ```yaml
 envVars:
@@ -118,7 +145,7 @@ envVars:
     sync: false
 ```
 
-After the next deploy, call the translation agent again:
+Once the next deploy goes live, call the translation agent again:
 
 ```bash
 curl https://<service>.onrender.com/agents/translate/model-test \
@@ -126,18 +153,19 @@ curl https://<service>.onrender.com/agents/translate/model-test \
   -d '{"text": "Good morning", "language": "Spanish"}'
 ```
 
-If the request succeeds, Render deployed the updated environment and Flue can still reach the model provider.
+A successful response means the new env values reached the running service and Flue can still talk to the provider.
+
+> You can swap models and providers without touching the rest of the Render setup.
 
 ## 5. Add session persistence
 
-On Node.js, Flue's default session storage is in memory. That is useful for development and stateless agents, but it is not durable across Render deploys, restarts, or multiple service instances.
+Skip this section if your agents are stateless or if in-memory sessions are enough. Otherwise, jump in.
 
-For durable conversations, implement a Flue `SessionStore` in your app and back it with a Render data store. The Render-specific part is wiring that data store into the existing Web Service.
+In-memory sessions disappear on every deploy or restart, and they don't help once you scale beyond one instance. To make conversations durable, implement a Flue `SessionStore` in your app and back it with a Render data store.
 
-Render Postgres is the best default for durable session history. To use it, extend the template's `render.yaml` with a database and add `DATABASE_URL` to the existing Web Service:
+Render Postgres is the best default for durable session history. Extend the template's `render.yaml` with a database and wire `DATABASE_URL` into the Web Service:
 
 ```yaml
-# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
 databases:
   - name: flue-db
     plan: basic-256mb
@@ -159,43 +187,29 @@ services:
         sync: false
 ```
 
-After your app uses `DATABASE_URL` in its `SessionStore`, redeploy and repeat the assistant test with the same session ID. Then trigger a manual deploy and call the same session again. If the agent keeps the conversation context after the deploy, persistence is working.
+Once your app reads `DATABASE_URL` in its `SessionStore`, redeploy and replay the assistant test with the same session ID. Trigger a manual deploy and call the same session again. If it remembers the earlier turn, persistence is working.
 
-Render Key Value can work for lightweight session-style storage. Use Postgres when you need long-term history, querying, or backups. To use Key Value, add the Key Value service and wire `REDIS_URL` into the existing Web Service:
+> Your sessions now survive deploys, restarts, and scale-out.
 
-```yaml
-# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
-services:
-  - type: keyvalue
-    name: flue-sessions
-    plan: starter
-    ipAllowList: []
+If you only need lightweight session-style storage, Render Key Value can stand in for Postgres. Replace the `databases` block with a `keyvalue` service and wire `REDIS_URL` into the Web Service via `fromService` (see the [Key Value docs](https://render.com/docs/key-value)).
 
-  - type: web
-    name: flue-agents
-    runtime: node
-    plan: free
-    buildCommand: npm ci && npx flue build --target node
-    startCommand: node dist/server.mjs
-    healthCheckPath: /health
-    envVars:
-      - key: REDIS_URL
-        fromService:
-          type: keyvalue
-          name: flue-sessions
-          property: connectionString
-      - key: ANTHROPIC_API_KEY
-        sync: false
-```
+To verify persistence end to end:
+
+1. Commit the updated `render.yaml` and let Render apply the new data store.
+2. Update your `SessionStore` to read `DATABASE_URL` or `REDIS_URL`.
+3. Call the `assistant` agent with a fresh session ID and ask a question.
+4. Trigger a manual deploy from the Render Dashboard.
+5. Call the same session ID again. The agent should still remember the earlier turn.
+
+If the conversation context survives the redeploy, persistence is wired up correctly.
 
 ## 6. Add a scheduled agent
 
-Use a Render Cron Job when an agent should run on a schedule and exit when it finishes. Common examples include nightly summaries, weekly reports, periodic audits, external API syncs, and cache refreshes.
+Some agents shouldn't sit behind an HTTP endpoint. Nightly summaries, weekly reports, periodic audits, API syncs, and cache refreshes work better as scheduled jobs. Render Cron Jobs run a command on a schedule and exit when the work is done, which is a clean fit for agents you invoke with `flue run`.
 
-Cron Jobs are a good fit for agents you invoke with `flue run` instead of an HTTP request. Add a cron service to the template's `render.yaml`:
+Add a cron service to the template's `render.yaml`:
 
 ```yaml
-# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
 services:
   - type: cron
     name: nightly-digest
@@ -209,58 +223,38 @@ services:
         sync: false
 ```
 
-Cron schedules are evaluated in UTC. Quote the `schedule` value so YAML does not parse `*` as an alias.
+Two things to remember:
 
-After Render creates the Cron Job, use **Trigger Run** in the Dashboard to run it immediately. Check the logs for the final `flue run` result. This gives you a quick feedback loop without waiting for the next scheduled run.
+- Cron schedules use UTC. Quote the `schedule` value so YAML doesn't parse `*` as an alias.
+- The cron runs the start command each time it fires. If your install prunes dev dependencies, keep `@flue/cli` available at runtime.
 
-Cron Jobs run the start command each time the schedule fires. If your install prunes dev dependencies, make sure `@flue/cli` is available at runtime.
+To verify the cron without waiting for the schedule:
 
-## 7. Add a queue worker
+1. Commit the updated `render.yaml` and let Render create the cron service.
+2. Open the cron service in the Render Dashboard.
+3. Click **Trigger Run**.
+4. Open the **Logs** tab and watch the run progress.
+5. Confirm the final `flue run` output for the `digest` agent appears in the logs.
 
-Use a Render Background Worker when a process should consume jobs from a queue continuously. The worker does not receive HTTP traffic. It connects to a queue, pulls a job, invokes a Flue agent, writes the result, and repeats.
+If the run completes cleanly, your scheduled agent is ready for production.
 
-For Redis-compatible queues, add Render Key Value and a worker service to `render.yaml`. Use `maxmemoryPolicy: noeviction` so queue keys are not evicted:
+> You can run a Flue agent on a schedule and verify the result straight from Render logs.
 
-```yaml
-# yaml-language-server: $schema=https://render.com/schema/render.yaml.json
-services:
-  - type: keyvalue
-    name: flue-jobs
-    plan: starter
-    ipAllowList: []
-    maxmemoryPolicy: noeviction
+## Going further
 
-  - type: worker
-    name: flue-worker
-    runtime: node
-    plan: starter
-    buildCommand: npm ci
-    startCommand: node worker.js
-    maxShutdownDelaySeconds: 120
-    envVars:
-      - key: REDIS_URL
-        fromService:
-          type: keyvalue
-          name: flue-jobs
-          property: connectionString
-      - key: ANTHROPIC_API_KEY
-        sync: false
-```
+For continuous, queue-backed agents, reach for a Render Background Worker. A common setup: a Web Service enqueues a job, a Background Worker pulls it from Render Key Value, the worker invokes a Flue agent, and the result lands in your data store. When Key Value is backing a queue, set `maxmemoryPolicy: noeviction` so jobs are never evicted.
 
-After the worker deploys, enqueue one test job and watch the worker logs. A useful first test is a job that asks the worker to invoke the translation agent with a small payload and write the result to logs or Postgres.
+For more, see Render's [Background Workers](https://render.com/docs/background-workers) docs and the [Blueprint reference](https://render.com/docs/blueprint-spec).
 
-Handle `SIGTERM` in long-running workers. Render sends `SIGTERM` before stopping an instance, then waits up to `maxShutdownDelaySeconds` before forcing shutdown.
+## Troubleshooting
 
-## Choose the right Render service
+When a step doesn't behave as expected, run through these quick checks:
 
-Use this mapping when deciding how to extend the template:
+| Symptom | Check |
+| --- | --- |
+| Health check fails | Make sure `startCommand` is `node dist/server.mjs` and that the build produced `dist/server.mjs`. |
+| Agent call returns a provider error | Confirm the matching provider key is set in the service's environment variables. |
+| Build can't find `flue` | Make sure `@flue/cli` is installed and available during the build or start command. |
+| Agent forgets context after a deploy | Wire up a custom `SessionStore` backed by Postgres or Key Value. |
+| Cron Job doesn't run when you expect | Re-check the `schedule` value: it must be quoted and is evaluated in UTC. |
 
-| Need | Render service | Configuration |
-| --- | --- | --- |
-| Public HTTP agent | Web Service | `flue build --target node`, then `node dist/server.mjs` |
-| Scheduled agent run | Cron Job | `flue run` in the start command |
-| Continuous queue consumer | Background Worker | Worker process invokes Flue from queue jobs |
-| Durable session history | Postgres | `DATABASE_URL` from `fromDatabase` |
-| Lightweight session storage | Key Value | `REDIS_URL` from `fromService` |
-
-The template starts with a Web Service. Add persistence when conversations need to survive deploys and restarts. Add Cron Jobs or Background Workers only when your agent needs scheduled or queue-backed execution.

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -6,7 +6,7 @@ By the end, you will have a live Render Web Service running Flue agents, and you
 
 ## Prerequisites
 
-- Comfort with the concepts in [Deploy Agents on Node.js](./deploy-node.md).
+- Familiarity with the [Deploy Agents on Node.js](./deploy-node.md) guide.
 - An API key for your model provider. The template prompts for `ANTHROPIC_API_KEY` by default.
 
 ## What you'll build

--- a/docs/deploy-render.md
+++ b/docs/deploy-render.md
@@ -2,7 +2,7 @@
 
 Run Flue's Node.js build output on Render, starting from the [Flue template](https://render.com/templates/flue). This guide builds on [Deploy Agents on Node.js](./deploy-node.md) and focuses on the Render-specific setup.
 
-By the end, you will have a live Render web service running Flue agents, and you will know how to add Render-managed persistence and scheduled agent runs.
+By the end, you will have a live Render web service running Flue agents, and you will know how to add Render-managed persistence on top.
 
 ## Prerequisites
 
@@ -16,7 +16,7 @@ Starting from the template, you'll ship a live Flue agent on Render that you can
 1. Deploy a Flue web service on Render.
 2. Send real requests to the `translate` and `assistant` agents.
 3. Read the `render.yaml` that makes the deploy work.
-4. Add durable sessions or scheduled runs when your agent needs them.
+4. Add durable sessions when your agent needs them.
 
 ## 1. Deploy the template
 
@@ -84,7 +84,7 @@ curl https://<service>.onrender.com/agents/assistant/session-1 \
 
 Reusing the ID keeps Flue's session scope stable. On Node.js, that session state lives in memory unless you wire up a custom store.
 
-Render closes idle HTTP connections after about 100 seconds. Most prompt-and-response agents finish well inside that window, but if you build agents that run long tool chains or large multi-step prompts, plan for either streamed responses or the cron pattern in section 6 instead of a single blocking request.
+Render closes idle HTTP connections after about 100 seconds. Most prompt-and-response agents finish well inside that window, but if you build agents that run long tool chains or large multi-step prompts, plan for either streamed responses or a scheduled / background runner (see [Going further](#going-further)) instead of a single blocking request.
 
 > **A conversational session works end to end.**
 >
@@ -277,48 +277,14 @@ If the response references `42`, your `SessionStore` is reading and writing thro
 
 > Your sessions now survive deploys, restarts, and scale-out.
 
-## 6. Add a scheduled agent
-
-Some agents shouldn't sit behind an HTTP endpoint. Nightly summaries, weekly reports, periodic audits, API syncs, and cache refreshes work better as scheduled jobs. Render cron jobs run a command on a schedule and exit when the work is done, which is a clean fit for agents you invoke with `flue run`.
-
-Add a cron service to the template's `render.yaml`. The example below assumes a `digest` agent in `.flue/agents/`. Swap in any agent name from your workspace:
-
-```yaml
-services:
-  - type: cron
-    name: nightly-digest
-    runtime: node
-    plan: starter
-    schedule: "0 8 * * *"
-    buildCommand: npm ci
-    startCommand: npx flue run digest --target node --id nightly-digest --payload '{"date":"today"}'
-    envVars:
-      - key: ANTHROPIC_API_KEY
-        sync: false
-```
-
-Two things to remember:
-
-- Cron schedules use UTC. Quote the `schedule` value so YAML doesn't try to parse a leading `*` as an alias.
-- The cron runs `buildCommand` and then `startCommand` on every fire. If your install prunes dev dependencies, keep `@flue/cli` available at runtime so `npx flue run` can resolve.
-
-To verify the cron without waiting for the schedule:
-
-1. Commit the updated `render.yaml` and let Render create the cron service.
-2. Open the cron service in the Render Dashboard.
-3. Click **Trigger Run**.
-4. Open the **Logs** tab and watch the run progress.
-5. Confirm the final `flue run` output for the `digest` agent appears in the logs.
-
-If the run completes cleanly, your scheduled agent is ready for production.
-
-> You can run a Flue agent on a schedule and verify the result straight from Render logs.
-
 ## Going further
 
-For continuous, queue-backed agents, reach for a Render background worker. A common setup: a web service enqueues a job, a background worker pulls it from Render Key Value, the worker invokes a Flue agent, and the result lands in your data store. When Key Value is backing a queue, set `maxmemoryPolicy: noeviction` so jobs are never evicted.
+A few patterns this guide doesn't cover yet:
 
-For more, see Render's [Background Workers](https://render.com/docs/background-workers) docs and the [Blueprint reference](https://render.com/docs/blueprint-spec).
+- **Scheduled runs.** Some agents work better as periodic jobs than as webhooks (nightly summaries, weekly reports, cache refreshes). Deploy them as a Render cron job whose `startCommand` is `npx flue run <agent> --target node --id <id>`. Each fire builds, runs the agent once, and exits.
+- **Queue-backed workers.** For continuous, queue-backed agents, reach for a Render background worker. A common setup: a web service enqueues a job, a background worker pulls it from Render Key Value, the worker invokes a Flue agent, and the result lands in your data store. When Key Value is backing a queue, set `maxmemoryPolicy: noeviction` so jobs are never evicted.
+
+For more, see Render's [Cron Jobs](https://render.com/docs/cron-jobs), [Background Workers](https://render.com/docs/background-workers), and the [Blueprint reference](https://render.com/docs/blueprint-spec).
 
 ## Troubleshooting
 
@@ -330,5 +296,4 @@ When a step doesn't behave as expected, run through these quick checks:
 | Agent call returns a provider error | Confirm the matching provider key is set in the service's environment variables. |
 | Build can't find `flue` | Make sure `@flue/cli` is installed and available during the build or start command. |
 | Agent forgets context after a deploy | Wire up a custom `SessionStore` backed by Postgres or Key Value. |
-| Cron job doesn't run when you expect | Re-check the `schedule` value: quote it (so YAML doesn't try to alias a leading `*`) and remember it's evaluated in UTC. |
 


### PR DESCRIPTION
## Summary

Adds `docs/deploy-render.md`, a Render-specific deploy guide that builds on `deploy-node.md`. Walks the reader from a one-click Blueprint deploy to agents with durable sessions.

## What the guide covers
1. **Deploy the template** — Blueprint deploy flow with a free-tier spin-down warning.
2. **Test the live service** — `/health` plus the `translate` and `assistant` agents, with a pointer to the **Logs** tab.
3. **Review the `render.yaml`** — annotated walkthrough of the template's Blueprint.
4. **Change model configuration** — provider keys and `MODEL_ID`, validated with a follow-up curl.
5. **Add session persistence** — extends the Blueprint with Render Postgres, ships a runnable `pg`-backed `SessionStore`, and verifies with a fact-recall test that survives a restart. Callout points readers at the new [Flue + Postgres template](https://render.com/templates/flue-with-postgresql) for the prewired path.
6. **Going further + Troubleshooting** — background workers, cron, Key Value with `noeviction`, and a quick-fix table.