### PR TITLE
fix(sdk): keep SSE streams alive past Node 300s timeout (#68)

### DIFF
--- a/packages/sdk/src/build-plugin-node.ts
+++ b/packages/sdk/src/build-plugin-node.ts
@@ -207,14 +207,7 @@ app.all('/agents/:name/:id', async (c) => {
         stream.writeSSE({ data: JSON.stringify(event), event: event.type, id: String(eventId++) }).catch(() => {});
       });
 
-      // Heartbeat: emit an SSE comment every 25s while the handler is running.
-      // This keeps the stream actively writing bytes so:
-      //   - undici (the Node fetch client used by \`flue run\`) does not hit
-      //     its 300s default \`bodyTimeout\` on an idle response, and
-      //   - intermediate proxies/load balancers in self-hosted deploys
-      //     don't idle-close the connection.
-      // SSE comments are ignored by clients, so this does not become part of
-      // Flue's application-level event protocol. Withastro/flue#68.
+      // Keep long-running, otherwise-idle SSE streams alive.
       const heartbeat = setInterval(() => {
         stream.write(': heartbeat\n\n').catch(() => {});
       }, 25_000);
@@ -274,10 +267,6 @@ app.onError((err) => toHttpResponse(err));
 
 const port = parseInt(process.env.PORT || '3000', 10);
 
-// Disable Node's per-request timeout. Node 18+ defaults requestTimeout to
-// 300s (https://nodejs.org/api/http.html#serverrequesttimeout), which silently
-// aborts long-lived SSE streams when the agent is mid-tool-call and not
-// emitting events. Withastro/flue#68.
 const server = serve({
   fetch: app.fetch,
   port,

--- a/packages/sdk/src/build-plugin-node.ts
+++ b/packages/sdk/src/build-plugin-node.ts
@@ -206,18 +206,16 @@ app.all('/agents/:name/:id', async (c) => {
         stream.writeSSE({ data: JSON.stringify(event), event: event.type, id: String(eventId++) }).catch(() => {});
       });
 
-      // Heartbeat: emit a no-op SSE event every 25s while the handler is
-      // running. This keeps the stream actively writing bytes so:
+      // Heartbeat: emit an SSE comment every 25s while the handler is running.
+      // This keeps the stream actively writing bytes so:
       //   - undici (the Node fetch client used by \`flue run\`) does not hit
       //     its 300s default \`bodyTimeout\` on an idle response, and
       //   - intermediate proxies/load balancers in self-hosted deploys
       //     don't idle-close the connection.
-      // The \`{ type: 'ping' }\` payload is unhandled by the CLI's logEvent
-      // switch and falls through harmlessly. Withastro/flue#68.
+      // SSE comments are ignored by clients, so this does not become part of
+      // Flue's application-level event protocol. Withastro/flue#68.
       const heartbeat = setInterval(() => {
-        stream
-          .writeSSE({ data: JSON.stringify({ type: 'ping' }), event: 'ping' })
-          .catch(() => {});
+        stream.write(': heartbeat\n\n').catch(() => {});
       }, 25_000);
 
       try {
@@ -278,12 +276,11 @@ const port = parseInt(process.env.PORT || '3000', 10);
 // Disable Node's per-request timeout. Node 18+ defaults requestTimeout to
 // 300s (https://nodejs.org/api/http.html#serverrequesttimeout), which silently
 // aborts long-lived SSE streams when the agent is mid-tool-call and not
-// emitting events. Headers timeout is similarly relaxed because SSE responses
-// stay open well beyond the typical 60s window. Withastro/flue#68.
+// emitting events. Withastro/flue#68.
 const server = serve({
   fetch: app.fetch,
   port,
-  serverOptions: { requestTimeout: 0, headersTimeout: 0 },
+  serverOptions: { requestTimeout: 0 },
 });
 console.log('[flue] Server listening on http://localhost:' + port);
 if (isLocalMode) {

--- a/packages/sdk/src/build-plugin-node.ts
+++ b/packages/sdk/src/build-plugin-node.ts
@@ -270,6 +270,7 @@ const port = parseInt(process.env.PORT || '3000', 10);
 const server = serve({
   fetch: app.fetch,
   port,
+  // SSE requests can outlive Node's default 300s request timeout.
   serverOptions: { requestTimeout: 0 },
 });
 console.log('[flue] Server listening on http://localhost:' + port);

--- a/packages/sdk/src/build-plugin-node.ts
+++ b/packages/sdk/src/build-plugin-node.ts
@@ -206,6 +206,20 @@ app.all('/agents/:name/:id', async (c) => {
         stream.writeSSE({ data: JSON.stringify(event), event: event.type, id: String(eventId++) }).catch(() => {});
       });
 
+      // Heartbeat: emit a no-op SSE event every 25s while the handler is
+      // running. This keeps the stream actively writing bytes so:
+      //   - undici (the Node fetch client used by \`flue run\`) does not hit
+      //     its 300s default \`bodyTimeout\` on an idle response, and
+      //   - intermediate proxies/load balancers in self-hosted deploys
+      //     don't idle-close the connection.
+      // The \`{ type: 'ping' }\` payload is unhandled by the CLI's logEvent
+      // switch and falls through harmlessly. Withastro/flue#68.
+      const heartbeat = setInterval(() => {
+        stream
+          .writeSSE({ data: JSON.stringify({ type: 'ping' }), event: 'ping' })
+          .catch(() => {});
+      }, 25_000);
+
       try {
         const result = await handler(ctx);
         if (!isIdle) {
@@ -228,6 +242,7 @@ app.all('/agents/:name/:id', async (c) => {
           await stream.writeSSE({ data: JSON.stringify(idle), event: 'idle', id: String(eventId++) });
         }
       } finally {
+        clearInterval(heartbeat);
         ctx.setEventCallback(undefined);
       }
     });
@@ -260,7 +275,16 @@ app.onError((err) => toHttpResponse(err));
 
 const port = parseInt(process.env.PORT || '3000', 10);
 
-const server = serve({ fetch: app.fetch, port });
+// Disable Node's per-request timeout. Node 18+ defaults requestTimeout to
+// 300s (https://nodejs.org/api/http.html#serverrequesttimeout), which silently
+// aborts long-lived SSE streams when the agent is mid-tool-call and not
+// emitting events. Headers timeout is similarly relaxed because SSE responses
+// stay open well beyond the typical 60s window. Withastro/flue#68.
+const server = serve({
+  fetch: app.fetch,
+  port,
+  serverOptions: { requestTimeout: 0, headersTimeout: 0 },
+});
 console.log('[flue] Server listening on http://localhost:' + port);
 if (isLocalMode) {
   console.log('[flue] Mode: local (all agents invokable, including trigger-less)');


### PR DESCRIPTION
Fixes #68.

## Summary
- `flue run` aborts long-running tool calls at ~300s with `[flue] Agent error: terminated`. Root cause is the **Node 300s timeout on _both_ ends** of the SSE stream:
  - Server: `@hono/node-server`'s `serve({ fetch, port })` inherits `http.Server.requestTimeout = 300_000` (Node 18+ default).
  - Client: `flue run` uses Node's global `fetch`, whose underlying undici dispatcher applies a 300s `bodyTimeout` to idle responses.
- Closing only one side is not enough — verified locally that disabling `requestTimeout` alone still terminates at ~301s because undici aborts the read side.

## Changes (`packages/sdk/src/build-plugin-node.ts`)
1. Pass `serverOptions: { requestTimeout: 0, headersTimeout: 0 }` to `serve(...)` so Node's HTTP server does not idle-abort long SSE responses.
2. Emit an SSE heartbeat (`{ type: 'ping' }`) every 25s while the agent handler is running, cleared in `finally`. Keeps bytes flowing so undici's `bodyTimeout` resets, and incidentally helps reverse proxies in self-hosted deploys (Render / Node guides). The CLI's `logEvent` switch has no case for `ping` — it falls through harmlessly.

```mermaid
sequenceDiagram
  participant CLI as flue run (undici)
  participant Srv as Node http.Server
  participant SSE as streamSSE handler
  CLI->>Srv: POST /agents/:name/:id (Accept: text/event-stream)
  Srv->>SSE: open stream
  loop every 25s while handler runs
    SSE-->>CLI: event: ping  (resets undici bodyTimeout)
  end
  Note over Srv: requestTimeout=0 → no 300s server-side abort
  SSE-->>CLI: event: result
```

## Repro / verification
Repro from the issue:

```ts
// .flue/agents/long-bash-probe.ts
import type { FlueContext } from '@flue/sdk/client';
import { defineCommand } from '@flue/sdk/node';

export const triggers = {};
const bash = defineCommand('bash');

export default async function (ctx: FlueContext<unknown>) {
  const agent = await ctx.init({ sandbox: 'local', commands: [bash], model: false });
  const session = await agent.session('long-bash-probe');
  return await session.shell("bash -lc 'sleep 305; echo done'", { timeout: 360, commands: [bash] });
}
```

```bash
flue run long-bash-probe --target node --id probe --workspace .flue --output ./.flue-out
```

| Config | Result |
|---|---|
| `main` (305s sleep) | `[flue] Agent error: terminated` at ~301s |
| Only `requestTimeout: 0` (no heartbeat) | `[flue] Agent error: terminated` at ~301s (undici client bodyTimeout) |
| **This PR** (`requestTimeout: 0` + 25s heartbeat) | `{ "stdout": "done\\n", "exitCode": 0 }` |

## Notes
- Cloudflare build plugin is unaffected — different runtime, no Node 300s timeout.
- `pnpm check:types` reports pre-existing `agent.ts` / `session.ts` errors on `main` HEAD (`d09472c`); not introduced by this PR.
- No tests added — repeating the bug end-to-end requires a 5-minute test run, which isn't friendly for CI. Happy to add a faster unit test on the heartbeat interval if maintainers want one.

