### PR TITLE
Document sandbox connector cancellation semantics

### DIFF
--- a/connectors/sandbox.md
+++ b/connectors/sandbox.md
@@ -50,6 +50,13 @@ These are the things that aren't obvious from the spec or the example.
   the user if their layout is unusual.
 - **Imports.** The published surface is `@flue/sdk/sandbox`. Don't import
   from `@flue/sdk/internal` or any other internal path.
+- **Cancellation.** `SandboxApi.exec()` receives both `timeout` and `signal`.
+  Treat them differently: `timeout` is recoverable command-level timeout
+  behavior, while `signal` is caller-driven cancellation. If the provider has
+  a real cancellation primitive, wire `signal` into it. If it doesn't, check
+  `signal.aborted` before and after the provider call and be explicit about
+  the limitation. Don't pretend a remote command was stopped unless the
+  provider actually stops it.
 - **Credentials.** If the provider needs secrets at runtime, never invent
   values for them. Let the project's conventions (`AGENTS.md`, an existing
   `.env` / `.dev.vars`, a secret manager, CI vars, etc.) decide where they

--- a/docs/sandbox-connector-spec.md
+++ b/docs/sandbox-connector-spec.md
@@ -105,7 +105,12 @@ export interface SandboxApi {
   rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void>;
   exec(
     command: string,
-    options?: { cwd?: string; env?: Record<string, string>; timeout?: number },
+    options?: {
+      cwd?: string;
+      env?: Record<string, string>;
+      timeout?: number;
+      signal?: AbortSignal;
+    },
   ): Promise<{ stdout: string; stderr: string; exitCode: number }>;
 }
 ```
@@ -187,9 +192,24 @@ Delete a file or directory. Honor `options.recursive` and `options.force`.
 ### `exec(command, options?) → Promise<{ stdout, stderr, exitCode }>`
 
 Run a shell command. Honor `options.cwd`, `options.env`, and
-`options.timeout` if your provider supports them. If `stderr` is not
-separately surfaced, return `''` for it; do the same for `exitCode` if
-unavailable, defaulting to `0` only when the call clearly succeeded.
+`options.timeout` if your provider supports them.
+
+Honor `options.signal` for caller-driven cancellation whenever the provider
+has a real cancellation primitive (`AbortSignal`, process kill, cancel token,
+etc.). If the provider cannot cancel an in-flight command, still check
+`options.signal.aborted` before starting the command and after it returns, and
+throw the abort reason (or an `AbortError`) when already aborted. Do not claim
+that cancellation stops the remote process unless it really does.
+
+`timeout` and `signal` intentionally have different semantics in Flue:
+`timeout` is for the LLM-facing bash tool and should return a normal
+`ShellResult` that the model can recover from; `signal` is caller-driven
+cancellation and should reject/throw instead of returning a successful-looking
+result.
+
+If `stderr` is not separately surfaced, return `''` for it; do the same for
+`exitCode` if unavailable, defaulting to `0` only when the call clearly
+succeeded.
 
 ---
 


### PR DESCRIPTION
## Summary

- update the canonical sandbox connector spec to include `signal?: AbortSignal` on `SandboxApi.exec()`
- document the intended distinction between numeric `timeout` and caller-driven `signal` cancellation
- add the same cancellation guidance to the generic `flue add <url> --category sandbox` instructions so generated connectors investigate real provider cancellation instead of silently dropping it

## Context

Flue core now threads `AbortSignal` through prompt/skill/task/shell calls and down into `SessionEnv.exec()`. The SDK type already exposes `signal?: AbortSignal`, but the canonical connector spec still showed the older `{ cwd, env, timeout }` shape.

This matters for future sandbox connectors: a connector should wire `signal` into a real provider cancellation primitive when one exists, and be explicit when a provider can only check before/after execution. It should also keep `timeout` and `signal` semantics separate: `timeout` returns a recoverable shell result, while caller cancellation should abort/reject.

## Verification

- `pnpm exec tsx packages/cli/scripts/generate-connector-index.ts`
- `pnpm --filter @flue/cli build`
