### PR TITLE
feat: make skills directory configurable via skillsPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ export default async function ({ init, payload }: FlueContext) {
   const session = await agent.session();
 
   // Skills can be referenced either by their frontmatter `name:` (shown below)
-  // or by a relative path under `.agents/skills/` — e.g.
+  // or by a relative path under the skills directory (`.agents/skills/` by
+  // default, configurable via `init({ skillsPath })`) — e.g.
   // `session.skill('triage/reproduce.md', ...)`. Path references are handy for
   // skill packs that group multiple stages under one directory.
   const result = await session.skill('triage', {
@@ -265,7 +266,7 @@ In production, generate a stable agent ID for the sandbox/runtime scope you want
 
 ### Tasks
 
-Use `session.task()` to run a focused, one-shot child agent in a detached session. Tasks share the same sandbox/filesystem, but get their own message history and discover `AGENTS.md` plus `.agents/skills/` from their working directory. The same `task` tool is also available to the LLM during `prompt()` and `skill()` calls, so the agent can delegate parallel research or exploration work itself.
+Use `session.task()` to run a focused, one-shot child agent in a detached session. Tasks share the same sandbox/filesystem, but get their own message history and discover `AGENTS.md` plus skills from their working directory. Tasks inherit the parent agent's `skillsPath` when set, or can override it with `task('...', { skillsPath: './other-skills' })`. The same `task` tool is also available to the LLM during `prompt()` and `skill()` calls, so the agent can delegate parallel research or exploration work itself.
 
 ```ts
 const session = await agent.session();

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -123,7 +123,8 @@ export default async function ({ init, payload }: FlueContext) {
   const session = await agent.session();
 
   // Skills can be referenced either by their frontmatter `name:` (shown below)
-  // or by a relative path under `.agents/skills/` — e.g.
+  // or by a relative path under the skills directory (`.agents/skills/` by
+  // default, configurable via `init({ skillsPath })`) — e.g.
   // `session.skill('triage/reproduce.md', ...)`. Path references are handy for
   // skill packs that group multiple stages under one directory.
   const result = await session.skill('triage', {
@@ -265,7 +266,7 @@ In production, generate a stable agent ID for the sandbox/runtime scope you want
 
 ### Tasks
 
-Use `session.task()` to run a focused, one-shot child agent in a detached session. Tasks share the same sandbox/filesystem, but get their own message history and discover `AGENTS.md` plus `.agents/skills/` from their working directory. The same `task` tool is also available to the LLM during `prompt()` and `skill()` calls, so the agent can delegate parallel research or exploration work itself.
+Use `session.task()` to run a focused, one-shot child agent in a detached session. Tasks share the same sandbox/filesystem, but get their own message history and discover `AGENTS.md` plus skills from their working directory. Tasks inherit the parent agent's `skillsPath` when set, or can override it with `task('...', { skillsPath: './other-skills' })`. The same `task` tool is also available to the LLM during `prompt()` and `skill()` calls, so the agent can delegate parallel research or exploration work itself.
 
 ```ts
 const session = await agent.session();

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -123,7 +123,8 @@ export default async function ({ init, payload }: FlueContext) {
   const session = await agent.session();
 
   // Skills can be referenced either by their frontmatter `name:` (shown below)
-  // or by a relative path under `.agents/skills/` — e.g.
+  // or by a relative path under the skills directory (`.agents/skills/` by
+  // default, configurable via `init({ skillsPath })`) — e.g.
   // `session.skill('triage/reproduce.md', ...)`. Path references are handy for
   // skill packs that group multiple stages under one directory.
   const result = await session.skill('triage', {
@@ -265,7 +266,7 @@ In production, generate a stable agent ID for the sandbox/runtime scope you want
 
 ### Tasks
 
-Use `session.task()` to run a focused, one-shot child agent in a detached session. Tasks share the same sandbox/filesystem, but get their own message history and discover `AGENTS.md` plus `.agents/skills/` from their working directory. The same `task` tool is also available to the LLM during `prompt()` and `skill()` calls, so the agent can delegate parallel research or exploration work itself.
+Use `session.task()` to run a focused, one-shot child agent in a detached session. Tasks share the same sandbox/filesystem, but get their own message history and discover `AGENTS.md` plus skills from their working directory. Tasks inherit the parent agent's `skillsPath` when set, or can override it with `task('...', { skillsPath: './other-skills' })`. The same `task` tool is also available to the LLM during `prompt()` and `skill()` calls, so the agent can delegate parallel research or exploration work itself.
 
 ```ts
 const session = await agent.session();

--- a/packages/sdk/src/agent-client.ts
+++ b/packages/sdk/src/agent-client.ts
@@ -144,11 +144,13 @@ export class AgentClient implements FlueAgent {
 		const taskEnv = options.cwd
 			? createCwdSessionEnv(options.parentEnv, options.parentEnv.resolvePath(options.cwd))
 			: options.parentEnv;
-		const localContext = await discoverSessionContext(taskEnv);
+		const effectiveSkillsPath = options.skillsPath ?? this.config.skillsPath;
+		const localContext = await discoverSessionContext(taskEnv, effectiveSkillsPath);
 		const taskConfig: AgentConfig = {
 			...this.config,
 			systemPrompt: localContext.systemPrompt,
 			skills: localContext.skills,
+			skillsPath: effectiveSkillsPath,
 		};
 		const storageKey = createSessionStorageKey(this.id, sessionId);
 		const data = createEmptySessionData();

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -75,7 +75,21 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 				const baseEnv = await resolveSessionEnv(id, sandbox, config, options.cwd);
 				const env = options.cwd ? createCwdSessionEnv(baseEnv, options.cwd) : baseEnv;
 				const store: SessionStore = options.persist ?? config.defaultStore;
-				const localContext = await discoverSessionContext(env);
+
+				let resolvedSkillsPath: string | undefined;
+				if (options.skillsPath !== undefined) {
+					const normalized = options.skillsPath.replace(/\/+$/, '');
+					resolvedSkillsPath = env.resolvePath(normalized);
+					if (!(await env.exists(resolvedSkillsPath))) {
+						throw new Error(
+							`[flue] skillsPath "${options.skillsPath}" does not exist ` +
+								`(resolved to "${resolvedSkillsPath}"). ` +
+								`Create the directory before calling init().`,
+						);
+					}
+				}
+
+				const localContext = await discoverSessionContext(env, resolvedSkillsPath);
 				const providers = mergeProvidersConfig(config.agentConfig.providers, options.providers);
 
 				// Agent-level model override. Per-call `model` on prompt()/skill() still wins
@@ -89,6 +103,7 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 					model: agentModel,
 					role: options.role ?? config.agentConfig.role,
 					providers,
+					skillsPath: resolvedSkillsPath,
 				};
 
 				return new AgentClient(
@@ -227,6 +242,7 @@ export type {
 	PromptOptions,
 	PromptResponse,
 	SkillOptions,
+	SkillsPath,
 	TaskOptions,
 	ShellOptions,
 	ShellResult,

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -1,8 +1,10 @@
 /**
- * Context discovery: reads AGENTS.md and .agents/skills/ from a session's
- * working directory. Used at runtime by the session initialisation path.
+ * Context discovery: reads AGENTS.md and skills from a session's working
+ * directory. Used at runtime by the session initialisation path.
  */
 import type { SessionEnv, Skill } from './types.ts';
+
+const DEFAULT_SKILLS_DIR = '.agents/skills';
 
 // ─── Frontmatter Parsing ────────────────────────────────────────────────────
 
@@ -56,7 +58,8 @@ export async function readAgentsMd(env: SessionEnv, basePath: string): Promise<s
 }
 
 /**
- * Load a skill directly by relative path under `.agents/skills/`.
+ * Load a skill directly by relative path under the skills directory
+ * (defaults to `.agents/skills/`).
  *
  * The path is taken as-is — no extension is auto-appended. Callers reference
  * the full filename, e.g. `'triage/reproduce.md'`. Returns `null` if the file
@@ -71,11 +74,12 @@ export async function loadSkillByPath(
 	env: SessionEnv,
 	basePath: string,
 	relPath: string,
+	skillsDir?: string,
 ): Promise<Skill | null> {
-	const skillsDir = basePath.endsWith('/')
-		? `${basePath}.agents/skills`
-		: `${basePath}/.agents/skills`;
-	const filePath = `${skillsDir}/${relPath}`;
+	const resolvedSkillsDir =
+		skillsDir ??
+		(basePath.endsWith('/') ? `${basePath}${DEFAULT_SKILLS_DIR}` : `${basePath}/${DEFAULT_SKILLS_DIR}`);
+	const filePath = `${resolvedSkillsDir}/${relPath}`;
 	if (!(await env.exists(filePath))) return null;
 
 	const content = await env.readFile(filePath);
@@ -90,22 +94,23 @@ export async function loadSkillByPath(
 	};
 }
 
-/** Discover skills from .agents/skills/<name>/SKILL.md under basePath. */
+/** Discover skills from <skillsDir>/<name>/SKILL.md under basePath. */
 export async function discoverLocalSkills(
 	env: SessionEnv,
 	basePath: string,
+	skillsDir?: string,
 ): Promise<Record<string, Skill>> {
-	const skillsDir = basePath.endsWith('/')
-		? `${basePath}.agents/skills`
-		: `${basePath}/.agents/skills`;
+	const resolvedSkillsDir =
+		skillsDir ??
+		(basePath.endsWith('/') ? `${basePath}${DEFAULT_SKILLS_DIR}` : `${basePath}/${DEFAULT_SKILLS_DIR}`);
 
-	if (!(await env.exists(skillsDir))) return {};
+	if (!(await env.exists(resolvedSkillsDir))) return {};
 
 	const skills: Record<string, Skill> = {};
-	const entries = await env.readdir(skillsDir);
+	const entries = await env.readdir(resolvedSkillsDir);
 
 	for (const entry of entries) {
-		const skillDir = `${skillsDir}/${entry}`;
+		const skillDir = `${resolvedSkillsDir}/${entry}`;
 
 		try {
 			const s = await env.stat(skillDir);
@@ -167,11 +172,12 @@ export function composeSystemPrompt(
 /** Discover AGENTS.md, local skills, and directory listing from the session's cwd. */
 export async function discoverSessionContext(
 	env: SessionEnv,
+	skillsPath?: string,
 ): Promise<{ systemPrompt: string; skills: Record<string, Skill> }> {
 	const cwd = env.cwd;
 
 	const agentsMd = await readAgentsMd(env, cwd);
-	const skills = await discoverLocalSkills(env, cwd);
+	const skills = await discoverLocalSkills(env, cwd, skillsPath);
 
 	let directoryListing: string[] | undefined;
 	try {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -23,6 +23,7 @@ export type {
 	ShellOptions,
 	ShellResult,
 	Skill,
+	SkillsPath,
 	Role,
 	AgentConfig,
 	ModelConfig,

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -62,6 +62,7 @@ export interface CreateTaskSessionOptions {
 	role?: string;
 	commands: Command[];
 	depth: number;
+	skillsPath?: string;
 }
 
 export type CreateTaskSession = (options: CreateTaskSessionOptions) => Promise<Session>;
@@ -285,24 +286,23 @@ export class Session implements FlueSession {
 
 			let registeredSkill = this.config.skills[name];
 
-			// Fallback: file-path lookup under .agents/skills/. Only attempted when the
-			// name looks like a path (contains `/` or ends in `.md`/`.markdown`) so that
-			// typos of registered skill names still fail fast with a helpful error.
 			if (!registeredSkill && (name.includes('/') || /\.(md|markdown)$/i.test(name))) {
-				const loaded = await loadSkillByPath(this.env, this.env.cwd, name);
+				const loaded = await loadSkillByPath(this.env, this.env.cwd, name, this.config.skillsPath);
 				if (loaded) registeredSkill = loaded;
 			}
 
 			if (!registeredSkill) {
 				const available = Object.keys(this.config.skills).join(', ') || '(none)';
-				const cwd = this.env.cwd;
+				const skillsDir = this.config.skillsPath ?? `${this.env.cwd}/.agents/skills`;
 				throw new Error(
 					`Skill "${name}" not registered. Available: ${available}.\n\n` +
-						`Skills are loaded at init() time from ${cwd}/.agents/skills/<name>/SKILL.md ` +
+						`Skills are loaded at init() time from ${skillsDir}/<name>/SKILL.md ` +
 						`inside the session's sandbox. If you expected "${name}" to be there, make sure ` +
-						`the file exists in your sandbox at that path before calling init() — the default ` +
-						`empty sandbox starts with no files, so it has no skills unless you put them there.\n\n` +
-						`Skills can also be referenced by relative path under .agents/skills/ ` +
+						`the file exists in your sandbox at that path before calling init()` +
+						(this.config.skillsPath
+							? ` — the skills directory was set to "${this.config.skillsPath}" via init({ skillsPath }).`
+							: ` — the default empty sandbox starts with no files, so it has no skills unless you put them there.`) +
+						`\n\nSkills can also be referenced by relative path under ${skillsDir}/ ` +
 						`(e.g. "triage/reproduce.md").`,
 				);
 			}
@@ -597,6 +597,21 @@ export class Session implements FlueSession {
 			const role = this.resolveEffectiveRole(options?.role);
 			const commands = mergeCommands(this.agentCommands, options?.commands);
 
+			let taskSkillsPath: string | undefined;
+			if (options?.skillsPath !== undefined) {
+				const normalized = options.skillsPath.replace(/\/+$/, '');
+				taskSkillsPath = this.env.resolvePath(normalized);
+				if (!(await this.env.exists(taskSkillsPath))) {
+					throw new Error(
+						`[flue] skillsPath "${options.skillsPath}" does not exist ` +
+							`(resolved to "${taskSkillsPath}"). ` +
+							`Create the directory before calling task().`,
+					);
+				}
+			} else {
+				taskSkillsPath = this.config.skillsPath;
+			}
+
 			child = await this.createTaskSession({
 				parentSessionId: this.id,
 				taskId,
@@ -605,6 +620,7 @@ export class Session implements FlueSession {
 				role,
 				commands,
 				depth: this.taskDepth + 1,
+				skillsPath: taskSkillsPath,
 			});
 			await this.recordTaskSession(child.id, child.storageKey, taskId);
 			this.activeTasks.add(child);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -11,6 +11,8 @@ export interface Skill {
 	instructions: string;
 }
 
+export type SkillsPath = `./${string}` | `/${string}`;
+
 // ─── Role ───────────────────────────────────────────────────────────────────
 
 export interface Role {
@@ -161,6 +163,7 @@ export interface AgentConfig {
 	/** Resolve model config to a Model instance. Throws on invalid model strings. */
 	resolveModel: (model: ModelConfig | undefined, providers?: ProvidersConfig) => Model<any> | undefined;
 	compaction?: CompactionConfig;
+	skillsPath?: string;
 }
 
 export type ModelConfig = string | false;
@@ -248,6 +251,17 @@ export interface AgentInit {
 	 * call.
 	 */
 	commands?: Command[];
+
+	/**
+	 * Directory to discover skills from. Replaces the default `.agents/skills`
+	 * discovery path entirely — no fallback to the default location.
+	 *
+	 * Accepts relative paths (resolved against `cwd`) or absolute paths.
+	 * The directory must exist at init time; an error is thrown if it doesn't.
+	 *
+	 * @default '.agents/skills'
+	 */
+	skillsPath?: SkillsPath;
 }
 
 // ─── Flue Agent (returned by init()) ────────────────────────────────────────
@@ -392,6 +406,11 @@ export interface TaskOptions<S extends v.GenericSchema | undefined = undefined> 
 	model?: string;
 	/** Working directory for the detached task session. Defaults to the parent session cwd. */
 	cwd?: string;
+	/**
+	 * Skills directory for the detached task session. Overrides the parent's
+	 * `skillsPath`. The directory must exist; an error is thrown if it doesn't.
+	 */
+	skillsPath?: SkillsPath;
 }
 
 export interface ShellOptions {


### PR DESCRIPTION
## Problem

The skills directory is hardcoded to `.agents/skills/`, which means there's no way to separate build-time skills (used while developing an agent) from runtime skills (the skills the agent itself executes). If you're building an agent that runs skills, those skills currently have to live alongside the skills you use to build it.

## Solution

Adds a `skillsPath` option to `AgentInit` that lets you point skill discovery at any directory, completely replacing the default `.agents/skills/` path.

```ts
const agent = await ctx.init({
  model: 'anthropic/claude-sonnet-4-6',
  skillsPath: './runtime-skills',
});
```

- **Type-safe paths** — `SkillsPath` type enforces relative (`./`) or absolute (`/`) paths
- **Validated at init** — throws immediately if the directory doesn't exist
- **Task inheritance** — child tasks inherit the parent's `skillsPath` by default
- **Task override** — `session.task('...', { skillsPath: './other-skills' })` lets child tasks use a different directory
- **No breaking changes** — default behaviour is unchanged (`.agents/skills/`)

## Files changed

- `packages/sdk/src/types.ts` — `SkillsPath` type, new property on `AgentInit`, `AgentConfig`, `TaskOptions`
- `packages/sdk/src/context.ts` — parameterized discovery functions
- `packages/sdk/src/client.ts` — resolve/validate/pass `skillsPath` in `init()`
- `packages/sdk/src/session.ts` — task flow, fallback loading, error messages
- `packages/sdk/src/agent-client.ts` — task inheritance
- `packages/sdk/src/index.ts` — export new type
- READMEs — updated docs