### PR TITLE
Remove cleanup contract from connectors and SessionEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ export default async function ({ init, payload, env }: FlueContext) {
   const client = new Daytona({ apiKey: env.DAYTONA_API_KEY });
   const sandbox = await client.create();
   const setupAgent = await init({
-    sandbox: daytona(sandbox, { cleanup: true }),
+    sandbox: daytona(sandbox),
     model: 'openai/gpt-5.5',
   });
   const setup = await setupAgent.session();

--- a/connectors/sandbox--boxd.md
+++ b/connectors/sandbox--boxd.md
@@ -78,14 +78,6 @@ export interface BoxdConnectorOptions {
 	 * the probe entirely (useful when reusing a box you know is warm).
 	 */
 	readyTimeoutMs?: number;
-	/**
-	 * Cleanup behavior when the session is destroyed.
-	 *
-	 * - `false` (default): No cleanup — user manages the VM lifecycle.
-	 * - `true`: Calls `box.destroy()` on session destroy.
-	 * - Function: Calls the provided function on session destroy.
-	 */
-	cleanup?: boolean | (() => Promise<void>);
 }
 
 /**
@@ -248,21 +240,7 @@ export function boxd(box: BoxdBox, options?: BoxdConnectorOptions): SandboxFacto
 			readyPromise ??= waitForReady(box, options?.readyTimeoutMs ?? 30_000);
 			await readyPromise;
 			const api = new BoxdSandboxApi(box);
-
-			let cleanupFn: (() => Promise<void>) | undefined;
-			if (options?.cleanup === true) {
-				cleanupFn = async () => {
-					try {
-						await box.destroy();
-					} catch (err) {
-						console.error('[flue:boxd] Failed to destroy box:', err);
-					}
-				};
-			} else if (typeof options?.cleanup === 'function') {
-				cleanupFn = options.cleanup;
-			}
-
-			return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+			return createSandboxSessionEnv(api, sandboxCwd);
 		},
 	};
 }
@@ -319,7 +297,7 @@ export default async function ({ init, env }: FlueContext) {
 
   try {
     const agent = await init({
-      sandbox: boxd(box, { cleanup: true }),
+      sandbox: boxd(box),
       model: 'anthropic/claude-sonnet-4-6',
     });
     const session = await agent.session();

--- a/connectors/sandbox--daytona.md
+++ b/connectors/sandbox--daytona.md
@@ -60,17 +60,6 @@ import { createSandboxSessionEnv } from '@flue/sdk/sandbox';
 import type { SandboxApi, SandboxFactory, SessionEnv, FileStat } from '@flue/sdk/sandbox';
 import type { Sandbox as DaytonaSandbox } from '@daytona/sdk';
 
-export interface DaytonaConnectorOptions {
-	/**
-	 * Cleanup behavior when the session is destroyed.
-	 *
-	 * - `false` (default): No cleanup — user manages the sandbox lifecycle.
-	 * - `true`: Calls `sandbox.delete()` on session destroy.
-	 * - Function: Calls the provided function on session destroy.
-	 */
-	cleanup?: boolean | (() => Promise<void>);
-}
-
 /**
  * Implements SandboxApi by wrapping Daytona's TypeScript SDK.
  */
@@ -153,30 +142,12 @@ class DaytonaSandboxApi implements SandboxApi {
  * The user owns the sandbox lifecycle; Flue wraps it into a SessionEnv
  * for agent use.
  */
-export function daytona(
-	sandbox: DaytonaSandbox,
-	options?: DaytonaConnectorOptions,
-): SandboxFactory {
+export function daytona(sandbox: DaytonaSandbox): SandboxFactory {
 	return {
 		async createSessionEnv({ cwd }: { id: string; cwd?: string }): Promise<SessionEnv> {
 			const sandboxCwd = cwd ?? (await sandbox.getWorkDir()) ?? '/home/daytona';
 			const api = new DaytonaSandboxApi(sandbox);
-
-			// Resolve cleanup function
-			let cleanupFn: (() => Promise<void>) | undefined;
-			if (options?.cleanup === true) {
-				cleanupFn = async () => {
-					try {
-						await sandbox.delete();
-					} catch (err) {
-						console.error('[flue:daytona] Failed to delete sandbox:', err);
-					}
-				};
-			} else if (typeof options?.cleanup === 'function') {
-				cleanupFn = options.cleanup;
-			}
-
-			return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+			return createSandboxSessionEnv(api, sandboxCwd);
 		},
 	};
 }
@@ -227,7 +198,7 @@ export default async function ({ init, env }: FlueContext) {
   const sandbox = await client.create();
 
   const agent = await init({
-    sandbox: daytona(sandbox, { cleanup: true }),
+    sandbox: daytona(sandbox),
     model: 'anthropic/claude-sonnet-4-6',
   });
   const session = await agent.session();

--- a/connectors/sandbox--e2b.md
+++ b/connectors/sandbox--e2b.md
@@ -67,17 +67,6 @@ import { createSandboxSessionEnv } from '@flue/sdk/sandbox';
 import type { SandboxApi, SandboxFactory, SessionEnv, FileStat } from '@flue/sdk/sandbox';
 import type { Sandbox as E2BSandbox } from 'e2b';
 
-export interface E2BConnectorOptions {
-	/**
-	 * Cleanup behavior when the session is destroyed.
-	 *
-	 * - `false` (default): No cleanup — user manages the sandbox lifecycle.
-	 * - `true`: Calls `sandbox.kill()` on session destroy.
-	 * - Function: Calls the provided function on session destroy.
-	 */
-	cleanup?: boolean | (() => Promise<void>);
-}
-
 /**
  * Implements SandboxApi by wrapping the E2B v2 TypeScript SDK.
  *
@@ -176,7 +165,7 @@ class E2BSandboxApi implements SandboxApi {
  * The user owns the sandbox lifecycle; Flue wraps it into a SessionEnv
  * for agent use.
  */
-export function e2b(sandbox: E2BSandbox, options?: E2BConnectorOptions): SandboxFactory {
+export function e2b(sandbox: E2BSandbox): SandboxFactory {
 	return {
 		async createSessionEnv({ cwd }: { id: string; cwd?: string }): Promise<SessionEnv> {
 			// The E2B base template's default user is `user` with home
@@ -184,21 +173,7 @@ export function e2b(sandbox: E2BSandbox, options?: E2BConnectorOptions): Sandbox
 			// overrides cwd.
 			const sandboxCwd = cwd ?? '/home/user';
 			const api = new E2BSandboxApi(sandbox);
-
-			let cleanupFn: (() => Promise<void>) | undefined;
-			if (options?.cleanup === true) {
-				cleanupFn = async () => {
-					try {
-						await sandbox.kill();
-					} catch (err) {
-						console.error('[flue:e2b] Failed to kill sandbox:', err);
-					}
-				};
-			} else if (typeof options?.cleanup === 'function') {
-				cleanupFn = options.cleanup;
-			}
-
-			return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+			return createSandboxSessionEnv(api, sandboxCwd);
 		},
 	};
 }
@@ -257,7 +232,7 @@ export default async function ({ init }: FlueContext) {
   const sandbox = await Sandbox.create();
 
   const agent = await init({
-    sandbox: e2b(sandbox, { cleanup: true }),
+    sandbox: e2b(sandbox),
     model: 'anthropic/claude-sonnet-4-6',
   });
   const session = await agent.session();

--- a/connectors/sandbox--exedev.md
+++ b/connectors/sandbox--exedev.md
@@ -119,8 +119,6 @@ export interface ExeDevConnectorOptions {
   privateKeyPath?: string;
   /** SSH agent socket path. Falls back to `$SSH_AUTH_SOCK` when no key resolves. */
   agent?: string;
-  /** Optional user cleanup hook to run before the SSH connection closes. */
-  cleanup?: () => Promise<void>;
 }
 
 export interface ExeDevLifecycleOptions {
@@ -620,7 +618,7 @@ export function exedev(vm: ExeDevVm | string, options?: ExeDevConnectorOptions):
   const resolvedVm = typeof vm === "string" ? { host: vm } : vm;
   return {
     async createSessionEnv({ cwd }: { id: string; cwd?: string }): Promise<SessionEnv> {
-      const { ssh, disconnect } = await sshConnect(resolvedVm, options ?? {});
+      const { ssh } = await sshConnect(resolvedVm, options ?? {});
       const api = new ExeDevSandboxApi(ssh);
 
       let sandboxCwd = cwd ?? "/home/user";
@@ -634,20 +632,7 @@ export function exedev(vm: ExeDevVm | string, options?: ExeDevConnectorOptions):
         }
       }
 
-      const cleanupFn = async () => {
-        const userCleanup = options?.cleanup;
-        if (typeof userCleanup === "function") {
-          try {
-            await userCleanup();
-          } finally {
-            disconnect();
-          }
-          return;
-        }
-        disconnect();
-      };
-
-      return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+      return createSandboxSessionEnv(api, sandboxCwd);
     },
   };
 }

--- a/connectors/sandbox--islo.md
+++ b/connectors/sandbox--islo.md
@@ -72,13 +72,6 @@ export interface IsloConnectorOptions {
 	cwd?: string;
 	/** Path to the islo binary. Defaults to `"islo"` (resolved via PATH). */
 	cliPath?: string;
-	/**
-	 * Cleanup behavior when the session is destroyed.
-	 * - `false` (default): no cleanup, user manages the sandbox.
-	 * - `true`: runs `islo rm <name> --force`.
-	 * - Function: called on destroy.
-	 */
-	cleanup?: boolean | (() => Promise<void>);
 }
 
 const q = (s: string) => `'${s.replace(/'/g, `'\\''`)}'`;
@@ -219,23 +212,7 @@ export function islo(name: string, options?: IsloConnectorOptions): SandboxFacto
 		async createSessionEnv({ cwd }: { id: string; cwd?: string }): Promise<SessionEnv> {
 			const sandboxCwd = cwd ?? options?.cwd ?? '/workspace';
 			const api = new IsloSandboxApi(name, cliPath);
-
-			let cleanupFn: (() => Promise<void>) | undefined;
-			if (options?.cleanup === true) {
-				cleanupFn = () =>
-					new Promise<void>((resolve) => {
-						const c = spawn(cliPath, ['rm', name, '--force'], {
-							env: process.env,
-							stdio: 'ignore',
-						});
-						c.on('error', () => resolve());
-						c.on('close', () => resolve());
-					});
-			} else if (typeof options?.cleanup === 'function') {
-				cleanupFn = options.cleanup;
-			}
-
-			return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+			return createSandboxSessionEnv(api, sandboxCwd);
 		},
 	};
 }

--- a/connectors/sandbox--modal.md
+++ b/connectors/sandbox--modal.md
@@ -85,14 +85,6 @@ export interface ModalConnectorOptions {
 	 * Defaults to "/".
 	 */
 	cwd?: string;
-	/**
-	 * Cleanup behavior when the session is destroyed.
-	 *
-	 * - `false` (default): No cleanup — user manages the sandbox lifecycle.
-	 * - `true`: Calls `sandbox.terminate()` on session destroy.
-	 * - Function: Calls the provided function on session destroy.
-	 */
-	cleanup?: boolean | (() => Promise<void>);
 }
 
 /**
@@ -261,21 +253,7 @@ export function modal(sandbox: ModalSandbox, options?: ModalConnectorOptions): S
 		async createSessionEnv({ cwd }: { id: string; cwd?: string }): Promise<SessionEnv> {
 			const sandboxCwd = cwd ?? options?.cwd ?? '/';
 			const api = new ModalSandboxApi(sandbox);
-
-			let cleanupFn: (() => Promise<void>) | undefined;
-			if (options?.cleanup === true) {
-				cleanupFn = async () => {
-					try {
-						await sandbox.terminate();
-					} catch (err) {
-						console.error('[flue:modal] Failed to terminate sandbox:', err);
-					}
-				};
-			} else if (typeof options?.cleanup === 'function') {
-				cleanupFn = options.cleanup;
-			}
-
-			return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+			return createSandboxSessionEnv(api, sandboxCwd);
 		},
 	};
 }
@@ -344,7 +322,7 @@ export default async function ({ init }: FlueContext) {
   const sandbox = await client.sandboxes.create(app, image);
 
   const agent = await init({
-    sandbox: modal(sandbox, { cleanup: true }),
+    sandbox: modal(sandbox),
     model: 'anthropic/claude-sonnet-4-6',
   });
   const session = await agent.session();

--- a/connectors/sandbox--vercel.md
+++ b/connectors/sandbox--vercel.md
@@ -59,17 +59,6 @@ import { createSandboxSessionEnv } from '@flue/sdk/sandbox';
 import type { SandboxApi, SandboxFactory, SessionEnv, FileStat } from '@flue/sdk/sandbox';
 import type { Sandbox as VercelSandbox } from '@vercel/sandbox';
 
-export interface VercelConnectorOptions {
-	/**
-	 * Cleanup behavior when the session is destroyed.
-	 *
-	 * - `false` (default): No cleanup — user manages the sandbox lifecycle.
-	 * - `true`: Calls `sandbox.stop({ blocking: true })` on session destroy.
-	 * - Function: Calls the provided function on session destroy.
-	 */
-	cleanup?: boolean | (() => Promise<void>);
-}
-
 /**
  * Implements SandboxApi by wrapping the Vercel Sandbox SDK.
  */
@@ -160,30 +149,12 @@ class VercelSandboxApi implements SandboxApi {
  * The user owns the sandbox lifecycle; Flue wraps it into a SessionEnv
  * for agent use.
  */
-export function vercel(
-	sandbox: VercelSandbox,
-	options?: VercelConnectorOptions,
-): SandboxFactory {
+export function vercel(sandbox: VercelSandbox): SandboxFactory {
 	return {
 		async createSessionEnv({ cwd }: { id: string; cwd?: string }): Promise<SessionEnv> {
 			const sandboxCwd = cwd ?? '/vercel/sandbox';
 			const api = new VercelSandboxApi(sandbox);
-
-			// Resolve cleanup function
-			let cleanupFn: (() => Promise<void>) | undefined;
-			if (options?.cleanup === true) {
-				cleanupFn = async () => {
-					try {
-						await sandbox.stop({ blocking: true });
-					} catch (err) {
-						console.error('[flue:vercel] Failed to stop sandbox:', err);
-					}
-				};
-			} else if (typeof options?.cleanup === 'function') {
-				cleanupFn = options.cleanup;
-			}
-
-			return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+			return createSandboxSessionEnv(api, sandboxCwd);
 		},
 	};
 }
@@ -249,7 +220,7 @@ export default async function ({ init }: FlueContext) {
   const sandbox = await Sandbox.create({ runtime: 'node24' });
 
   const agent = await init({
-    sandbox: vercel(sandbox, { cleanup: true }),
+    sandbox: vercel(sandbox),
     model: 'anthropic/claude-sonnet-4-6',
   });
   const session = await agent.session();

--- a/docs/connect-daytona.md
+++ b/docs/connect-daytona.md
@@ -61,7 +61,7 @@ export default async function ({ init, env }: FlueContext) {
   const sandbox = await client.create();
 
   const agent = await init({
-    sandbox: daytona(sandbox, { cleanup: true }),
+    sandbox: daytona(sandbox),
     model: 'anthropic/claude-sonnet-4-6',
   });
   const session = await agent.session();
@@ -70,7 +70,7 @@ export default async function ({ init, env }: FlueContext) {
 }
 ```
 
-`cleanup: true` tells Flue to delete the sandbox when the request finishes. The default is `false` (you manage the lifecycle), and you can also pass a function for custom teardown.
+You own the sandbox. Flue does not delete it for you — sandboxes persist across requests by default, which is usually what you want for debugging, log inspection, or warm reuse.
 
 ## Advanced: Sharing a sandbox across sessions
 
@@ -89,7 +89,7 @@ export default async function ({ init, payload, env }: FlueContext) {
 
   // Setup session — clone the repo and install dependencies.
   const setupAgent = await init({
-    sandbox: daytona(sandbox, { cleanup: true }),
+    sandbox: daytona(sandbox),
     model: 'anthropic/claude-sonnet-4-6',
   });
   const setup = await setupAgent.session();
@@ -109,7 +109,7 @@ export default async function ({ init, payload, env }: FlueContext) {
 }
 ```
 
-Both `init()` calls share the same Daytona sandbox. Only the first carries `cleanup: true` so the sandbox is torn down when the request finishes. The second passes `cwd` so the agent's tools operate inside the project directory.
+Both `init()` calls share the same Daytona sandbox. The second passes `cwd` so the agent's tools operate inside the project directory.
 
 ## Configuring the sandbox
 

--- a/docs/sandbox-connector-spec.md
+++ b/docs/sandbox-connector-spec.md
@@ -46,39 +46,25 @@ import type {
 } from '@flue/sdk/sandbox';
 import type { Sandbox as ProviderSandbox } from '<provider-sdk>';
 
-export interface ProviderConnectorOptions {
-  cleanup?: boolean | (() => Promise<void>);
-}
-
 class ProviderSandboxApi implements SandboxApi {
   constructor(private sandbox: ProviderSandbox) {}
   // ... implement every method on SandboxApi (see "Required SandboxApi Methods" below)
 }
 
-export function provider(
-  sandbox: ProviderSandbox,
-  options?: ProviderConnectorOptions,
-): SandboxFactory {
+export function provider(sandbox: ProviderSandbox): SandboxFactory {
   return {
     async createSessionEnv({ cwd }): Promise<SessionEnv> {
       const sandboxCwd = cwd ?? '/workspace'; // pick a sensible default
       const api = new ProviderSandboxApi(sandbox);
-
-      let cleanupFn: (() => Promise<void>) | undefined;
-      if (options?.cleanup === true) {
-        cleanupFn = async () => {
-          try { await sandbox.delete(); }
-          catch (err) { console.error('[flue:provider] cleanup failed:', err); }
-        };
-      } else if (typeof options?.cleanup === 'function') {
-        cleanupFn = options.cleanup;
-      }
-
-      return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+      return createSandboxSessionEnv(api, sandboxCwd);
     },
   };
 }
 ```
+
+Connectors are pure adapters. They map a provider sandbox to `SessionEnv`
+and stop there. They do not manage the sandbox's lifetime — the user owns
+what they create.
 
 ---
 
@@ -86,8 +72,8 @@ export function provider(
 
 All from `@flue/sdk/sandbox`:
 
-- `createSandboxSessionEnv(api, cwd, cleanup?)` — wraps your `SandboxApi` into
-  a `SessionEnv` that Flue can drive.
+- `createSandboxSessionEnv(api, cwd)` — wraps your `SandboxApi` into a
+  `SessionEnv` that Flue can drive.
 - `SandboxApi` — the interface you implement.
 - `SandboxFactory` — what your factory returns.
 - `SessionEnv` — what `createSandboxSessionEnv` returns. You don't construct
@@ -147,8 +133,8 @@ export interface FileStat {
 ### `SessionEnv` (you do **not** implement this)
 
 You return one of these from `createSessionEnv`, but you get it from
-`createSandboxSessionEnv(api, cwd, cleanup?)`. You never write `SessionEnv`
-methods by hand in a connector.
+`createSandboxSessionEnv(api, cwd)`. You never write `SessionEnv` methods by
+hand in a connector.
 
 ---
 
@@ -207,17 +193,17 @@ unavailable, defaulting to `0` only when the call clearly succeeded.
 
 ---
 
-## The `cleanup` Option
+## Sandbox Lifetime
 
-By convention, connector factories accept a `cleanup` option:
+Flue does not manage sandbox lifetime. The user creates the sandbox, the
+user decides when (or whether) to delete it. Connectors must not call
+`sandbox.delete()`, `sandbox.terminate()`, `sandbox.kill()`, or any
+equivalent on the user's behalf.
 
-- `false` (default): Flue does not delete the sandbox. The user manages its
-  lifecycle.
-- `true`: Flue calls a provider-specific delete (e.g. `sandbox.delete()`) when
-  the session is destroyed.
-- A function: Flue calls the function when the session is destroyed.
-
-Wire `cleanup` into the third argument of `createSandboxSessionEnv`.
+This means connector factories take no `cleanup` option, and
+`createSandboxSessionEnv` takes no cleanup callback. If the connector
+itself opens a real socket (e.g. SSH), it can manage that socket
+internally — but it must not assume Flue will trigger teardown.
 
 ---
 
@@ -236,8 +222,8 @@ https://raw.githubusercontent.com/withastro/flue/refs/heads/main/connectors/sand
 ```
 
 It's the cleanest example of the patterns described here: shell-fallback for
-recursive mkdir, try/catch on `exists()`, buffer/string conversion in
-`writeFile`, and `cleanup` wiring.
+recursive mkdir, try/catch on `exists()`, and buffer/string conversion in
+`writeFile`.
 
 ---
 

--- a/examples/hello-world/.flue/connectors/daytona.ts
+++ b/examples/hello-world/.flue/connectors/daytona.ts
@@ -20,19 +20,6 @@ import { createSandboxSessionEnv } from '@flue/sdk/sandbox';
 import type { SandboxApi, SandboxFactory, SessionEnv, FileStat } from '@flue/sdk/sandbox';
 import type { Sandbox as DaytonaSandbox } from '@daytona/sdk';
 
-// ─── Options ────────────────────────────────────────────────────────────────
-
-export interface DaytonaConnectorOptions {
-	/**
-	 * Cleanup behavior when the session is destroyed.
-	 *
-	 * - `false` (default): No cleanup — user manages the sandbox lifecycle.
-	 * - `true`: Calls `sandbox.delete()` on session destroy.
-	 * - Function: Calls the provided function on session destroy.
-	 */
-	cleanup?: boolean | (() => Promise<void>);
-}
-
 // ─── DaytonaSandboxApi ──────────────────────────────────────────────────────
 
 /**
@@ -121,32 +108,13 @@ class DaytonaSandboxApi implements SandboxApi {
  * passes it here. Flue wraps it into a SessionEnv for agent use.
  *
  * @param sandbox - An initialized Daytona Sandbox instance.
- * @param options - Connector options (cleanup behavior, etc.).
  */
-export function daytona(
-	sandbox: DaytonaSandbox,
-	options?: DaytonaConnectorOptions,
-): SandboxFactory {
+export function daytona(sandbox: DaytonaSandbox): SandboxFactory {
 	return {
 		async createSessionEnv({ cwd }: { id: string; cwd?: string }): Promise<SessionEnv> {
 			const sandboxCwd = cwd ?? (await sandbox.getWorkDir()) ?? '/home/daytona';
 			const api = new DaytonaSandboxApi(sandbox);
-
-			// Resolve cleanup function
-			let cleanupFn: (() => Promise<void>) | undefined;
-			if (options?.cleanup === true) {
-				cleanupFn = async () => {
-					try {
-						await sandbox.delete();
-					} catch (err) {
-						console.error('[flue:daytona] Failed to delete sandbox:', err);
-					}
-				};
-			} else if (typeof options?.cleanup === 'function') {
-				cleanupFn = options.cleanup;
-			}
-
-			return createSandboxSessionEnv(api, sandboxCwd, cleanupFn);
+			return createSandboxSessionEnv(api, sandboxCwd);
 		},
 	};
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -171,7 +171,7 @@ export default async function ({ init, payload, env }: FlueContext) {
   const client = new Daytona({ apiKey: env.DAYTONA_API_KEY });
   const sandbox = await client.create();
   const setupAgent = await init({
-    sandbox: daytona(sandbox, { cleanup: true }),
+    sandbox: daytona(sandbox),
     model: 'openai/gpt-5.5',
   });
   const setup = await setupAgent.session();

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -171,7 +171,7 @@ export default async function ({ init, payload, env }: FlueContext) {
   const client = new Daytona({ apiKey: env.DAYTONA_API_KEY });
   const sandbox = await client.create();
   const setupAgent = await init({
-    sandbox: daytona(sandbox, { cleanup: true }),
+    sandbox: daytona(sandbox),
     model: 'openai/gpt-5.5',
   });
   const setup = await setupAgent.session();

--- a/packages/sdk/src/agent-client.ts
+++ b/packages/sdk/src/agent-client.ts
@@ -31,7 +31,6 @@ export class AgentClient implements FlueAgent {
 	};
 
 	private openSessions = new Map<string, Session>();
-	private destroyed = false;
 
 	constructor(
 		readonly id: string,
@@ -48,7 +47,6 @@ export class AgentClient implements FlueAgent {
 	}
 
 	async shell(command: string, options?: ShellOptions): Promise<ShellResult> {
-		this.assertActive();
 		const effectiveCommands = mergeCommands(this.agentCommands, options?.commands);
 		const env = await createScopedEnv(this.env, effectiveCommands);
 		const result = await env.exec(command, {
@@ -59,22 +57,11 @@ export class AgentClient implements FlueAgent {
 		return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
 	}
 
-	async destroy(): Promise<void> {
-		if (this.destroyed) return;
-		this.destroyed = true;
-		for (const session of Array.from(this.openSessions.values())) {
-			session.close();
-		}
-		this.openSessions.clear();
-		await this.env.cleanup();
-	}
-
 	private async openSession(
 		id: string | undefined,
 		mode: OpenMode,
 		options?: SessionOptions,
 	): Promise<FlueSession> {
-		this.assertActive();
 		assertRoleExists(this.config.roles, options?.role);
 		const sessionId = normalizeSessionId(id);
 		const open = this.openSessions.get(sessionId);
@@ -126,7 +113,6 @@ export class AgentClient implements FlueAgent {
 	}
 
 	private async deleteSession(id: string | undefined): Promise<void> {
-		this.assertActive();
 		const sessionId = normalizeSessionId(id);
 		const open = this.openSessions.get(sessionId);
 		if (open) {
@@ -137,7 +123,6 @@ export class AgentClient implements FlueAgent {
 	}
 
 	private async createTaskSession(options: CreateTaskSessionOptions): Promise<Session> {
-		this.assertActive();
 		assertRoleExists(this.config.roles, options.role);
 
 		const sessionId = `task:${options.parentSessionId}:${options.taskId}`;
@@ -185,12 +170,6 @@ export class AgentClient implements FlueAgent {
 			taskDepth: options.depth,
 			createTaskSession: (childOptions) => this.createTaskSession(childOptions),
 		});
-	}
-
-	private assertActive(): void {
-		if (this.destroyed) {
-			throw new Error(`[flue] Agent "${this.id}" has been destroyed.`);
-		}
 	}
 }
 

--- a/packages/sdk/src/sandbox.ts
+++ b/packages/sdk/src/sandbox.ts
@@ -35,7 +35,6 @@ export function createCwdSessionEnv(parentEnv: SessionEnv, cwd: string): Session
 		rm: (p, o) => parentEnv.rm(resolvePath(p), o),
 		cwd: scopedCwd,
 		resolvePath,
-		cleanup: () => parentEnv.cleanup(),
 	};
 }
 
@@ -129,7 +128,6 @@ function createBashSessionEnv(
 		rm: (p, o) => fs.rm(resolve(p), o),
 		cwd,
 		resolvePath: resolve,
-		cleanup: async () => {},
 	};
 }
 
@@ -177,11 +175,7 @@ export interface SandboxApi {
 }
 
 /** Wrap a SandboxApi into SessionEnv. No just-bash, no intermediate filesystem layer. */
-export function createSandboxSessionEnv(
-	api: SandboxApi,
-	cwd: string,
-	cleanup?: () => Promise<void>,
-): SessionEnv {
+export function createSandboxSessionEnv(api: SandboxApi, cwd: string): SessionEnv {
 	const resolvePath = (p: string): string => {
 		if (p.startsWith('/')) return normalizePath(p);
 		if (cwd === '/') return normalizePath('/' + p);
@@ -235,9 +229,5 @@ export function createSandboxSessionEnv(
 		cwd,
 
 		resolvePath,
-
-		async cleanup(): Promise<void> {
-			if (cleanup) await cleanup();
-		},
 	};
 }

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -112,8 +112,6 @@ export interface SessionEnv {
 	 * for your own logic (e.g., extracting the parent directory).
 	 */
 	resolvePath(p: string): string;
-
-	cleanup(): Promise<void>;
 }
 
 // ─── Compaction ─────────────────────────────────────────────────────────────
@@ -311,9 +309,6 @@ export interface FlueAgent {
 
 	/** Run a shell command in the agent sandbox without recording it in a conversation. */
 	shell(command: string, options?: ShellOptions): Promise<ShellResult>;
-
-	/** Destroy the agent runtime and clean up the sandbox resources it owns. */
-	destroy(): Promise<void>;
 }
 
 export interface FlueSessions {


### PR DESCRIPTION
## Summary

The `cleanup` option on sandbox connectors was documented as firing when a request finished, but nothing in the runtime ever invoked it (#58). Rather than wire up auto-destroy (#66), this PR removes the contract entirely: connectors are pure adapters, sandboxes are user-owned.

## Changes

- **SDK**: drop `SessionEnv.cleanup`, `FlueAgent.destroy`, and the `cleanup` arg on `createSandboxSessionEnv`. `AgentClient.destroy()` and its destroyed-flag guards are gone.
- **Connectors**: drop the `cleanup` option from all 7 sandbox connector docs and the in-tree daytona example. Connectors whose only option was `cleanup` lose the options arg too.
- **Docs**: rewrite the connector spec's "cleanup option" section as "Sandbox Lifetime" stating Flue does not manage sandbox lifetime. Update `connect-daytona.md` and READMEs to use `daytona(sandbox)`.

## Why this direction over #66

`#66` proposed wiring auto-destroy into request lifecycle hooks, so the runtime would call `agent.destroy()` for the user. That fixes the leak but introduces a split-ownership model that's confusing: the user constructs the sandbox themselves, then Flue silently tears it down. Removing the contract is simpler — user owns what they create, full stop. Most users don't actually want their sandbox auto-deleted (debugging, log inspection, warm reuse), so opt-in `sandbox.delete()` in user code is closer to what's actually needed.

Closes #58. Supersedes #66.

## Verification

- `pnpm run check:types` clean in `packages/sdk`
- `pnpm run build` clean in `packages/sdk` and `packages/cli`
- `flue build --target node` and `flue build --target cloudflare` succeed against `examples/hello-world`
- Smoke workspace bundles via esbuild and passes `node --check` on both targets