### PR TITLE
Destroy request-scoped agents after handlers

### DIFF
--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -65,34 +65,35 @@ function createReadTool(env: SessionEnv): AgentTool<any> {
 			offset: Type.Optional(Type.Number({ description: 'Line number to start from (1-indexed)' })),
 			limit: Type.Optional(Type.Number({ description: 'Maximum number of lines to read' })),
 		}),
-		async execute(_toolCallId, params: { path: string; offset?: number; limit?: number }, signal?) {
+		async execute(_toolCallId, params, signal?) {
 			throwIfAborted(signal);
+			const args = params as { path: string; offset?: number; limit?: number };
 
 			try {
-				const fileStat = await env.stat(params.path);
+				const fileStat = await env.stat(args.path);
 				if (fileStat.isDirectory) {
-					const entries = await env.readdir(params.path);
+					const entries = await env.readdir(args.path);
 					const listing = entries.join('\n');
 					return {
 						content: [{ type: 'text', text: listing || '(empty directory)' }],
-						details: { path: params.path, isDirectory: true, entries: entries.length },
+						details: { path: args.path, isDirectory: true, entries: entries.length },
 					};
 				}
 			} catch {
 				// stat failed — fall through to readFile
 			}
 
-			const content = await env.readFile(params.path);
+			const content = await env.readFile(args.path);
 			const allLines = content.split('\n');
 
-			const startLine = params.offset ? Math.max(0, params.offset - 1) : 0;
+			const startLine = args.offset ? Math.max(0, args.offset - 1) : 0;
 			if (startLine >= allLines.length) {
 				throw new Error(
-					`Offset ${params.offset} is beyond end of file (${allLines.length} lines total)`,
+					`Offset ${args.offset} is beyond end of file (${allLines.length} lines total)`,
 				);
 			}
 
-			const endLine = params.limit ? startLine + params.limit : allLines.length;
+			const endLine = args.limit ? startLine + args.limit : allLines.length;
 			const lines = allLines.slice(startLine, endLine);
 			const { text: truncatedText, wasTruncated } = truncateHead(
 				lines,
@@ -108,7 +109,7 @@ function createReadTool(env: SessionEnv): AgentTool<any> {
 
 			return {
 				content: [{ type: 'text', text: output }],
-				details: { path: params.path, lines: allLines.length },
+				details: { path: args.path, lines: allLines.length },
 			};
 		},
 	};
@@ -124,22 +125,23 @@ function createWriteTool(env: SessionEnv): AgentTool<any> {
 			path: Type.String({ description: 'Path to the file to write' }),
 			content: Type.String({ description: 'Content to write to the file' }),
 		}),
-		async execute(_toolCallId, params: { path: string; content: string }, signal?) {
+		async execute(_toolCallId, params, signal?) {
 			throwIfAborted(signal);
-			const resolved = env.resolvePath(params.path);
+			const args = params as { path: string; content: string };
+			const resolved = env.resolvePath(args.path);
 			const dir = resolved.replace(/\/[^/]*$/, '');
 			if (dir && dir !== resolved) {
 				await env.mkdir(dir, { recursive: true });
 			}
-			await env.writeFile(resolved, params.content);
+			await env.writeFile(resolved, args.content);
 			return {
 				content: [
 					{
 						type: 'text',
-						text: `Successfully wrote ${params.content.length} bytes to ${params.path}`,
+						text: `Successfully wrote ${args.content.length} bytes to ${args.path}`,
 					},
 				],
-				details: { path: params.path, size: params.content.length },
+				details: { path: args.path, size: args.content.length },
 			};
 		},
 	};
@@ -157,44 +159,46 @@ function createEditTool(env: SessionEnv): AgentTool<any> {
 			newText: Type.String({ description: 'Replacement text' }),
 			replaceAll: Type.Optional(Type.Boolean({ description: 'Replace all occurrences' })),
 		}),
-		async execute(
-			_toolCallId,
-			params: { path: string; oldText: string; newText: string; replaceAll?: boolean },
-			signal?,
-		) {
+		async execute(_toolCallId, params, signal?) {
 			throwIfAborted(signal);
-			const content = await env.readFile(params.path);
+			const args = params as {
+				path: string;
+				oldText: string;
+				newText: string;
+				replaceAll?: boolean;
+			};
+			const content = await env.readFile(args.path);
 
-			if (params.replaceAll) {
-				const newContent = content.replaceAll(params.oldText, params.newText);
+			if (args.replaceAll) {
+				const newContent = content.replaceAll(args.oldText, args.newText);
 				if (newContent === content) {
-					throw new Error(`Could not find the text in ${params.path}. No changes made.`);
+					throw new Error(`Could not find the text in ${args.path}. No changes made.`);
 				}
-				await env.writeFile(params.path, newContent);
-				const count = content.split(params.oldText).length - 1;
+				await env.writeFile(args.path, newContent);
+				const count = content.split(args.oldText).length - 1;
 				return {
-					content: [{ type: 'text', text: `Replaced ${count} occurrences in ${params.path}` }],
-					details: { path: params.path, replacements: count },
+					content: [{ type: 'text', text: `Replaced ${count} occurrences in ${args.path}` }],
+					details: { path: args.path, replacements: count },
 				};
 			}
 
-			const occurrences = countOccurrences(content, params.oldText);
+			const occurrences = countOccurrences(content, args.oldText);
 			if (occurrences === 0) {
 				throw new Error(
-					`Could not find the exact text in ${params.path}. Make sure your oldText matches exactly, including whitespace and indentation.`,
+					`Could not find the exact text in ${args.path}. Make sure your oldText matches exactly, including whitespace and indentation.`,
 				);
 			}
 			if (occurrences > 1) {
 				throw new Error(
-					`Found ${occurrences} occurrences of the text in ${params.path}. Provide more surrounding context to make the match unique, or use replaceAll.`,
+					`Found ${occurrences} occurrences of the text in ${args.path}. Provide more surrounding context to make the match unique, or use replaceAll.`,
 				);
 			}
 
-			const newContent = content.replace(params.oldText, params.newText);
-			await env.writeFile(params.path, newContent);
+			const newContent = content.replace(args.oldText, args.newText);
+			await env.writeFile(args.path, newContent);
 			return {
-				content: [{ type: 'text', text: `Successfully edited ${params.path}` }],
-				details: { path: params.path },
+				content: [{ type: 'text', text: `Successfully edited ${args.path}` }],
+				details: { path: args.path },
 			};
 		},
 	};
@@ -210,10 +214,11 @@ function createBashTool(env: SessionEnv): AgentTool<any> {
 			command: Type.String({ description: 'Bash command to execute' }),
 			timeout: Type.Optional(Type.Number({ description: 'Timeout in seconds' })),
 		}),
-		async execute(_toolCallId, params: { command: string; timeout?: number }, signal?) {
+		async execute(_toolCallId, params, signal?) {
 			throwIfAborted(signal);
-			const result = await env.exec(params.command, { timeout: params.timeout });
-			return formatBashResult(result, params.command);
+			const args = params as { command: string; timeout?: number };
+			const result = await env.exec(args.command, { timeout: args.timeout });
+			return formatBashResult(result, args.command);
 		},
 	};
 }
@@ -252,9 +257,9 @@ function createTaskTool(
 				}),
 			),
 		}),
-		async execute(_toolCallId, params: TaskToolParams, signal?) {
+		async execute(_toolCallId, params, signal?) {
 			throwIfAborted(signal);
-			return runTask(params, signal);
+			return runTask(params as TaskToolParams, signal);
 		},
 	};
 }
@@ -289,17 +294,14 @@ function createGrepTool(env: SessionEnv): AgentTool<any> {
 			path: Type.Optional(Type.String({ description: 'Directory or file to search (default: .)' })),
 			include: Type.Optional(Type.String({ description: 'Glob filter, e.g. "*.ts"' })),
 		}),
-		async execute(
-			_toolCallId,
-			params: { pattern: string; path?: string; include?: string },
-			signal?,
-		) {
+		async execute(_toolCallId, params, signal?) {
 			throwIfAborted(signal);
+			const args = params as { pattern: string; path?: string; include?: string };
 
-			const searchPath = params.path || '.';
-			let cmd = `grep -rn ${shellQuote(params.pattern)} ${shellQuote(searchPath)}`;
-			if (params.include) {
-				cmd = `grep -rn --include=${shellQuote(params.include)} ${shellQuote(params.pattern)} ${shellQuote(searchPath)}`;
+			const searchPath = args.path || '.';
+			let cmd = `grep -rn ${shellQuote(args.pattern)} ${shellQuote(searchPath)}`;
+			if (args.include) {
+				cmd = `grep -rn --include=${shellQuote(args.include)} ${shellQuote(args.pattern)} ${shellQuote(searchPath)}`;
 			}
 
 			const result = await env.exec(cmd);
@@ -345,11 +347,12 @@ function createGlobTool(env: SessionEnv): AgentTool<any> {
 			pattern: Type.String({ description: 'Filename pattern, e.g. "*.ts"' }),
 			path: Type.Optional(Type.String({ description: 'Directory to search in (default: .)' })),
 		}),
-		async execute(_toolCallId, params: { pattern: string; path?: string }, signal?) {
+		async execute(_toolCallId, params, signal?) {
 			throwIfAborted(signal);
+			const args = params as { pattern: string; path?: string };
 
-			const searchPath = params.path || '.';
-			const cmd = `find ${shellQuote(searchPath)} -type f -name ${shellQuote(params.pattern)} 2>/dev/null | head -${MAX_GLOB_RESULTS}`;
+			const searchPath = args.path || '.';
+			const cmd = `find ${shellQuote(searchPath)} -type f -name ${shellQuote(args.pattern)} 2>/dev/null | head -${MAX_GLOB_RESULTS}`;
 			const result = await env.exec(cmd);
 
 			if (result.exitCode !== 0 && !result.stdout.trim()) {

--- a/packages/sdk/src/build-plugin-cloudflare.ts
+++ b/packages/sdk/src/build-plugin-cloudflare.ts
@@ -270,6 +270,15 @@ function runHandlerWithKeepAlive(doInstance, ctx, handler) {
   });
 }
 
+async function cleanupContext(ctx) {
+  ctx.setEventCallback(undefined);
+  try {
+    await ctx.destroyAgents();
+  } catch (err) {
+    console.error('[flue] Agent cleanup error:', err);
+  }
+}
+
 function startWebhookFiber(doInstance, requestId, agentName, id, payload, handler) {
   const run = async (fiber) => {
     fiber?.stash?.({
@@ -287,7 +296,7 @@ function startWebhookFiber(doInstance, requestId, agentName, id, payload, handle
       try {
         return await handler(ctx);
       } finally {
-        ctx.setEventCallback(undefined);
+        await cleanupContext(ctx);
       }
     });
   };
@@ -380,7 +389,7 @@ async function handleAgentRequest(request, doInstance, agentName, handler) {
             await writeSSE({ type: 'idle' }, 'idle');
           }
         } finally {
-          ctx.setEventCallback(undefined);
+          await runWithInstanceContext(doInstance, () => cleanupContext(ctx));
           await writer.close();
         }
       })();
@@ -403,7 +412,7 @@ async function handleAgentRequest(request, doInstance, agentName, handler) {
         { headers: { 'content-type': 'application/json' } },
       );
     } finally {
-      ctx.setEventCallback(undefined);
+      await runWithInstanceContext(doInstance, () => cleanupContext(ctx));
     }
   } catch (err) {
     // toHttpResponse logs unknowns via flueLog.error — no extra console.error

--- a/packages/sdk/src/build-plugin-node.ts
+++ b/packages/sdk/src/build-plugin-node.ts
@@ -137,6 +137,15 @@ function createContextForRequest(id, payload) {
   });
 }
 
+async function cleanupContext(ctx) {
+  ctx.setEventCallback(undefined);
+  try {
+    await ctx.destroyAgents();
+  } catch (err) {
+    console.error('[flue] Agent cleanup error:', err);
+  }
+}
+
 // ─── Server ─────────────────────────────────────────────────────────────────
 
 const app = new Hono();
@@ -177,12 +186,12 @@ app.all('/agents/:name/:id', async (c) => {
     const requestId = randomUUID();
     const ctx = createContextForRequest(id, payload);
     handler(ctx).then(
-      (result) => {
-        ctx.setEventCallback(undefined);
+      async (result) => {
+        await cleanupContext(ctx);
         console.log('[flue] Webhook handler complete:', name, result !== undefined ? JSON.stringify(result) : '(no return)');
       },
-      (err) => {
-        ctx.setEventCallback(undefined);
+      async (err) => {
+        await cleanupContext(ctx);
         console.error('[flue] Webhook handler error:', name, err);
       },
     );
@@ -228,7 +237,7 @@ app.all('/agents/:name/:id', async (c) => {
           await stream.writeSSE({ data: JSON.stringify(idle), event: 'idle', id: String(eventId++) });
         }
       } finally {
-        ctx.setEventCallback(undefined);
+        await cleanupContext(ctx);
       }
     });
   }
@@ -239,7 +248,7 @@ app.all('/agents/:name/:id', async (c) => {
     const result = await handler(ctx);
     return c.json({ result: result !== undefined ? result : null });
   } finally {
-    ctx.setEventCallback(undefined);
+    await cleanupContext(ctx);
   }
 });
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -34,11 +34,13 @@ export interface FlueContextConfig {
 /** Extends FlueContext with server-only methods. Agent handlers only see FlueContext. */
 export interface FlueContextInternal extends FlueContext {
 	setEventCallback(callback: FlueEventCallback | undefined): void;
+	destroyAgents(): Promise<void>;
 }
 
 export function createFlueContext(config: FlueContextConfig): FlueContextInternal {
 	let currentEventCallback: FlueEventCallback | undefined;
 	const initializedAgentIds = new Set<string>();
+	const initializedAgents: FlueAgent[] = [];
 
 	const ctx: FlueContextInternal = {
 		get id() {
@@ -91,7 +93,7 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 					providers,
 				};
 
-				return new AgentClient(
+				const agent = new AgentClient(
 					id,
 					agentConfig,
 					env,
@@ -100,6 +102,8 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 					options.commands,
 					options.tools,
 				);
+				initializedAgents.push(agent);
+				return agent;
 			} catch (error) {
 				initializedAgentIds.delete(id);
 				throw error;
@@ -108,6 +112,24 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 
 		setEventCallback(callback: FlueEventCallback | undefined): void {
 			currentEventCallback = callback;
+		},
+
+		async destroyAgents(): Promise<void> {
+			const agents = initializedAgents.splice(0).reverse();
+			const errors: unknown[] = [];
+			for (const agent of agents) {
+				try {
+					await agent.destroy();
+				} catch (error) {
+					errors.push(error);
+				}
+			}
+			initializedAgentIds.clear();
+			if (errors.length > 0) {
+				const [first] = errors;
+				if (first instanceof Error) throw first;
+				throw new Error(String(first));
+			}
 		},
 	};
 

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -454,9 +454,9 @@ export class Session implements FlueSession {
 			label: toolDef.name,
 			description: toolDef.description,
 			parameters: toolDef.parameters,
-			async execute(_toolCallId: string, params: Record<string, any>, signal?: AbortSignal) {
+			async execute(_toolCallId: string, params: unknown, signal?: AbortSignal) {
 				if (signal?.aborted) throw new Error('Operation aborted');
-				const resultText = await toolDef.execute(params, signal);
+				const resultText = await toolDef.execute(params as Record<string, any>, signal);
 				return {
 					content: [{ type: 'text' as const, text: resultText }],
 					details: { customTool: toolDef.name },


### PR DESCRIPTION
## Summary
- track every FlueAgent created by a request-scoped context via init()
- add an internal context finalizer that destroys those agents after handler completion
- run the finalizer for sync, SSE, and webhook paths in both Node and Cloudflare generated servers
- keep Cloudflare cleanup inside the Durable Object instance context when needed
- align built-in/custom tool execute signatures with the current Pi 0.73 AgentTool type so check:types stays green

Fixes #58.

## Notes
This keeps cleanup request-scoped rather than session-scoped: sessions remain durable state, while agents own sandbox/runtime resources. Manual agent.destroy() is still safe because destroy is idempotent.

## Verification
- pnpm run check:types
- git diff --check
- node packages/cli/dist/flue.js build --target node --workspace /private/tmp/flue-lifecycle-smoke --output /private/tmp/flue-lifecycle-smoke-node
- node --check /private/tmp/flue-lifecycle-smoke-node/dist/server.mjs
- node packages/cli/dist/flue.js build --target cloudflare --workspace /private/tmp/flue-lifecycle-smoke --output /private/tmp/flue-lifecycle-smoke-cf
- pnpm --dir packages/sdk exec esbuild /private/tmp/flue-lifecycle-smoke-cf/dist/_entry.ts --bundle --platform=neutral --format=esm '--external:agents' '--external:just-bash' '--external:@flue/sdk/*' --outfile=/private/tmp/flue-lifecycle-smoke-cf/check.mjs
- node --check /private/tmp/flue-lifecycle-smoke-cf/check.mjs