### PR TITLE
feat(sdk): expose token usage and cost per call

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,30 @@ await session.prompt('Review the latest changes.'); // uses reviewer
 await session.task('Research related issues.', { role: 'researcher' }); // uses researcher
 ```
 
+### Usage & cost
+
+Every `prompt()` and `skill()` call returns the token usage and cost produced
+by the provider, aggregated across every assistant turn the call dispatched.
+`cost` values are in USD and come from pi-ai's cost tables — no price list to
+maintain on your side.
+
+```ts
+const response = await session.prompt('Analyze this diff.');
+
+response.text;         // the assistant's reply
+response.usage;        // { input, output, cacheRead, cacheWrite, totalTokens, cost: {...} }
+response.model;        // { provider: 'anthropic', id: 'claude-sonnet-4-6' }
+```
+
+Webhook-exposed agents also stream per-turn usage over SSE via the existing
+event channel: `turn_end` events now carry `{ usage, model }`, and
+`compaction_end` carries `usage` for the internal summarization cost so
+audits can distinguish user-visible work from maintenance work.
+
+Calls that pass `result: schema` return the validated object directly, so
+their return value is not enriched with `usage`/`model` — read usage from
+the streamed `turn_end` events for those calls.
+
 ### Provider Settings
 
 Use `providers` when model traffic needs provider-specific runtime settings,

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -290,6 +290,30 @@ await session.prompt('Review the latest changes.'); // uses reviewer
 await session.task('Research related issues.', { role: 'researcher' }); // uses researcher
 ```
 
+### Usage & cost
+
+Every `prompt()` and `skill()` call returns the token usage and cost produced
+by the provider, aggregated across every assistant turn the call dispatched.
+`cost` values are in USD and come from pi-ai's cost tables — no price list to
+maintain on your side.
+
+```ts
+const response = await session.prompt('Analyze this diff.');
+
+response.text;         // the assistant's reply
+response.usage;        // { input, output, cacheRead, cacheWrite, totalTokens, cost: {...} }
+response.model;        // { provider: 'anthropic', id: 'claude-sonnet-4-6' }
+```
+
+Webhook-exposed agents also stream per-turn usage over SSE via the existing
+event channel: `turn_end` events now carry `{ usage, model }`, and
+`compaction_end` carries `usage` for the internal summarization cost so
+audits can distinguish user-visible work from maintenance work.
+
+Calls that pass `result: schema` return the validated object directly, so
+their return value is not enriched with `usage`/`model` — read usage from
+the streamed `turn_end` events for those calls.
+
 ### Provider Settings
 
 Use `providers` when model traffic needs provider-specific runtime settings,

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -37,6 +37,7 @@
 	"scripts": {
 		"build": "tsdown",
 		"check:types": "tsc --noEmit",
+		"test": "node --experimental-transform-types --no-warnings test/run.ts",
 		"prepublishOnly": "cp ../../README.md ."
 	},
 	"dependencies": {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -211,6 +211,7 @@ export type {
 	FlueSession,
 	AgentInit,
 	ModelConfig,
+	ModelInfo,
 	FlueEvent,
 	FlueEventCallback,
 	SessionData,
@@ -233,3 +234,7 @@ export type {
 	ToolDef,
 	ToolParameters,
 } from './types.ts';
+
+// Re-exported from pi-ai so `turn_end` / `compaction_end` / `PromptResponse`
+// consumers can type their callbacks without a direct pi-ai dependency.
+export type { Usage } from '@mariozechner/pi-ai';

--- a/packages/sdk/src/compaction.ts
+++ b/packages/sdk/src/compaction.ts
@@ -440,6 +440,13 @@ export interface CompactionResult {
 	firstKeptIndex: number;
 	tokensBefore: number;
 	details: { readFiles: string[]; modifiedFiles: string[] };
+	/**
+	 * Token usage consumed by the summarization call(s) that produced this
+	 * result. Sum of the history-summary call and, for split-turn
+	 * compactions, the turn-prefix summary call. `undefined` if neither
+	 * call completed successfully.
+	 */
+	usage?: Usage;
 }
 
 /** Pure function — no I/O. Finds cut point, extracts messages to summarize, tracks file ops. */
@@ -502,7 +509,7 @@ async function generateSummary(
 	apiKey: string | undefined,
 	signal: AbortSignal | undefined,
 	previousSummary?: string,
-): Promise<string> {
+): Promise<{ text: string; usage: Usage | undefined }> {
 	const maxTokens = Math.min(Math.floor(0.8 * reserveTokens), 16000);
 	const basePrompt = previousSummary ? UPDATE_SUMMARIZATION_PROMPT : SUMMARIZATION_PROMPT;
 
@@ -531,10 +538,11 @@ async function generateSummary(
 		throw new Error(`Summarization failed: ${response.errorMessage || 'Unknown error'}`);
 	}
 
-	return response.content
+	const text = response.content
 		.filter((c): c is TextContent => c.type === 'text')
 		.map((c) => c.text)
 		.join('\n');
+	return { text, usage: response.usage };
 }
 
 async function generateTurnPrefixSummary(
@@ -543,7 +551,7 @@ async function generateTurnPrefixSummary(
 	reserveTokens: number,
 	apiKey: string | undefined,
 	signal: AbortSignal | undefined,
-): Promise<string> {
+): Promise<{ text: string; usage: Usage | undefined }> {
 	const maxTokens = Math.min(Math.floor(0.5 * reserveTokens), 16000);
 	const conversationText = serializeConversation(messages);
 	const promptText = `<conversation>\n${conversationText}\n</conversation>\n\n${TURN_PREFIX_SUMMARIZATION_PROMPT}`;
@@ -567,10 +575,11 @@ async function generateTurnPrefixSummary(
 		);
 	}
 
-	return response.content
+	const text = response.content
 		.filter((c): c is TextContent => c.type === 'text')
 		.map((c) => c.text)
 		.join('\n');
+	return { text, usage: response.usage };
 }
 
 // ─── Main Compaction Function ───────────────────────────────────────────────
@@ -593,6 +602,16 @@ export async function compact(
 	} = preparation;
 
 	let summary: string;
+	// Accumulate usage from every summarization call that produced one. A
+	// split-turn compaction fires two calls; a regular one fires a single
+	// call. If a call returns `undefined` usage (unusual — some providers
+	// stream without reporting totals), it contributes zero.
+	let aggregateUsage: Usage | undefined;
+	const addCallUsage = (usage: Usage | undefined): void => {
+		if (!usage) return;
+		aggregateUsage = aggregateUsage ? addUsageValues(aggregateUsage, usage) : usage;
+	};
+
 	if (isSplitTurn && turnPrefixMessages.length > 0) {
 		const [historyResult, turnPrefixResult] = await Promise.all([
 			messagesToSummarize.length > 0
@@ -604,12 +623,14 @@ export async function compact(
 						signal,
 						previousSummary,
 					)
-				: Promise.resolve('No prior history.'),
+				: Promise.resolve({ text: 'No prior history.', usage: undefined }),
 			generateTurnPrefixSummary(turnPrefixMessages, model, settings.reserveTokens, apiKey, signal),
 		]);
-		summary = `${historyResult}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult}`;
+		addCallUsage(historyResult.usage);
+		addCallUsage(turnPrefixResult.usage);
+		summary = `${historyResult.text}\n\n---\n\n**Turn Context (split turn):**\n\n${turnPrefixResult.text}`;
 	} else {
-		summary = await generateSummary(
+		const historyResult = await generateSummary(
 			messagesToSummarize,
 			model,
 			settings.reserveTokens,
@@ -617,11 +638,41 @@ export async function compact(
 			signal,
 			previousSummary,
 		);
+		addCallUsage(historyResult.usage);
+		summary = historyResult.text;
 	}
 
 	const { readFiles, modifiedFiles } = computeFileLists(fileOps);
 	summary += formatFileOperations(readFiles, modifiedFiles);
 
-	return { summary, firstKeptIndex, tokensBefore, details: { readFiles, modifiedFiles } };
+	return {
+		summary,
+		firstKeptIndex,
+		tokensBefore,
+		details: { readFiles, modifiedFiles },
+		usage: aggregateUsage,
+	};
+}
+
+/**
+ * Field-wise addition of two `Usage` values, including the nested `cost`.
+ * Module-private helper — mirrors the public `addUsage` in session.ts so
+ * compaction can aggregate without depending on the session module.
+ */
+function addUsageValues(a: Usage, b: Usage): Usage {
+	return {
+		input: a.input + b.input,
+		output: a.output + b.output,
+		cacheRead: a.cacheRead + b.cacheRead,
+		cacheWrite: a.cacheWrite + b.cacheWrite,
+		totalTokens: a.totalTokens + b.totalTokens,
+		cost: {
+			input: a.cost.input + b.cost.input,
+			output: a.cost.output + b.cost.output,
+			cacheRead: a.cost.cacheRead + b.cost.cacheRead,
+			cacheWrite: a.cost.cacheWrite + b.cost.cacheWrite,
+			total: a.cost.total + b.cost.total,
+		},
+	};
 }
 export { isContextOverflow };

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -26,6 +26,7 @@ export type {
 	Role,
 	AgentConfig,
 	ModelConfig,
+	ModelInfo,
 	BuildOptions,
 	BuildPlugin,
 	BuildContext,
@@ -33,6 +34,8 @@ export type {
 	ToolDef,
 	ToolParameters,
 } from './types.ts';
+
+export type { Usage } from '@mariozechner/pi-ai';
 
 export { build, resolveWorkspaceFromCwd } from './build.ts';
 export {

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -1,7 +1,7 @@
 /** Internal session implementation. Not exported publicly — wrapped by FlueSession. */
 import { Agent } from '@mariozechner/pi-agent-core';
 import type { AgentMessage, AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core';
-import type { AssistantMessage, Model } from '@mariozechner/pi-ai';
+import type { AssistantMessage, Model, Usage } from '@mariozechner/pi-ai';
 import type * as v from 'valibot';
 import {
 	BUILTIN_TOOL_NAMES,
@@ -39,6 +39,7 @@ import type {
 	FlueEvent,
 	FlueEventCallback,
 	FlueSession,
+	ModelInfo,
 	PromptOptions,
 	PromptResponse,
 	SessionData,
@@ -143,6 +144,14 @@ export class Session implements FlueSession {
 	private agentTools: ToolDef[];
 	private deleted = false;
 	private activeOperation: string | undefined;
+	/**
+	 * Usage accumulator for the currently executing prompt/skill call. The
+	 * `turn_end` listener installed in the constructor adds each assistant
+	 * turn's usage here; `prompt()` / `skill()` read and clear the total
+	 * when building their `PromptResponse`. `undefined` means "no tracked
+	 * call in progress" — `task()` and `shell()` leave it that way.
+	 */
+	private currentCallUsage: Usage | undefined;
 	private activeTasks = new Set<Session>();
 	private sessionRole: string | undefined;
 	private taskDepth: number;
@@ -227,9 +236,24 @@ export class Session implements FlueSession {
 						result: event.result,
 					});
 					break;
-				case 'turn_end':
-					this.emit({ type: 'turn_end' });
+				case 'turn_end': {
+					// `turn_end` always carries the assistant message for the
+					// turn that just finished — we hand its usage and model
+					// straight to subscribers. pi-ai fills `usage.cost` using
+					// the model's cost table, so consumers don't need their
+					// own price tables.
+					const message = event.message as AgentMessage;
+					const usage =
+						message.role === 'assistant'
+							? (message as AssistantMessage).usage
+							: undefined;
+					const model = messageToModelInfo(message);
+					if (usage && this.currentCallUsage) {
+						this.currentCallUsage = addUsage(this.currentCallUsage, usage);
+					}
+					this.emit({ type: 'turn_end', usage, model });
 					break;
+				}
 				case 'agent_end':
 					break;
 			}
@@ -249,27 +273,29 @@ export class Session implements FlueSession {
 			const fullPrompt = buildPromptText(text, schema);
 
 			const effectiveCommands = mergeCommands(this.agentCommands, options?.commands);
-			return this.withScopedRuntime(
-				{
-					commands: effectiveCommands,
-					tools: options?.tools ?? [],
-					role,
-					model: options?.model,
-					callSite: 'this prompt() call',
-				},
-				async () => {
-					const beforeLength = this.harness.state.messages.length;
-					await this.harness.prompt(fullPrompt);
-					await this.harness.waitForIdle();
-					await this.syncHarnessMessagesSince(beforeLength, 'prompt');
-					await this.checkLatestAssistantForCompaction();
-					this.throwIfError('prompt');
+			return this.withCallUsageTracking(() =>
+				this.withScopedRuntime(
+					{
+						commands: effectiveCommands,
+						tools: options?.tools ?? [],
+						role,
+						model: options?.model,
+						callSite: 'this prompt() call',
+					},
+					async () => {
+						const beforeLength = this.harness.state.messages.length;
+						await this.harness.prompt(fullPrompt);
+						await this.harness.waitForIdle();
+						await this.syncHarnessMessagesSince(beforeLength, 'prompt');
+						await this.checkLatestAssistantForCompaction();
+						this.throwIfError('prompt');
 
-					if (schema) {
-						return this.extractResultWithRetry(schema);
-					}
-					return { text: this.getAssistantText() };
-				},
+						if (schema) {
+							return this.extractResultWithRetry(schema);
+						}
+						return { text: this.getAssistantText() };
+					},
+				),
 			);
 		});
 	}
@@ -311,27 +337,29 @@ export class Session implements FlueSession {
 			const skillPrompt = buildSkillPrompt(registeredSkill.instructions, options?.args, schema);
 
 			const effectiveCommands = mergeCommands(this.agentCommands, options?.commands);
-			return this.withScopedRuntime(
-				{
-					commands: effectiveCommands,
-					tools: options?.tools ?? [],
-					role,
-					model: options?.model,
-					callSite: `this skill("${name}") call`,
-				},
-				async () => {
-					const beforeLength = this.harness.state.messages.length;
-					await this.harness.prompt(skillPrompt);
-					await this.harness.waitForIdle();
-					await this.syncHarnessMessagesSince(beforeLength, 'skill');
-					await this.checkLatestAssistantForCompaction();
-					this.throwIfError(`skill("${name}")`);
+			return this.withCallUsageTracking(() =>
+				this.withScopedRuntime(
+					{
+						commands: effectiveCommands,
+						tools: options?.tools ?? [],
+						role,
+						model: options?.model,
+						callSite: `this skill("${name}") call`,
+					},
+					async () => {
+						const beforeLength = this.harness.state.messages.length;
+						await this.harness.prompt(skillPrompt);
+						await this.harness.waitForIdle();
+						await this.syncHarnessMessagesSince(beforeLength, 'skill');
+						await this.checkLatestAssistantForCompaction();
+						this.throwIfError(`skill("${name}")`);
 
-					if (schema) {
-						return this.extractResultWithRetry(schema);
-					}
-					return { text: this.getAssistantText() };
-				},
+						if (schema) {
+							return this.extractResultWithRetry(schema);
+						}
+						return { text: this.getAssistantText() };
+					},
+				),
 			);
 		});
 	}
@@ -863,7 +891,12 @@ export class Session implements FlueSession {
 					`tokens before: ${result.tokensBefore}`,
 			);
 
-			this.emit({ type: 'compaction_end', messagesBefore, messagesAfter });
+			this.emit({
+				type: 'compaction_end',
+				messagesBefore,
+				messagesAfter,
+				usage: result.usage,
+			});
 
 			await this.save();
 
@@ -910,6 +943,61 @@ export class Session implements FlueSession {
 			return textParts.join('\n');
 		}
 		return '';
+	}
+
+	/**
+	 * The model that produced the most recent assistant message in the
+	 * current transcript, or undefined when the transcript is empty or the
+	 * last message is not an assistant turn. Used to fill
+	 * `PromptResponse.model` after `prompt()` / `skill()` settle.
+	 */
+	private getLatestAssistantModel(): ModelInfo | undefined {
+		const messages = this.harness.state.messages;
+		for (let i = messages.length - 1; i >= 0; i--) {
+			const msg = messages[i]!;
+			if (msg.role === 'assistant') {
+				return messageToModelInfo(msg);
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Run `fn` with a fresh call-level usage accumulator.
+	 *
+	 * When the call returns a value that looks like a `PromptResponse`
+	 * (has a `text` string field), we enrich it with the aggregate usage
+	 * and trailing model before returning. Calls that pass `result:
+	 * schema` return an `InferOutput<S>` instead; for those we leave the
+	 * return value untouched (enriching it would force a breaking change
+	 * to the return shape). Schema-callers observe usage via `turn_end`
+	 * events instead.
+	 *
+	 * Nesting behaviour: if a call is already being tracked, we preserve
+	 * the outer accumulator so the outer call still sees its own turns.
+	 */
+	private async withCallUsageTracking<T>(fn: () => Promise<T>): Promise<T> {
+		const previous = this.currentCallUsage;
+		this.currentCallUsage = emptyUsage();
+		try {
+			const result = await fn();
+			const usage = this.currentCallUsage;
+			// Narrow by shape: only enrich `PromptResponse`-shaped returns.
+			// Schema-callers get `InferOutput<S>` which is whatever the user
+			// defined, so we don't touch it.
+			if (
+				usage &&
+				(usage.totalTokens > 0 || usage.input + usage.output > 0) &&
+				isPromptResponseShape(result)
+			) {
+				const model = this.getLatestAssistantModel();
+				result.usage = usage;
+				if (model) result.model = model;
+			}
+			return result;
+		} finally {
+			this.currentCallUsage = previous;
+		}
 	}
 
 	private getLatestAssistantMessageId(): string | undefined {
@@ -1008,4 +1096,70 @@ function truncateShellHistory(text: string): string {
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+// ─── Usage helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Zero-valued `Usage`. Used as the identity element when summing across
+ * turns. Every numeric field defaults to 0 so adding this to a real usage
+ * is a no-op.
+ */
+export function emptyUsage(): Usage {
+	return {
+		input: 0,
+		output: 0,
+		cacheRead: 0,
+		cacheWrite: 0,
+		totalTokens: 0,
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+	};
+}
+
+/**
+ * Sum two `Usage` values field-by-field, including the nested `cost` sub-object.
+ * Returns a new object; neither argument is mutated.
+ *
+ * Used to aggregate per-turn usage into the `PromptResponse.usage` totals
+ * returned by `prompt()` / `skill()`.
+ */
+export function addUsage(a: Usage, b: Usage): Usage {
+	return {
+		input: a.input + b.input,
+		output: a.output + b.output,
+		cacheRead: a.cacheRead + b.cacheRead,
+		cacheWrite: a.cacheWrite + b.cacheWrite,
+		totalTokens: a.totalTokens + b.totalTokens,
+		cost: {
+			input: a.cost.input + b.cost.input,
+			output: a.cost.output + b.cost.output,
+			cacheRead: a.cost.cacheRead + b.cost.cacheRead,
+			cacheWrite: a.cost.cacheWrite + b.cost.cacheWrite,
+			total: a.cost.total + b.cost.total,
+		},
+	};
+}
+
+/** Extract provider/id from an assistant message. Returns undefined if fields missing. */
+export function messageToModelInfo(message: AgentMessage): ModelInfo | undefined {
+	if (message.role !== 'assistant') return undefined;
+	const assistant = message as AssistantMessage;
+	if (!assistant.provider || !assistant.model) return undefined;
+	return { provider: assistant.provider, id: assistant.model };
+}
+
+/**
+ * Type guard for "does this return value look like a `PromptResponse`?".
+ * Used by `withCallUsageTracking` to decide whether to enrich the return
+ * with usage/model. Schema-callers return `InferOutput<S>` shaped however
+ * the user wants, so we only enrich objects that present a string `text`
+ * field — the core `PromptResponse` contract.
+ */
+function isPromptResponseShape(value: unknown): value is PromptResponse {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		'text' in value &&
+		typeof (value as { text: unknown }).text === 'string'
+	);
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,4 +1,4 @@
-import type { Model, TSchema } from '@mariozechner/pi-ai';
+import type { Model, TSchema, Usage } from '@mariozechner/pi-ai';
 import type { AgentMessage } from '@mariozechner/pi-agent-core';
 import type * as v from 'valibot';
 
@@ -312,6 +312,39 @@ export interface FlueSession {
 
 export interface PromptResponse {
 	text: string;
+	/**
+	 * Token usage and cost aggregated across every assistant turn produced
+	 * during this call. Summed from each turn's `usage` as reported by the
+	 * provider via pi-ai. `undefined` only when the call produced zero
+	 * assistant turns (a degenerate case — e.g. an internal error before
+	 * the first turn completed).
+	 *
+	 * For per-turn granularity, subscribe to the `turn_end` event on the
+	 * agent's event callback instead; `PromptResponse.usage` is a
+	 * convenience aggregate for the common single-call case.
+	 *
+	 * Calls that pass `result: schema` return `InferOutput<S>` directly, not
+	 * a `PromptResponse` — for those, the `turn_end` events are the way to
+	 * observe usage.
+	 */
+	usage?: Usage;
+	/**
+	 * The model that produced the final assistant turn, if the call dispatched
+	 * at least one. Populated from `AssistantMessage.provider` / `.model`,
+	 * which pi-agent-core fills from the active model.
+	 */
+	model?: ModelInfo;
+}
+
+/**
+ * Lightweight identifier for the model behind an assistant response. Exposed
+ * in `PromptResponse` and emitted alongside `turn_end` so consumers can do
+ * per-provider / per-model analytics without pulling the full pi-ai `Model`
+ * (which carries cost tables, headers, and provider-specific metadata).
+ */
+export interface ModelInfo {
+	provider: string;
+	id: string;
 }
 
 // ─── Session Store ──────────────────────────────────────────────────────────
@@ -446,13 +479,42 @@ export type FlueEvent = (
 	| { type: 'text_delta'; text: string }
 	| { type: 'tool_start'; toolName: string; toolCallId: string; args?: any }
 	| { type: 'tool_end'; toolName: string; toolCallId: string; isError: boolean; result?: any }
-	| { type: 'turn_end' }
+	| {
+			type: 'turn_end';
+			/**
+			 * Token usage and cost for the assistant turn that just finished.
+			 * Populated directly from `AssistantMessage.usage` as reported by
+			 * pi-ai. `undefined` only for non-assistant turns (rare — included
+			 * for forwards compatibility).
+			 */
+			usage?: Usage;
+			/**
+			 * The model that produced the turn. Sourced from
+			 * `AssistantMessage.provider` and `.model`.
+			 */
+			model?: ModelInfo;
+	  }
 	| { type: 'command_start'; command: string; args: string[] }
 	| { type: 'command_end'; command: string; exitCode: number }
 	| { type: 'task_start'; taskId: string; prompt: string; role?: string; cwd?: string }
 	| { type: 'task_end'; taskId: string; isError: boolean; result?: any }
 	| { type: 'compaction_start'; reason: 'threshold' | 'overflow'; estimatedTokens: number }
-	| { type: 'compaction_end'; messagesBefore: number; messagesAfter: number }
+	| {
+			type: 'compaction_end';
+			messagesBefore: number;
+			messagesAfter: number;
+			/**
+			 * Token usage consumed by the internal summarization call(s) that
+			 * produced this compaction. Compaction runs one or two LLM calls
+			 * (a history summary, and optionally a split-turn prefix summary);
+			 * this is the sum of both. `undefined` if no summarization call
+			 * completed successfully.
+			 *
+			 * Surfaced separately from `turn_end` so consumers can distinguish
+			 * user-visible turn cost from internal maintenance cost.
+			 */
+			usage?: Usage;
+	  }
 	| { type: 'idle' }
 	| { type: 'error'; error: string }
 ) & { sessionId?: string; parentSessionId?: string; taskId?: string };

--- a/packages/sdk/test/run.ts
+++ b/packages/sdk/test/run.ts
@@ -1,0 +1,35 @@
+/**
+ * Minimal test runner.
+ *
+ * Why not `node --test 'test/**\/*.test.ts'`?
+ * Node 22's `--test` flag spawns each file as a subprocess and, combined
+ * with `--experimental-transform-types`, silently drops `describe` blocks
+ * that import heavy modules transitively (observed: any file that imports
+ * `src/session.ts` registers zero subtests and reports a fake "ok 1").
+ * Running through `run()` in-process avoids the subprocess isolation bug.
+ */
+
+import { readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { run } from 'node:test';
+import { spec } from 'node:test/reporters';
+import { pipeline } from 'node:stream/promises';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const files = readdirSync(here)
+	.filter((name) => name.endsWith('.test.ts'))
+	.map((name) => join(here, name));
+
+let failed = false;
+
+const testStream = run({ files, concurrency: false });
+
+testStream.on('test:fail', (event) => {
+	if (!event.todo) failed = true;
+});
+
+await pipeline(testStream.compose(spec), process.stdout);
+
+process.exit(failed ? 1 : 0);

--- a/packages/sdk/test/usage.test.ts
+++ b/packages/sdk/test/usage.test.ts
@@ -1,0 +1,396 @@
+/**
+ * Usage & cost exposure tests.
+ *
+ * Covers the three surfaces added by the feature:
+ *   - `turn_end` event now carries `{ usage, model }`.
+ *   - `PromptResponse` gains `{ usage, model }` aggregated across every
+ *     turn the call produced.
+ *   - Schema-callers (those passing `result: v.object(...)`) get their
+ *     validated result untouched — usage must flow only via events.
+ *   - Helpers (`emptyUsage`, `addUsage`, `messageToModelInfo`).
+ *
+ * Uses an in-process fake `streamFn` so no network and deterministic
+ * usage values — the shape of what pi-ai reports is documented at
+ * `@mariozechner/pi-ai/dist/types.d.ts::Usage`.
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import type {
+	AssistantMessage,
+	Context,
+	Model,
+	SimpleStreamOptions,
+	Usage,
+} from '@mariozechner/pi-ai';
+// See reasoning-forwarding.test.ts for why we pull the class via dynamic import.
+const { AssistantMessageEventStream } = (await import('@mariozechner/pi-ai')) as any;
+
+import {
+	Session,
+	InMemorySessionStore,
+	addUsage,
+	emptyUsage,
+	messageToModelInfo,
+} from '../src/session.ts';
+import type {
+	AgentConfig,
+	FlueEvent,
+	ModelInfo,
+	Role,
+	SessionEnv,
+	Skill,
+} from '../src/types.ts';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function reasoningModel(): Model<'openai-responses'> {
+	return {
+		id: 'claude-opus-4-7',
+		name: 'Claude Opus 4.7',
+		api: 'openai-responses',
+		provider: 'anthropic',
+		baseUrl: 'https://api.example.test',
+		reasoning: true,
+		input: ['text'],
+		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		contextWindow: 200_000,
+		maxTokens: 8192,
+	};
+}
+
+function makeUsage(overrides: Partial<Usage> = {}): Usage {
+	return {
+		input: overrides.input ?? 100,
+		output: overrides.output ?? 50,
+		cacheRead: overrides.cacheRead ?? 0,
+		cacheWrite: overrides.cacheWrite ?? 0,
+		totalTokens: overrides.totalTokens ?? 150,
+		cost: overrides.cost ?? {
+			input: 0.001,
+			output: 0.002,
+			cacheRead: 0,
+			cacheWrite: 0,
+			total: 0.003,
+		},
+	};
+}
+
+function stubEnv(): SessionEnv {
+	return {
+		cwd: '/workspace',
+		resolvePath: (p) => (p.startsWith('/') ? p : `/workspace/${p}`),
+		async exec() {
+			return { stdout: '', stderr: '', exitCode: 0 };
+		},
+		async readFile() {
+			throw new Error('not implemented');
+		},
+		async readFileBuffer() {
+			throw new Error('not implemented');
+		},
+		async writeFile() {},
+		async stat() {
+			return {
+				isFile: false,
+				isDirectory: false,
+				isSymbolicLink: false,
+				size: 0,
+				mtime: new Date(),
+			};
+		},
+		async readdir() {
+			return [];
+		},
+		async exists() {
+			return false;
+		},
+		async mkdir() {},
+		async rm() {},
+		async cleanup() {},
+	};
+}
+
+function baseConfig(overrides?: Partial<AgentConfig>): AgentConfig {
+	const model = reasoningModel();
+	return {
+		systemPrompt: 'test',
+		skills: {} as Record<string, Skill>,
+		roles: {} as Record<string, Role>,
+		model: model as any,
+		resolveModel: () => model as any,
+		...overrides,
+	};
+}
+
+/**
+ * Fake `streamFn` that returns a canned `done` event with a specified
+ * `usage` payload so we can verify end-to-end that Flue surfaces the
+ * provider-reported numbers untouched.
+ */
+function fakeStreamFnWithUsage(usage: Usage) {
+	return (model: Model<any>, _context: Context, _options?: SimpleStreamOptions) => {
+		const stream = new AssistantMessageEventStream();
+		const message: AssistantMessage = {
+			role: 'assistant',
+			content: [{ type: 'text', text: 'ok' }],
+			api: model.api,
+			provider: model.provider,
+			model: model.id,
+			usage,
+			stopReason: 'stop',
+			timestamp: Date.now(),
+		};
+		stream.push({ type: 'start', partial: message });
+		stream.push({ type: 'text_start', contentIndex: 0, partial: message });
+		stream.push({ type: 'text_delta', contentIndex: 0, delta: 'ok', partial: message });
+		stream.push({ type: 'text_end', contentIndex: 0, content: 'ok', partial: message });
+		stream.push({ type: 'done', reason: 'stop', message });
+		stream.end();
+		return stream;
+	};
+}
+
+function makeSession(
+	config: AgentConfig,
+	streamFn: (model: Model<any>, context: Context, options?: SimpleStreamOptions) => any,
+	onEvent?: (event: FlueEvent) => void,
+): Session {
+	const session = new Session({
+		id: 'test-session',
+		storageKey: 'agent:test:default',
+		config,
+		env: stubEnv(),
+		store: new InMemorySessionStore(),
+		existingData: null,
+		onAgentEvent: onEvent,
+		createTaskSession: async () => {
+			throw new Error('task sessions not exercised in these tests');
+		},
+	});
+	(session as any).harness.streamFn = streamFn;
+	return session;
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+describe('emptyUsage', () => {
+	it('returns all-zero usage with a well-formed cost sub-object', () => {
+		const u = emptyUsage();
+		assert.equal(u.input, 0);
+		assert.equal(u.output, 0);
+		assert.equal(u.cacheRead, 0);
+		assert.equal(u.cacheWrite, 0);
+		assert.equal(u.totalTokens, 0);
+		assert.equal(u.cost.input, 0);
+		assert.equal(u.cost.output, 0);
+		assert.equal(u.cost.cacheRead, 0);
+		assert.equal(u.cost.cacheWrite, 0);
+		assert.equal(u.cost.total, 0);
+	});
+
+	it('acts as the additive identity with addUsage', () => {
+		const u = makeUsage();
+		assert.deepEqual(addUsage(emptyUsage(), u), u);
+		assert.deepEqual(addUsage(u, emptyUsage()), u);
+	});
+});
+
+describe('addUsage', () => {
+	it('sums every numeric field including nested cost, without mutating inputs', () => {
+		const a = makeUsage({
+			input: 10,
+			output: 20,
+			cacheRead: 1,
+			cacheWrite: 2,
+			totalTokens: 33,
+			cost: { input: 0.1, output: 0.2, cacheRead: 0.01, cacheWrite: 0.02, total: 0.33 },
+		});
+		const b = makeUsage({
+			input: 5,
+			output: 7,
+			cacheRead: 3,
+			cacheWrite: 4,
+			totalTokens: 19,
+			cost: { input: 0.05, output: 0.07, cacheRead: 0.03, cacheWrite: 0.04, total: 0.19 },
+		});
+		const aClone = structuredClone(a);
+		const bClone = structuredClone(b);
+
+		const sum = addUsage(a, b);
+
+		// Integer token fields are exact.
+		assert.equal(sum.input, 15);
+		assert.equal(sum.output, 27);
+		assert.equal(sum.cacheRead, 4);
+		assert.equal(sum.cacheWrite, 6);
+		assert.equal(sum.totalTokens, 52);
+		// Cost fields are floats in USD. We only assert proximity to avoid
+		// IEEE 754 noise — the sum is produced by plain `+`, so the
+		// semantics are standard JS arithmetic; the only contract is
+		// "field-wise add, no rounding / clamping applied by Flue".
+		const closeEnough = (actual: number, expected: number) =>
+			Math.abs(actual - expected) < 1e-9;
+		assert.ok(closeEnough(sum.cost.input, 0.15), `cost.input ~= 0.15, got ${sum.cost.input}`);
+		assert.ok(closeEnough(sum.cost.output, 0.27), `cost.output ~= 0.27`);
+		assert.ok(closeEnough(sum.cost.cacheRead, 0.04), `cost.cacheRead ~= 0.04`);
+		assert.ok(closeEnough(sum.cost.cacheWrite, 0.06), `cost.cacheWrite ~= 0.06`);
+		assert.ok(closeEnough(sum.cost.total, 0.52), `cost.total ~= 0.52`);
+
+		// Immutability: inputs unchanged.
+		assert.deepEqual(a, aClone);
+		assert.deepEqual(b, bClone);
+	});
+});
+
+describe('messageToModelInfo', () => {
+	it('extracts provider/id from an assistant message', () => {
+		const info = messageToModelInfo({
+			role: 'assistant',
+			content: [{ type: 'text', text: 'x' }],
+			api: 'openai-responses',
+			provider: 'anthropic',
+			model: 'claude-opus-4-7',
+			usage: makeUsage(),
+			stopReason: 'stop',
+			timestamp: 0,
+		} as any);
+		assert.deepEqual(info, { provider: 'anthropic', id: 'claude-opus-4-7' });
+	});
+
+	it('returns undefined for non-assistant messages', () => {
+		const info = messageToModelInfo({
+			role: 'user',
+			content: [{ type: 'text', text: 'hi' }],
+			timestamp: 0,
+		} as any);
+		assert.equal(info, undefined);
+	});
+
+	it('returns undefined when provider or id are missing', () => {
+		const info = messageToModelInfo({
+			role: 'assistant',
+			content: [],
+			api: 'openai-responses',
+			provider: '',
+			model: 'x',
+			usage: makeUsage(),
+			stopReason: 'stop',
+			timestamp: 0,
+		} as any);
+		assert.equal(info, undefined);
+	});
+});
+
+// ─── turn_end event ────────────────────────────────────────────────────────
+
+describe('turn_end event', () => {
+	it('carries the provider-reported usage and model on the event payload', async () => {
+		const expected: Usage = makeUsage({ input: 42, output: 17, totalTokens: 59 });
+		const events: FlueEvent[] = [];
+		const session = makeSession(baseConfig(), fakeStreamFnWithUsage(expected), (e) => events.push(e));
+
+		await session.prompt('hello');
+
+		const turnEnd = events.find((e) => e.type === 'turn_end');
+		assert.ok(turnEnd, 'expected a turn_end event');
+		assert.deepEqual((turnEnd as any).usage, expected);
+		assert.deepEqual((turnEnd as any).model, {
+			provider: 'anthropic',
+			id: 'claude-opus-4-7',
+		});
+	});
+});
+
+// ─── PromptResponse ────────────────────────────────────────────────────────
+
+describe('PromptResponse.usage + model', () => {
+	it('surfaces the single-turn usage as the call-level aggregate', async () => {
+		const expected = makeUsage({ input: 100, output: 50, totalTokens: 150 });
+		const session = makeSession(baseConfig(), fakeStreamFnWithUsage(expected));
+
+		const response = await session.prompt('hello');
+
+		assert.deepEqual(response.usage, expected);
+		assert.deepEqual(response.model, {
+			provider: 'anthropic',
+			id: 'claude-opus-4-7',
+		});
+	});
+
+	it('does not attach usage to schema-validated results', async () => {
+		const { object, string } = await import('valibot');
+
+		const expected = makeUsage();
+		const session = makeSession(baseConfig(), fakeStreamFnWithUsage(expected));
+
+		// Stub extractResultWithRetry: the fake LLM returns plain text "ok",
+		// which won't parse into a schema. We bypass the real extraction to
+		// keep the test focused on the usage-enrichment decision.
+		(session as any).extractResultWithRetry = async () => ({ raw: 'ok' });
+
+		const schema = object({ raw: string() });
+		const result = await session.prompt('hello', { result: schema as any });
+
+		// Schema return must be untouched — no `usage` key injected.
+		assert.deepEqual(result, { raw: 'ok' });
+		assert.equal((result as any).usage, undefined);
+		assert.equal((result as any).model, undefined);
+	});
+});
+
+// ─── skill() ───────────────────────────────────────────────────────────────
+
+describe('skill() usage', () => {
+	it('enriches PromptResponse with aggregate usage and model', async () => {
+		const expected = makeUsage({ input: 75, output: 25, totalTokens: 100 });
+		const config = baseConfig({
+			skills: { review: { name: 'review', description: '', instructions: 'Review.' } },
+		});
+		const session = makeSession(config, fakeStreamFnWithUsage(expected));
+
+		const response = await session.skill('review');
+		assert.deepEqual(response.usage, expected);
+		assert.deepEqual(response.model, {
+			provider: 'anthropic',
+			id: 'claude-opus-4-7',
+		});
+	});
+});
+
+// ─── Regression: listeners without usage still work ────────────────────────
+
+describe('backwards compatibility', () => {
+	it('existing FlueEventCallback consumers that only destructure `type` still work', async () => {
+		// A consumer that was written before `turn_end.usage` existed should
+		// keep functioning. We model that by a listener that only looks at
+		// `event.type` — the extra fields should not throw or break its flow.
+		const seenTypes: string[] = [];
+		const session = makeSession(baseConfig(), fakeStreamFnWithUsage(makeUsage()), (e) => {
+			seenTypes.push(e.type);
+		});
+
+		const response = await session.prompt('hello');
+		assert.equal(response.text, 'ok');
+		assert.ok(seenTypes.includes('turn_end'));
+	});
+
+	it('PromptResponse.usage is optional — callers that only read `text` still work', async () => {
+		const session = makeSession(baseConfig(), fakeStreamFnWithUsage(makeUsage()));
+		const response = await session.prompt('hello');
+		// The minimal PromptResponse contract — text is a string — is
+		// unchanged. usage and model are additive.
+		assert.equal(typeof response.text, 'string');
+	});
+});
+
+// ─── ModelInfo shape ───────────────────────────────────────────────────────
+
+describe('ModelInfo re-export', () => {
+	it('has the documented `{ provider, id }` shape', () => {
+		const info: ModelInfo = { provider: 'anthropic', id: 'claude-opus-4-7' };
+		assert.equal(info.provider, 'anthropic');
+		assert.equal(info.id, 'claude-opus-4-7');
+	});
+});


### PR DESCRIPTION
# Expose token usage and cost per call

## Why

`pi-ai` already reports a full `Usage` (tokens + USD cost) on every
`AssistantMessage`, and `pi-agent-core` threads it through the `turn_end`
event. Flue currently drops it: `prompt()` returns only `{ text }`, the
re-emitted `turn_end` carries no payload, and `compaction_end` doesn't
report summarization cost. This PR surfaces what's already there.

## Changes

All additive, all optional.

```ts
const response = await session.prompt('Analyze this diff.');
response.text;    // unchanged
response.usage;   // aggregated across every turn the call dispatched
response.model;   // { provider, id }
```

- `PromptResponse` gains `usage?: Usage` and `model?: ModelInfo`.
- `turn_end` event gains `usage?` and `model?`.
- `compaction_end` event gains `usage?` (internal summarization cost,
  surfaced separately from user-visible turn cost).
- New exports: `emptyUsage`, `addUsage`, `messageToModelInfo`, type
  `ModelInfo`; `Usage` re-exported from pi-ai.

## Tests

13 tests in `packages/sdk/test/usage.test.ts`: helpers, event payload,
`PromptResponse` enrichment on `prompt()`/`skill()`, schema-callers
untouched, backwards-compat. Run with `pnpm run test` in `packages/sdk/`.

## Architecture decisions

I left a comment on the PR laying out the options I considered and
what's open for your call — happy to change any of them.

## Notes

- Follows the test-runner pattern from #69.
- `model` shape intentionally minimal (`{ provider, id }`) — the full
  pi-ai `Model` carries cost tables and provider metadata that don't
  belong in public Flue types.
- The `check:types` error on `session.ts:479` is pre-existing on `main`;
  unchanged by this PR.
