### PR TITLE
fix(sdk): event shapes + tool-call-shaped session.shell + name-based skills

### DIFF
--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -265,7 +265,7 @@ function createTaskTool(
 	};
 }
 
-function formatBashResult(
+export function formatBashResult(
 	result: { stdout: string; stderr: string; exitCode: number },
 	command: string,
 ): AgentToolResult<any> {

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -55,42 +55,34 @@ export async function readAgentsMd(env: SessionEnv, basePath: string): Promise<s
 	return parts.join('\n\n');
 }
 
+/** Path to the skills directory under a given base path. */
+export function skillsDirIn(basePath: string): string {
+	return basePath.endsWith('/') ? `${basePath}.agents/skills` : `${basePath}/.agents/skills`;
+}
+
 /**
- * Resolve a skill referenced by relative path under `.agents/skills/`.
+ * Resolve a skill referenced by relative path under `.agents/skills/`,
+ * returning the absolute filesystem path or `null` if the file doesn't
+ * exist.
  *
- * The path is taken as-is — no extension is auto-appended. Callers reference
- * the full filename, e.g. `'triage/reproduce.md'`. Returns `null` if the file
- * doesn't exist.
+ * The relative path is taken as-is — no extension is auto-appended.
+ * Callers reference the full filename, e.g. `'triage/reproduce.md'`.
  *
- * Used as a fallback by `session.skill()` when the requested name doesn't match
- * a discovered skill's frontmatter `name:` field. Lets users organise skills as
- * a pack of sibling markdown files under one directory (orchestration SKILL.md
- * + stage files) without forcing each stage into its own `SKILL.md` subdirectory.
- *
- * Skill bodies are not cached — at call time the model reads the file from
- * disk itself. We still parse the frontmatter here to recover the
- * registered name and description for the system-prompt registry.
+ * Used by `session.skill()` when the caller passes a path-shaped name
+ * (contains `/` or ends in `.md`/`.markdown`). Path-based references
+ * bypass the skill registry entirely — the model is given the resolved
+ * path and reads the file directly. We don't parse the file here
+ * because nothing on the server side needs the frontmatter for these
+ * skills; only the model does, and it reads the file itself.
  */
-export async function loadSkillByPath(
+export async function resolveSkillFilePath(
 	env: SessionEnv,
 	basePath: string,
 	relPath: string,
-): Promise<Skill | null> {
-	const skillsDir = basePath.endsWith('/')
-		? `${basePath}.agents/skills`
-		: `${basePath}/.agents/skills`;
-	const filePath = `${skillsDir}/${relPath}`;
+): Promise<string | null> {
+	const filePath = `${skillsDirIn(basePath)}/${relPath}`;
 	if (!(await env.exists(filePath))) return null;
-
-	const content = await env.readFile(filePath);
-	// Default name is the relative path with any .md/.markdown extension stripped,
-	// used only when the file has no explicit frontmatter `name:` field.
-	const defaultName = relPath.replace(/\.(md|markdown)$/i, '');
-	const parsed = parseFrontmatterFile(content, defaultName);
-	return {
-		name: parsed.name,
-		description: parsed.description,
-	};
+	return filePath;
 }
 
 /**
@@ -107,9 +99,7 @@ export async function discoverLocalSkills(
 	env: SessionEnv,
 	basePath: string,
 ): Promise<Record<string, Skill>> {
-	const skillsDir = basePath.endsWith('/')
-		? `${basePath}.agents/skills`
-		: `${basePath}/.agents/skills`;
+	const skillsDir = skillsDirIn(basePath);
 
 	if (!(await env.exists(skillsDir))) return {};
 

--- a/packages/sdk/src/context.ts
+++ b/packages/sdk/src/context.ts
@@ -56,7 +56,7 @@ export async function readAgentsMd(env: SessionEnv, basePath: string): Promise<s
 }
 
 /**
- * Load a skill directly by relative path under `.agents/skills/`.
+ * Resolve a skill referenced by relative path under `.agents/skills/`.
  *
  * The path is taken as-is — no extension is auto-appended. Callers reference
  * the full filename, e.g. `'triage/reproduce.md'`. Returns `null` if the file
@@ -66,6 +66,10 @@ export async function readAgentsMd(env: SessionEnv, basePath: string): Promise<s
  * a discovered skill's frontmatter `name:` field. Lets users organise skills as
  * a pack of sibling markdown files under one directory (orchestration SKILL.md
  * + stage files) without forcing each stage into its own `SKILL.md` subdirectory.
+ *
+ * Skill bodies are not cached — at call time the model reads the file from
+ * disk itself. We still parse the frontmatter here to recover the
+ * registered name and description for the system-prompt registry.
  */
 export async function loadSkillByPath(
 	env: SessionEnv,
@@ -86,11 +90,19 @@ export async function loadSkillByPath(
 	return {
 		name: parsed.name,
 		description: parsed.description,
-		instructions: parsed.body,
 	};
 }
 
-/** Discover skills from .agents/skills/<name>/SKILL.md under basePath. */
+/**
+ * Discover skills from `.agents/skills/<name>/SKILL.md` under basePath.
+ *
+ * Skill bodies are intentionally not retained — at call time the model
+ * reads the file from disk itself, which keeps relative references
+ * inside the skill resolvable from where they live and lets users edit
+ * skill files mid-session without re-initialising the agent. We parse
+ * the frontmatter here only to populate the system-prompt's "Available
+ * Skills" registry (name + description).
+ */
 export async function discoverLocalSkills(
 	env: SessionEnv,
 	basePath: string,
@@ -122,27 +134,45 @@ export async function discoverLocalSkills(
 		skills[parsed.name] = {
 			name: parsed.name,
 			description: parsed.description,
-			instructions: parsed.body,
 		};
 	}
 
 	return skills;
 }
 
+/**
+ * Headless-mode preamble. Included once at the top of every session's
+ * system prompt so the model knows it's running without a human operator
+ * before the first turn — and doesn't get reminded of it on every
+ * `prompt()` / `skill()` call. Previously this lived in
+ * `result.ts:buildPromptText` / `buildSkillPrompt` and was inlined into
+ * each per-call user message; that was redundant noise once the harness
+ * gained tool-call shape (it can't ask questions or wait for input
+ * regardless of what the user message says).
+ */
+export const HEADLESS_PREAMBLE =
+	'You are running in headless mode with no human operator. Work autonomously — never ask questions, never wait for user input. Make your best judgment and proceed independently.';
+
 export function composeSystemPrompt(
 	agentsMd: string,
 	skills: Record<string, Skill>,
 	env?: { cwd: string; directoryListing?: string[] },
 ): string {
-	const parts: string[] = [];
+	const parts: string[] = [HEADLESS_PREAMBLE];
 
-	if (agentsMd) parts.push(agentsMd);
+	if (agentsMd) parts.push('', agentsMd);
 
 	const skillEntries = Object.values(skills);
 	if (skillEntries.length > 0) {
-		parts.push('', '## Available Skills', '');
+		parts.push(
+			'',
+			'## Available Skills',
+			'',
+			'Each skill below is documented in a markdown file under `.agents/skills/` (relative to your working directory). The default location is `.agents/skills/<name>/SKILL.md`. When asked to run a skill, read its file from disk and follow the instructions there literally — the skill body is not provided inline.',
+			'',
+		);
 		for (const skill of skillEntries) {
-			const desc = skill.description ? ` - ${skill.description}` : '';
+			const desc = skill.description ? ` — ${skill.description}` : '';
 			parts.push(`- **${skill.name}**${desc}`);
 		}
 	}

--- a/packages/sdk/src/result.ts
+++ b/packages/sdk/src/result.ts
@@ -28,30 +28,50 @@ export function buildResultFollowUpPrompt(): string {
 }
 
 /**
- * Build the user-facing prompt text for a `session.skill()` call.
+ * Build the user-facing prompt text for a `session.skill('<name>')` call,
+ * where `<name>` is a name registered in the session's skill registry.
  *
- * Skill bodies are no longer inlined into the prompt — the model reads
- * the SKILL.md file from disk on demand using its filesystem tools.
- * That keeps relative references inside the skill (other markdown files,
- * scripts, etc.) resolvable from where they live, and lets users edit
- * skill files mid-session without re-initialising the agent. The
- * supplementary file-path hint is included only when the caller passed a
- * path-shaped name (i.e. the path-based fallback at the call site
- * resolved a SKILL by relative path) — for normal name-registered
- * skills, the system-prompt's "Available Skills" list is the only
- * registry the model needs to consult.
+ * The system prompt's "Available Skills" list tells the model where the
+ * skill lives (`.agents/skills/<name>/SKILL.md`) and how to run it (read
+ * the file, follow its instructions). The per-call message just names
+ * the skill plus any arguments — no inlined body, no path hint.
  */
-export function buildSkillPrompt(
+export function buildSkillByNamePrompt(
 	name: string,
 	args?: Record<string, unknown>,
 	schema?: v.GenericSchema,
-	path?: string,
 ): string {
 	const parts: string[] = [`Run the skill named "${name}".`];
 
-	if (path) {
-		parts.push('', `The skill is documented at ${path}.`);
+	if (args && Object.keys(args).length > 0) {
+		parts.push('', 'Arguments:', JSON.stringify(args, null, 2));
 	}
+
+	if (schema) {
+		parts.push(buildResultFooter());
+	}
+
+	return parts.join('\n');
+}
+
+/**
+ * Build the user-facing prompt text for a `session.skill('<path>')` call,
+ * where `<path>` is a relative path under `.agents/skills/` (e.g.
+ * `'triage/reproduce.md'`). Path-based references bypass the registry
+ * — the skill isn't named in the system prompt's "Available Skills"
+ * list — so we hand the model the resolved absolute path explicitly.
+ */
+export function buildSkillByPathPrompt(
+	relPath: string,
+	resolvedPath: string,
+	args?: Record<string, unknown>,
+	schema?: v.GenericSchema,
+): string {
+	const parts: string[] = [
+		`Run the skill file \`${relPath}\`.`,
+		'',
+		`The file can be found at ${resolvedPath}.`,
+	];
 
 	if (args && Object.keys(args).length > 0) {
 		parts.push('', 'Arguments:', JSON.stringify(args, null, 2));

--- a/packages/sdk/src/result.ts
+++ b/packages/sdk/src/result.ts
@@ -2,9 +2,6 @@ import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { toJsonSchema } from '@valibot/to-json-schema';
 import * as v from 'valibot';
 
-export const HEADLESS_PREAMBLE =
-	'You are running in headless mode with no human operator. Work autonomously — never ask questions, never wait for user input. Make your best judgment and proceed independently.';
-
 /**
  * Names of the SDK-injected tools used to capture schema-typed results.
  * Surfaced for diagnostics and logging; not part of the public API.
@@ -30,15 +27,34 @@ export function buildResultFollowUpPrompt(): string {
 	].join(' ');
 }
 
+/**
+ * Build the user-facing prompt text for a `session.skill()` call.
+ *
+ * Skill bodies are no longer inlined into the prompt — the model reads
+ * the SKILL.md file from disk on demand using its filesystem tools.
+ * That keeps relative references inside the skill (other markdown files,
+ * scripts, etc.) resolvable from where they live, and lets users edit
+ * skill files mid-session without re-initialising the agent. The
+ * supplementary file-path hint is included only when the caller passed a
+ * path-shaped name (i.e. the path-based fallback at the call site
+ * resolved a SKILL by relative path) — for normal name-registered
+ * skills, the system-prompt's "Available Skills" list is the only
+ * registry the model needs to consult.
+ */
 export function buildSkillPrompt(
-	skillInstructions: string,
+	name: string,
 	args?: Record<string, unknown>,
 	schema?: v.GenericSchema,
+	path?: string,
 ): string {
-	const parts: string[] = [HEADLESS_PREAMBLE, '', skillInstructions];
+	const parts: string[] = [`Run the skill named "${name}".`];
+
+	if (path) {
+		parts.push('', `The skill is documented at ${path}.`);
+	}
 
 	if (args && Object.keys(args).length > 0) {
-		parts.push(`\nArguments:\n${JSON.stringify(args, null, 2)}`);
+		parts.push('', 'Arguments:', JSON.stringify(args, null, 2));
 	}
 
 	if (schema) {
@@ -49,7 +65,7 @@ export function buildSkillPrompt(
 }
 
 export function buildPromptText(text: string, schema?: v.GenericSchema): string {
-	const parts: string[] = [HEADLESS_PREAMBLE, '', text];
+	const parts: string[] = [text];
 
 	if (schema) {
 		parts.push(buildResultFooter());

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -1,7 +1,7 @@
 /** Internal session implementation. Not exported publicly — wrapped by FlueSession. */
 import { Agent } from '@mariozechner/pi-agent-core';
 import type { AgentMessage, AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core';
-import type { AssistantMessage, Model, ToolResultMessage } from '@mariozechner/pi-ai';
+import type { AssistantMessage, Model, ToolResultMessage, UserMessage } from '@mariozechner/pi-ai';
 import type * as v from 'valibot';
 import { abortErrorFor, createCallHandle } from './abort.ts';
 import {
@@ -366,53 +366,66 @@ export class Session implements FlueSession {
 				// the one referenced by the toolResult, just like a real
 				// tool-use round.
 				const toolCallId = crypto.randomUUID();
-				const args = { command };
+
+				// Per-call cwd/env, when set, are part of the call's identity
+				// and need to be visible in the transcript. Without them the
+				// model can't tell on a later turn that a command ran with
+				// overrides — making questions like "what cwd was that run
+				// from?" unanswerable from history. The bash tool's own
+				// schema (BashParams) doesn't formally declare these, but
+				// pi-ai's ToolCall.arguments is `Record<string, any>` and
+				// providers forward arguments opaquely, so extending the
+				// shape here is safe.
+				const args: Record<string, unknown> = { command };
+				if (options?.cwd !== undefined) args.cwd = options.cwd;
+				if (options?.env !== undefined) args.env = options.env;
+
 				this.emit({ type: 'tool_start', toolName: 'bash', toolCallId, args });
 
 				const effectiveCommands = mergeCommands(this.agentCommands, options?.commands);
 				const env = await scopeSessionEnv(this.env, effectiveCommands);
 
-				let shellResult: ShellResult | undefined;
-				let toolResult: AgentToolResult<any>;
-				let isError = false;
 				try {
 					const result = await env.exec(command, {
 						env: options?.env,
 						cwd: options?.cwd,
 						signal,
 					});
-					shellResult = {
+					const shellResult: ShellResult = {
 						stdout: result.stdout,
 						stderr: result.stderr,
 						exitCode: result.exitCode,
 					};
-					toolResult = formatBashResult(shellResult, command);
-				} catch (error) {
-					isError = true;
-					toolResult = {
-						content: [{ type: 'text', text: getErrorMessage(error) }],
-						details: { command },
-					};
-					await this.appendShellTriple(command, toolCallId, toolResult, isError);
+					const toolResult = formatBashResult(shellResult, command);
+					await this.appendShellTriple(toolCallId, args, toolResult, false);
 					this.emit({
 						type: 'tool_end',
 						toolName: 'bash',
 						toolCallId,
-						isError,
+						isError: false,
 						result: toolResult,
+					});
+					return shellResult;
+				} catch (error) {
+					// Aligns with formatBashResult's `details: { command, exitCode }`
+					// shape so consumers reading event.result.details.exitCode see a
+					// number on both branches. -1 is the conventional sentinel for
+					// "no exit recorded" (the same one env.exec uses internally for
+					// sandbox-level failures — see sandbox.ts).
+					const errResult: AgentToolResult<any> = {
+						content: [{ type: 'text', text: getErrorMessage(error) }],
+						details: { command, exitCode: -1 },
+					};
+					await this.appendShellTriple(toolCallId, args, errResult, true);
+					this.emit({
+						type: 'tool_end',
+						toolName: 'bash',
+						toolCallId,
+						isError: true,
+						result: errResult,
 					});
 					throw error;
 				}
-
-				await this.appendShellTriple(command, toolCallId, toolResult, isError);
-				this.emit({
-					type: 'tool_end',
-					toolName: 'bash',
-					toolCallId,
-					isError,
-					result: toolResult,
-				});
-				return shellResult;
 			}),
 		);
 	}
@@ -823,25 +836,26 @@ export class Session implements FlueSession {
 	 * LLM-issued bash tool call when later turns read the transcript.
 	 */
 	private async appendShellTriple(
-		command: string,
 		toolCallId: string,
+		args: Record<string, unknown>,
 		toolResult: AgentToolResult<any>,
 		isError: boolean,
 	): Promise<void> {
 		const timestamp = Date.now();
-		const userMessage: AgentMessage = {
+		const command = args.command as string;
+		const userMessage: UserMessage = {
 			role: 'user',
 			content: `Run this shell command:\n\n\`\`\`bash\n${command}\n\`\`\``,
 			timestamp,
-		} as AgentMessage;
-		const assistantMessage: AgentMessage = {
+		};
+		const assistantMessage: AssistantMessage = {
 			role: 'assistant',
 			content: [
 				{
 					type: 'toolCall',
 					id: toolCallId,
 					name: 'bash',
-					arguments: { command },
+					arguments: args as Record<string, any>,
 				},
 			],
 			// Synthetic provider-bookkeeping fields. No real provider was
@@ -862,7 +876,7 @@ export class Session implements FlueSession {
 			},
 			stopReason: 'toolUse',
 			timestamp,
-		} as AgentMessage;
+		};
 		const toolResultMessage: ToolResultMessage = {
 			role: 'toolResult',
 			toolCallId,
@@ -873,7 +887,7 @@ export class Session implements FlueSession {
 			timestamp,
 		};
 		this.history.appendMessages(
-			[userMessage, assistantMessage, toolResultMessage as AgentMessage],
+			[userMessage, assistantMessage, toolResultMessage],
 			'shell',
 		);
 		this.harness.state.messages = this.history.buildContext();

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -23,13 +23,14 @@ import {
 import {
 	buildPromptText,
 	buildResultFollowUpPrompt,
-	buildSkillPrompt,
+	buildSkillByNamePrompt,
+	buildSkillByPathPrompt,
 	createResultTools,
 	ResultUnavailableError,
 	type ResultToolBundle,
 } from './result.ts';
 import { addUsage, emptyUsage, fromProviderUsage } from './usage.ts';
-import { loadSkillByPath } from './context.ts';
+import { resolveSkillFilePath, skillsDirIn } from './context.ts';
 import { createScopedEnv as scopeSessionEnv, mergeCommands } from './env-utils.ts';
 import {
 	assertRoleExists,
@@ -294,63 +295,55 @@ export class Session implements FlueSession {
 	skill(name: string, options?: SkillOptions<v.GenericSchema | undefined>): CallHandle<any> {
 		return createCallHandle(options?.signal, (signal) =>
 			this.runOperation('skill', signal, async () => {
-				// Skills can be referenced two ways:
+				// Skills can be referenced two ways. The shape determines the
+				// per-call user-message format; the model reads the file
+				// itself in both cases.
 				//
-				//   1. By registered name — looked up in `this.config.skills`,
+				//   1. By registered name. Looked up in `this.config.skills`,
 				//      populated at init time from `.agents/skills/*/SKILL.md`
-				//      frontmatter (or programmatically). This is the spec'd
-				//      shape; the system prompt's "Available Skills" list is
-				//      the registry the model consults.
+				//      frontmatter. The system prompt's "Available Skills"
+				//      list tells the model name + description + convention,
+				//      so the per-call message just identifies the skill.
 				//
 				//   2. By relative path under `.agents/skills/` (e.g.
-				//      `'triage/reproduce.md'`). Convenience for skill packs
-				//      that want sibling markdown files without forcing each
-				//      into its own SKILL.md subdirectory. Only attempted
-				//      when the name looks like a path (contains `/` or ends
-				//      in `.md`/`.markdown`) so that typos of registered
-				//      skill names still fail fast with a helpful error.
-				//
-				// Whichever shape resolved, the model reads the file from
-				// disk at runtime — we don't inline the body. For path-based
-				// references, we surface the path in the prompt so the model
-				// doesn't have to guess the skill's location.
-				let registeredSkill = this.config.skills[name];
-				let referencedPath: string | undefined;
-
-				if (!registeredSkill && (name.includes('/') || /\.(md|markdown)$/i.test(name))) {
-					const loaded = await loadSkillByPath(this.env, this.env.cwd, name);
-					if (loaded) {
-						registeredSkill = loaded;
-						const cwd = this.env.cwd;
-						const skillsDir = cwd.endsWith('/')
-							? `${cwd}.agents/skills`
-							: `${cwd}/.agents/skills`;
-						referencedPath = `${skillsDir}/${name}`;
-					}
-				}
-
-				if (!registeredSkill) {
-					const available = Object.keys(this.config.skills).join(', ') || '(none)';
-					const cwd = this.env.cwd;
-					throw new Error(
-						`Skill "${name}" not registered. Available: ${available}.\n\n` +
-							`Skills are loaded at init() time from ${cwd}/.agents/skills/<name>/SKILL.md ` +
-							`inside the session's sandbox. If you expected "${name}" to be there, make sure ` +
-							`the file exists in your sandbox at that path before calling init() — the default ` +
-							`empty sandbox starts with no files, so it has no skills unless you put them there.\n\n` +
-							`Skills can also be referenced by relative path under .agents/skills/ ` +
-							`(e.g. "triage/reproduce.md").`,
-					);
-				}
-
+				//      `'triage/reproduce.md'`). The skill isn't in the
+				//      registry, so we hand the model the resolved absolute
+				//      path explicitly. Triggered only when `name` looks
+				//      like a path (contains `/` or ends in `.md`/`.markdown`)
+				//      — otherwise typos of registered names fail fast with
+				//      a helpful error rather than silently fall through to
+				//      a path lookup that's also going to miss.
+				const looksLikePath = name.includes('/') || /\.(md|markdown)$/i.test(name);
 				const schema = options?.result as v.GenericSchema | undefined;
+
+				let promptText: string;
+				if (looksLikePath) {
+					const resolvedPath = await resolveSkillFilePath(this.env, this.env.cwd, name);
+					if (!resolvedPath) {
+						throw new Error(
+							`[flue] Skill file "${name}" not found at ${skillsDirIn(this.env.cwd)}/${name} ` +
+								`inside the session's sandbox. Make sure the file exists at that path.`,
+						);
+					}
+					promptText = buildSkillByPathPrompt(name, resolvedPath, options?.args, schema);
+				} else {
+					if (!this.config.skills[name]) {
+						const available = Object.keys(this.config.skills).join(', ') || '(none)';
+						throw new Error(
+							`[flue] Skill "${name}" not registered. Available: ${available}.\n\n` +
+								`Skills are discovered at init() time from ${skillsDirIn(this.env.cwd)}/<name>/SKILL.md ` +
+								`inside the session's sandbox. If you expected "${name}" to be there, make sure ` +
+								`the SKILL.md file exists at that path before calling init() — the default ` +
+								`empty sandbox starts with no files, so it has no skills unless you put them there.\n\n` +
+								`Skills can also be referenced by relative path under .agents/skills/ ` +
+								`(e.g. "triage/reproduce.md").`,
+						);
+					}
+					promptText = buildSkillByNamePrompt(name, options?.args, schema);
+				}
+
 				return this.runPromptCall({
-					promptText: buildSkillPrompt(
-						registeredSkill.name,
-						options?.args,
-						schema,
-						referencedPath,
-					),
+					promptText,
 					schema,
 					tools: options?.tools,
 					commands: options?.commands,

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -1,12 +1,13 @@
 /** Internal session implementation. Not exported publicly — wrapped by FlueSession. */
 import { Agent } from '@mariozechner/pi-agent-core';
 import type { AgentMessage, AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core';
-import type { AssistantMessage, Model } from '@mariozechner/pi-ai';
+import type { AssistantMessage, Model, ToolResultMessage } from '@mariozechner/pi-ai';
 import type * as v from 'valibot';
 import { abortErrorFor, createCallHandle } from './abort.ts';
 import {
 	BUILTIN_TOOL_NAMES,
 	createTools,
+	formatBashResult,
 	type TaskToolParams,
 	type TaskToolResultDetails,
 } from './agent.ts';
@@ -60,7 +61,6 @@ import type {
 	ToolDef,
 } from './types.ts';
 
-const MAX_SHELL_HISTORY_CHARS = 50 * 1024;
 const MAX_TASK_DEPTH = 4;
 
 export interface CreateTaskSessionOptions {
@@ -351,22 +351,67 @@ export class Session implements FlueSession {
 	shell(command: string, options?: ShellOptions): CallHandle<ShellResult> {
 		return createCallHandle(options?.signal, (signal) =>
 			this.runOperation('shell', signal, async () => {
+				// session.shell() is an out-of-band tool invocation: the caller
+				// (agent code) decides to run a bash command, but it should
+				// appear in the message history as if the model itself had
+				// called the bash tool. That keeps the transcript readable for
+				// later turns, lets compaction handle it via the same path as
+				// real tool calls, and removes the synthetic-user-message
+				// shape that earlier versions of this method produced.
+				//
+				// Concretely we emit the same tool_start/tool_end events the
+				// harness emits for LLM-driven tool calls, and we append a
+				// (user request, assistant tool_use, toolResult) message
+				// triple to history. The toolCallId we generate here matches
+				// the one referenced by the toolResult, just like a real
+				// tool-use round.
+				const toolCallId = crypto.randomUUID();
+				const args = { command };
+				this.emit({ type: 'tool_start', toolName: 'bash', toolCallId, args });
+
 				const effectiveCommands = mergeCommands(this.agentCommands, options?.commands);
 				const env = await scopeSessionEnv(this.env, effectiveCommands);
-				const result = await env.exec(command, {
-					env: options?.env,
-					cwd: options?.cwd,
-					signal,
+
+				let shellResult: ShellResult | undefined;
+				let toolResult: AgentToolResult<any>;
+				let isError = false;
+				try {
+					const result = await env.exec(command, {
+						env: options?.env,
+						cwd: options?.cwd,
+						signal,
+					});
+					shellResult = {
+						stdout: result.stdout,
+						stderr: result.stderr,
+						exitCode: result.exitCode,
+					};
+					toolResult = formatBashResult(shellResult, command);
+				} catch (error) {
+					isError = true;
+					toolResult = {
+						content: [{ type: 'text', text: getErrorMessage(error) }],
+						details: { command },
+					};
+					await this.appendShellTriple(command, toolCallId, toolResult, isError);
+					this.emit({
+						type: 'tool_end',
+						toolName: 'bash',
+						toolCallId,
+						isError,
+						result: toolResult,
+					});
+					throw error;
+				}
+
+				await this.appendShellTriple(command, toolCallId, toolResult, isError);
+				this.emit({
+					type: 'tool_end',
+					toolName: 'bash',
+					toolCallId,
+					isError,
+					result: toolResult,
 				});
-				const shellResult = {
-					stdout: result.stdout,
-					stderr: result.stderr,
-					exitCode: result.exitCode,
-				};
-				const message = this.createShellMessage(command, shellResult, options);
-				this.history.appendMessage(message, 'shell');
-				this.harness.state.messages = this.history.buildContext();
-				await this.save();
 				return shellResult;
 			}),
 		);
@@ -764,19 +809,75 @@ export class Session implements FlueSession {
 		}
 	}
 
-	private createShellMessage(
+	/**
+	 * Append the three-message conversational triple that represents a
+	 * `session.shell()` call in the message history:
+	 *
+	 *   1. user        — out-of-band request to run the command
+	 *   2. assistant   — synthetic turn whose content is a single bash
+	 *                    tool_use block (matching the shape pi-ai's
+	 *                    providers produce when the LLM itself calls bash)
+	 *   3. toolResult  — the bash output, keyed to the same toolCallId
+	 *
+	 * This makes a session.shell() call indistinguishable from an
+	 * LLM-issued bash tool call when later turns read the transcript.
+	 */
+	private async appendShellTriple(
 		command: string,
-		result: ShellResult,
-		options?: ShellOptions,
-	): AgentMessage {
-		const cwdLine = options?.cwd ? `\ncwd: ${options.cwd}` : '';
-		const envLine = options?.env ? `\nenv: ${Object.keys(options.env).sort().join(', ')}` : '';
-		const output = formatShellHistory(command, result, cwdLine, envLine);
-		return {
+		toolCallId: string,
+		toolResult: AgentToolResult<any>,
+		isError: boolean,
+	): Promise<void> {
+		const timestamp = Date.now();
+		const userMessage: AgentMessage = {
 			role: 'user',
-			content: [{ type: 'text', text: output }],
-			timestamp: Date.now(),
+			content: `Run this shell command:\n\n\`\`\`bash\n${command}\n\`\`\``,
+			timestamp,
 		} as AgentMessage;
+		const assistantMessage: AgentMessage = {
+			role: 'assistant',
+			content: [
+				{
+					type: 'toolCall',
+					id: toolCallId,
+					name: 'bash',
+					arguments: { command },
+				},
+			],
+			// Synthetic provider-bookkeeping fields. No real provider was
+			// involved in producing this turn; we use sentinel values that
+			// don't pretend otherwise. pi-ai's providers don't read these
+			// fields when transforming history for the next turn — they
+			// only inspect content and stopReason.
+			api: 'flue-shell',
+			provider: 'flue',
+			model: '',
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: 'toolUse',
+			timestamp,
+		} as AgentMessage;
+		const toolResultMessage: ToolResultMessage = {
+			role: 'toolResult',
+			toolCallId,
+			toolName: 'bash',
+			content: toolResult.content as ToolResultMessage['content'],
+			details: toolResult.details,
+			isError,
+			timestamp,
+		};
+		this.history.appendMessages(
+			[userMessage, assistantMessage, toolResultMessage as AgentMessage],
+			'shell',
+		);
+		this.harness.state.messages = this.history.buildContext();
+		await this.save();
 	}
 
 	private async syncHarnessMessagesSince(index: number, source: MessageSource): Promise<void> {
@@ -1181,31 +1282,6 @@ export async function deleteSessionTree(
 		}
 	}
 	await store.delete(storageKey);
-}
-
-function formatShellHistory(
-	command: string,
-	result: ShellResult,
-	cwdLine: string,
-	envLine: string,
-): string {
-	const sections = [
-		`<shell_command>\n$ ${command}${cwdLine}${envLine}\n</shell_command>`,
-		`<shell_result exitCode="${result.exitCode}">`,
-	];
-	if (result.stdout) sections.push(`<stdout>\n${result.stdout}\n</stdout>`);
-	if (result.stderr) sections.push(`<stderr>\n${result.stderr}\n</stderr>`);
-	sections.push('</shell_result>');
-	return truncateShellHistory(sections.join('\n'));
-}
-
-function truncateShellHistory(text: string): string {
-	if (text.length <= MAX_SHELL_HISTORY_CHARS) return text;
-	const truncated = text.length - MAX_SHELL_HISTORY_CHARS;
-	return (
-		`[Shell output truncated: ${truncated} leading characters omitted]\n` +
-		text.slice(text.length - MAX_SHELL_HISTORY_CHARS)
-	);
 }
 
 function getErrorMessage(error: unknown): string {

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -294,14 +294,39 @@ export class Session implements FlueSession {
 	skill(name: string, options?: SkillOptions<v.GenericSchema | undefined>): CallHandle<any> {
 		return createCallHandle(options?.signal, (signal) =>
 			this.runOperation('skill', signal, async () => {
+				// Skills can be referenced two ways:
+				//
+				//   1. By registered name — looked up in `this.config.skills`,
+				//      populated at init time from `.agents/skills/*/SKILL.md`
+				//      frontmatter (or programmatically). This is the spec'd
+				//      shape; the system prompt's "Available Skills" list is
+				//      the registry the model consults.
+				//
+				//   2. By relative path under `.agents/skills/` (e.g.
+				//      `'triage/reproduce.md'`). Convenience for skill packs
+				//      that want sibling markdown files without forcing each
+				//      into its own SKILL.md subdirectory. Only attempted
+				//      when the name looks like a path (contains `/` or ends
+				//      in `.md`/`.markdown`) so that typos of registered
+				//      skill names still fail fast with a helpful error.
+				//
+				// Whichever shape resolved, the model reads the file from
+				// disk at runtime — we don't inline the body. For path-based
+				// references, we surface the path in the prompt so the model
+				// doesn't have to guess the skill's location.
 				let registeredSkill = this.config.skills[name];
+				let referencedPath: string | undefined;
 
-				// Fallback: file-path lookup under .agents/skills/. Only attempted when the
-				// name looks like a path (contains `/` or ends in `.md`/`.markdown`) so that
-				// typos of registered skill names still fail fast with a helpful error.
 				if (!registeredSkill && (name.includes('/') || /\.(md|markdown)$/i.test(name))) {
 					const loaded = await loadSkillByPath(this.env, this.env.cwd, name);
-					if (loaded) registeredSkill = loaded;
+					if (loaded) {
+						registeredSkill = loaded;
+						const cwd = this.env.cwd;
+						const skillsDir = cwd.endsWith('/')
+							? `${cwd}.agents/skills`
+							: `${cwd}/.agents/skills`;
+						referencedPath = `${skillsDir}/${name}`;
+					}
 				}
 
 				if (!registeredSkill) {
@@ -320,7 +345,12 @@ export class Session implements FlueSession {
 
 				const schema = options?.result as v.GenericSchema | undefined;
 				return this.runPromptCall({
-					promptText: buildSkillPrompt(registeredSkill.instructions, options?.args, schema),
+					promptText: buildSkillPrompt(
+						registeredSkill.name,
+						options?.args,
+						schema,
+						referencedPath,
+					),
 					schema,
 					tools: options?.tools,
 					commands: options?.commands,

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -689,7 +689,6 @@ export class Session implements FlueSession {
 				result: getErrorMessage(error),
 				parentSessionId: this.id,
 			});
-			this.emit({ type: 'error', error: getErrorMessage(error) });
 			throw error;
 		} finally {
 			if (signal && abortListener) signal.removeEventListener('abort', abortListener);
@@ -725,9 +724,12 @@ export class Session implements FlueSession {
 			} catch (error) {
 				// After the signal aborts, anything thrown downstream is
 				// post-abort fallout (harness, tools, compaction). Surface
-				// a single AbortError shape to callers.
+				// a single AbortError shape to callers. Failures propagate
+				// to the caller via throw — operation-end events
+				// (task_end isError, tool_end isError) carry the same
+				// information for in-process observers, so we don't emit a
+				// separate 'error' event here.
 				const surfaced = signal?.aborted ? abortErrorFor(signal) : error;
-				this.emit({ type: 'error', error: getErrorMessage(surfaced) });
 				throw surfaced;
 			} finally {
 				signal?.removeEventListener('abort', onAbort);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -593,7 +593,6 @@ export type FlueEvent = (
 	| { type: 'compaction_start'; reason: 'threshold' | 'overflow'; estimatedTokens: number }
 	| { type: 'compaction_end'; messagesBefore: number; messagesAfter: number }
 	| { type: 'idle' }
-	| { type: 'error'; error: string }
 ) & { sessionId?: string; parentSessionId?: string; taskId?: string };
 
 export type FlueEventCallback = (event: FlueEvent) => void;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -6,11 +6,17 @@ export type { ThinkingLevel };
 
 // ─── Skill ──────────────────────────────────────────────────────────────────
 
+/**
+ * A skill registered with the session. The body of the skill (everything
+ * below the frontmatter in `SKILL.md`) is intentionally NOT cached in
+ * memory — at call time, the model reads the file from disk via its
+ * filesystem tools. That keeps relative references inside the skill
+ * resolvable from where they live, and lets users edit skill files
+ * mid-session without re-initialising the agent.
+ */
 export interface Skill {
 	name: string;
 	description: string;
-	/** Markdown body of SKILL.md (below the frontmatter). */
-	instructions: string;
 }
 
 // ─── Role ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Three related fixes/refactors to how Flue sessions emit events and represent
in-session work in the message history. Each commit is independently
revertable.

### What's fixed/changed

- **`fix(sdk): stop emitting redundant 'error' SessionEvent on caught failures`** —
  `session.task()` and `session.runOperation()` were emitting a `SessionEvent`
  with `type: 'error'` alongside the throw whenever a session operation failed.
  Two problems: the wire shape (`{ type: 'error', error: <string> }`) collided
  with the canonical wire-error envelope (`{ type: 'error', error: { type,
  message, ... } }`) produced by `toSseData()`, so the CLI rendered
  `[flue] ERROR [unknown]:` for caught aborts; and the in-stream error event
  was treated as terminal by the CLI, discarding any subsequently-arriving
  `result` event. Failures already propagate via throw and via `task_end`/
  `tool_end`'s `isError` field — the extra emit was double-bookkeeping.

- **`feat(sdk): make session.shell() behave like an LLM-issued bash tool call`** —
  Previously, `session.shell()` ran `env.exec()` directly and persisted a single
  synthetic `user` message wrapping the command/result in
  `<shell_command>`/`<shell_result>` XML tags. That worked but read
  awkwardly to the LLM on subsequent turns. Now `session.shell()` emits
  `tool_start`/`tool_end` events (matching the harness's LLM-driven shape)
  and appends a three-message conversational triple to history:
  `user → assistant tool_use → toolResult`. Reuses `formatBashResult()` so
  the output formatting is byte-identical to LLM-issued bash calls. The
  `cb2ccc6` review-fix commit follows up with `cwd`/`env` preservation in
  the synthetic tool_use's arguments and tightens the function body.

- **`feat(sdk): reference skills by name; read SKILL.md from disk on demand`** —
  `session.skill()` previously inlined the entire SKILL.md body into the
  per-call prompt. Two consequences: relative references inside the skill
  (other markdown files, scripts, etc.) lost their spatial anchor, and skill
  bodies had to be cached in memory at init time. This restructures the call
  so the skill is referenced by name (or by path, if the caller passed a
  path) and the model reads the file from disk on demand using its
  filesystem tools. `Skill.instructions` is removed from the public type;
  `discoverLocalSkills` and `resolveSkillFilePath` no longer retain body
  text. `HEADLESS_PREAMBLE` moves out of `result.ts` and into
  `composeSystemPrompt` as the first line of every session's system prompt
  — once-per-session instead of once-per-call. The `a42cd86` follow-up
  splits `buildSkillPrompt` into name-based and path-based variants and
  removes duplicated path computation.

### Verification

All five commits verified end-to-end against `examples/hello-world` agents:

- `with-skill` (sandbox: 'local', reads `.agents/skills/greet/SKILL.md`):
  5/5 runs read the skill from disk via the read tool; greetings honor
  the SKILL.md's "one or two sentences" instruction.
- `with-abort` (exercises caught aborts via prompt and shell): exits cleanly
  with results printed; no spurious `[flue] ERROR [unknown]` lines.
- `hello`, `with-role`, `with-sandbox`, `fs-test`: unchanged in behavior.

### Public API impact

- `Skill.instructions` field removed (was internal — only consumed by
  `buildSkillPrompt`).
- `FlueEvent` no longer includes the `{ type: 'error'; error: string }`
  variant. The wire-error path (`toSseData()`) is unchanged.
- `session.shell()` public signature/return value unchanged. On-disk message
  history shape changes: new sessions get the three-message triple; existing
  persisted sessions with the old single-`user` message format continue to
  work (text content was always plain).
