### PR TITLE
Add custom route discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,4 +392,23 @@ flue build --target node          # Node.js server (single bundled .mjs)
 flue build --target cloudflare    # Cloudflare Workers + Durable Objects
 ```
 
+#### Custom Routes
+
+For the Node target, add custom Hono routes under `.flue/routes/`. Each route
+file is registered at build time and must export `httpMethod`, `path`, and
+`handler`:
+
+```ts
+// .flue/routes/status.ts
+export const httpMethod = 'GET';
+export const path = '/status';
+
+export const handler = (c) => {
+  return c.json({ status: 'ok' });
+};
+```
+
+Custom routes are bundled into the generated Hono server before Flue's built-in
+routes.
+
 For Cloudflare, `flue build` produces an unbundled TypeScript entry that `wrangler deploy` bundles itself — the same path `flue dev --target cloudflare` uses. Dev and deploy go through the same bundler, so what works in dev will work in production.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -392,4 +392,23 @@ flue build --target node          # Node.js server (single bundled .mjs)
 flue build --target cloudflare    # Cloudflare Workers + Durable Objects
 ```
 
+#### Custom Routes
+
+For the Node target, add custom Hono routes under `.flue/routes/`. Each route
+file is registered at build time and must export `httpMethod`, `path`, and
+`handler`:
+
+```ts
+// .flue/routes/status.ts
+export const httpMethod = 'GET';
+export const path = '/status';
+
+export const handler = (c) => {
+  return c.json({ status: 'ok' });
+};
+```
+
+Custom routes are bundled into the generated Hono server before Flue's built-in
+routes.
+
 For Cloudflare, `flue build` produces an unbundled TypeScript entry that `wrangler deploy` bundles itself — the same path `flue dev --target cloudflare` uses. Dev and deploy go through the same bundler, so what works in dev will work in production.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -392,4 +392,23 @@ flue build --target node          # Node.js server (single bundled .mjs)
 flue build --target cloudflare    # Cloudflare Workers + Durable Objects
 ```
 
+#### Custom Routes
+
+For the Node target, add custom Hono routes under `.flue/routes/`. Each route
+file is registered at build time and must export `httpMethod`, `path`, and
+`handler`:
+
+```ts
+// .flue/routes/status.ts
+export const httpMethod = 'GET';
+export const path = '/status';
+
+export const handler = (c) => {
+  return c.json({ status: 'ok' });
+};
+```
+
+Custom routes are bundled into the generated Hono server before Flue's built-in
+routes.
+
 For Cloudflare, `flue build` produces an unbundled TypeScript entry that `wrangler deploy` bundles itself — the same path `flue dev --target cloudflare` uses. Dev and deploy go through the same bundler, so what works in dev will work in production.

--- a/packages/sdk/src/build-plugin-cloudflare.ts
+++ b/packages/sdk/src/build-plugin-cloudflare.ts
@@ -43,6 +43,12 @@ export class CloudflarePlugin implements BuildPlugin {
 	async generateEntryPoint(ctx: BuildContext): Promise<string> {
 		const { agents, roles } = ctx;
 		const rolesJson = JSON.stringify(roles);
+		if (ctx.routes.length > 0) {
+			throw new Error(
+				'[flue] Custom routes from routes/ are currently only supported by the Node target. ' +
+					'Remove routes/ or build with --target node.',
+			);
+		}
 		validateCloudflareAgentNames(ctx);
 
 		const webhookAgents = agents.filter((a) => a.triggers.webhook);

--- a/packages/sdk/src/build-plugin-node.ts
+++ b/packages/sdk/src/build-plugin-node.ts
@@ -8,7 +8,7 @@ export class NodePlugin implements BuildPlugin {
 	bundle = 'esbuild' as const;
 
 	generateEntryPoint(ctx: BuildContext): string {
-		const { agents, roles } = ctx;
+		const { agents, routes, roles } = ctx;
 		const rolesJson = JSON.stringify(roles);
 
 		const webhookAgents = agents.filter((a) => a.triggers.webhook);
@@ -22,6 +22,20 @@ export class NodePlugin implements BuildPlugin {
 				const varName = agentVarName(a.name, index);
 				const filePath = a.filePath.replace(/\\/g, '/');
 				return `import ${varName} from '${filePath}';`;
+			})
+			.join('\n');
+
+		const routeImports = routes
+			.map((route, index) => {
+				const filePath = route.filePath.replace(/\\/g, '/');
+				return `import * as routeModule_${index} from '${filePath}';`;
+			})
+			.join('\n');
+
+		const routeRegistrations = routes
+			.map((route, index) => {
+				const source = JSON.stringify(route.filePath);
+				return `registerCustomRoute(routeModule_${index}, ${source});`;
 			})
 			.join('\n');
 
@@ -65,6 +79,7 @@ import {
 import { randomUUID } from 'node:crypto';
 
 ${agentImports}
+${routeImports}
 
 // ─── Config ─────────────────────────────────────────────────────────────────
 
@@ -141,6 +156,26 @@ function createContextForRequest(id, payload, req) {
 // ─── Server ─────────────────────────────────────────────────────────────────
 
 const app = new Hono();
+
+function registerCustomRoute(routeModule, source) {
+  const httpMethod = routeModule.httpMethod;
+  const routePath = routeModule.path;
+  const handler = routeModule.handler;
+
+  if (typeof httpMethod !== 'string' || httpMethod.trim() === '') {
+    throw new Error('[flue] Custom route "' + source + '" must export const httpMethod as a non-empty string.');
+  }
+  if (typeof routePath !== 'string' || routePath.trim() === '') {
+    throw new Error('[flue] Custom route "' + source + '" must export const path as a non-empty string.');
+  }
+  if (typeof handler !== 'function') {
+    throw new Error('[flue] Custom route "' + source + '" must export const handler as a Hono route handler.');
+  }
+
+  app.on(httpMethod.toUpperCase(), routePath, handler);
+}
+
+${routeRegistrations}
 
 app.get('/health', (c) => c.json({ status: 'ok' }));
 app.get('/agents', (c) => c.json(manifest));

--- a/packages/sdk/src/build.ts
+++ b/packages/sdk/src/build.ts
@@ -11,6 +11,7 @@ import type {
 	BuildContext,
 	BuildOptions,
 	BuildPlugin,
+	RouteInfo,
 	Role,
 	ThinkingLevel,
 } from './types.ts';
@@ -71,6 +72,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
 
 	const roles = discoverRoles(workspaceDir);
 	const agents = discoverAgents(workspaceDir);
+	const routes = discoverRoutes(workspaceDir);
 
 	if (agents.length === 0) {
 		throw new Error(
@@ -91,6 +93,11 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
 		`[flue] Found ${Object.keys(roles).length} role(s): ${Object.keys(roles).join(', ') || '(none)'}`,
 	);
 	console.log(`[flue] Found ${agents.length} agent(s): ${agents.map((a) => a.name).join(', ')}`);
+	if (routes.length > 0) {
+		console.log(
+			`[flue] Found ${routes.length} custom route(s): ${routes.map((r) => r.name).join(', ')}`,
+		);
+	}
 	if (webhookAgents.length > 0) {
 		console.log(`[flue] Webhook agents: ${webhookAgents.map((a) => a.name).join(', ')}`);
 	}
@@ -118,6 +125,7 @@ export async function build(options: BuildOptions): Promise<BuildResult> {
 
 	const ctx: BuildContext = {
 		agents,
+		routes,
 		roles,
 		workspaceDir,
 		outputDir,
@@ -305,6 +313,20 @@ function discoverAgents(workspaceRoot: string): AgentInfo[] {
 				triggers,
 			};
 		});
+}
+
+function discoverRoutes(workspaceRoot: string): RouteInfo[] {
+	const routesDir = path.join(workspaceRoot, 'routes');
+	if (!fs.existsSync(routesDir)) return [];
+
+	return fs
+		.readdirSync(routesDir)
+		.filter((f) => /\.(ts|js|mts|mjs)$/.test(f))
+		.sort()
+		.map((f) => ({
+			name: f.replace(/\.(ts|js|mts|mjs)$/, ''),
+			filePath: path.join(routesDir, f),
+		}));
 }
 
 /** Externalize user's direct deps (bare name + subpath wildcard). */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -34,6 +34,7 @@ export type {
 	BuildPlugin,
 	BuildContext,
 	AgentInfo,
+	RouteInfo,
 	ToolDef,
 	ToolParameters,
 	ThinkingLevel,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -606,8 +606,14 @@ export interface AgentInfo {
 	triggers: { webhook?: boolean };
 }
 
+export interface RouteInfo {
+	name: string;
+	filePath: string;
+}
+
 export interface BuildContext {
 	agents: AgentInfo[];
+	routes: RouteInfo[];
 	roles: Record<string, Role>;
 	/** The workspace root: the directory directly containing agents/ and roles/. */
 	workspaceDir: string;


### PR DESCRIPTION
## Summary
- Discover route modules from .flue/routes/ during build.
- Register custom route modules in the generated Node Hono server using exported httpMethod, path, and handler.
- Document the route convention and fail clearly for Cloudflare builds when custom routes are present.

## Validation
- pnpm run build in packages/sdk
- Route-generation assertion with pnpm exec tsx
- pnpm run check:types currently fails on existing Cloudflare provider type errors in src/cloudflare/workers-ai-provider.ts.
