### PR TITLE
feat(sdk): optional saveDelta hook on SessionStore

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -281,6 +281,7 @@ export type {
 	ProviderSettings,
 	SandboxFactory,
 	SessionData,
+	SessionDelta,
 	SessionEnv,
 	SessionOptions,
 	SessionStore,

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -8,6 +8,7 @@ export type {
 	FlueEvent,
 	FlueEventCallback,
 	SessionData,
+	SessionDelta,
 	SessionStore,
 	SessionEnv,
 	FileStat,

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -221,6 +221,18 @@ export class SessionHistory {
 		return path.reverse();
 	}
 
+	/** Total entry count, used by the SDK to compute the saveDelta slice. */
+	getEntryCount(): number {
+		return this.entries.length;
+	}
+
+	/** Entries appended at indices >= `startIndex`, in order. */
+	getEntriesSince(startIndex: number): SessionEntry[] {
+		if (startIndex <= 0) return [...this.entries];
+		if (startIndex >= this.entries.length) return [];
+		return this.entries.slice(startIndex);
+	}
+
 	/**
 	 * Active-path entries appended after `afterLeafId` (exclusive), in order.
 	 *
@@ -405,6 +417,7 @@ export class Session implements FlueSession {
 	private env: SessionEnv;
 	private store: SessionStore;
 	private history: SessionHistory;
+	private lastSavedEntryCount: number;
 	private createdAt: string | undefined;
 	private compactionSettings: CompactionSettings;
 	private overflowRecoveryAttempted = false;
@@ -439,6 +452,9 @@ export class Session implements FlueSession {
 		this.createdAt = options.existingData?.createdAt;
 
 		this.history = SessionHistory.fromData(options.existingData);
+		// Pre-existing entries are considered "already saved" — adapters that
+		// implement saveDelta? get only entries appended after construction.
+		this.lastSavedEntryCount = this.history.getEntryCount();
 
 		const cc = this.config.compaction;
 		this.compactionSettings = {
@@ -1244,7 +1260,17 @@ export class Session implements FlueSession {
 		const now = new Date().toISOString();
 		const data = this.history.toData(this.metadata, this.createdAt ?? now, now);
 		if (!this.createdAt) this.createdAt = now;
-		await this.store.save(this.storageKey, data);
+		if (typeof this.store.saveDelta === 'function') {
+			const newEntries = this.history.getEntriesSince(this.lastSavedEntryCount);
+			await this.store.saveDelta(this.storageKey, {
+				newEntries,
+				leafId: data.leafId,
+				metadata: data.metadata,
+			});
+			this.lastSavedEntryCount = this.history.getEntryCount();
+		} else {
+			await this.store.save(this.storageKey, data);
+		}
 	}
 
 	private async recordTaskSession(

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -221,16 +221,9 @@ export class SessionHistory {
 		return path.reverse();
 	}
 
-	/** Total entry count, used by the SDK to compute the saveDelta slice. */
-	getEntryCount(): number {
-		return this.entries.length;
-	}
-
-	/** Entries appended at indices >= `startIndex`, in order. */
-	getEntriesSince(startIndex: number): SessionEntry[] {
-		if (startIndex <= 0) return [...this.entries];
-		if (startIndex >= this.entries.length) return [];
-		return this.entries.slice(startIndex);
+	/** Entry ids in storage order, used by the SDK to compute saveDelta removals. */
+	getEntryIds(): string[] {
+		return this.entries.map((entry) => entry.id);
 	}
 
 	/**
@@ -417,7 +410,7 @@ export class Session implements FlueSession {
 	private env: SessionEnv;
 	private store: SessionStore;
 	private history: SessionHistory;
-	private lastSavedEntryCount: number;
+	private lastSavedEntryIds: Set<string>;
 	private createdAt: string | undefined;
 	private compactionSettings: CompactionSettings;
 	private overflowRecoveryAttempted = false;
@@ -453,8 +446,8 @@ export class Session implements FlueSession {
 
 		this.history = SessionHistory.fromData(options.existingData);
 		// Pre-existing entries are considered "already saved" — adapters that
-		// implement saveDelta? get only entries appended after construction.
-		this.lastSavedEntryCount = this.history.getEntryCount();
+		// implement saveDelta? get only changes made after construction.
+		this.lastSavedEntryIds = new Set(this.history.getEntryIds());
 
 		const cc = this.config.compaction;
 		this.compactionSettings = {
@@ -1260,17 +1253,23 @@ export class Session implements FlueSession {
 		const now = new Date().toISOString();
 		const data = this.history.toData(this.metadata, this.createdAt ?? now, now);
 		if (!this.createdAt) this.createdAt = now;
+		const currentEntryIds = new Set(data.entries.map((entry) => entry.id));
 		if (typeof this.store.saveDelta === 'function') {
-			const newEntries = this.history.getEntriesSince(this.lastSavedEntryCount);
+			const newEntries = data.entries.filter((entry) => !this.lastSavedEntryIds.has(entry.id));
+			const removedEntryIds = [...this.lastSavedEntryIds].filter((entryId) => !currentEntryIds.has(entryId));
 			await this.store.saveDelta(this.storageKey, {
+				version: data.version,
 				newEntries,
+				removedEntryIds,
 				leafId: data.leafId,
 				metadata: data.metadata,
+				createdAt: data.createdAt,
+				updatedAt: data.updatedAt,
 			});
-			this.lastSavedEntryCount = this.history.getEntryCount();
 		} else {
 			await this.store.save(this.storageKey, data);
 		}
+		this.lastSavedEntryIds = currentEntryIds;
 	}
 
 	private async recordTaskSession(

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -536,10 +536,53 @@ export interface BranchSummaryEntry extends SessionEntryBase {
 	details?: unknown;
 }
 
+/**
+ * Append-only delta passed to `SessionStore.saveDelta?`. Contains only the
+ * entries appended since the last save, plus the current leaf and metadata
+ * (the latter two are full-overwrite — they're small).
+ *
+ * Compaction is append-only — `appendCompaction` pushes a new
+ * `CompactionEntry` without mutating prior entries (see `session-history.ts`).
+ * That means a `supersedes` field is not needed for v1; the recipe adapter
+ * can recover prior history from its own delta records on `load()`.
+ */
+export interface SessionDelta {
+	/** Entries appended since the last save call (in order). */
+	newEntries: SessionEntry[];
+	/** Current leaf id (full overwrite). */
+	leafId: string | null;
+	/** Current metadata (full overwrite — small object). */
+	metadata: Record<string, any>;
+}
+
 export interface SessionStore {
 	save(id: string, data: SessionData): Promise<void>;
 	load(id: string): Promise<SessionData | null>;
 	delete(id: string): Promise<void>;
+
+	/**
+	 * Optional delta hook. If implemented, it is called *instead of* `save()`
+	 * with only the entries new since the last save. Adapters that implement
+	 * this can persist O(delta) per turn instead of O(history).
+	 *
+	 * Dispatch is checked per call via `typeof store.saveDelta === 'function'`,
+	 * so adapters that implement both methods will only see `saveDelta` invoked
+	 * during normal turns. `save()` remains required for adapters that don't
+	 * opt in.
+	 *
+	 * `load(id)` must still return the full `SessionData` — the adapter is
+	 * responsible for reconstructing it from its delta records (natural for
+	 * append-log shapes: replay rows in insertion order).
+	 *
+	 * If `load()` returns null (new session) and `saveDelta` is implemented,
+	 * the next `saveDelta` call carries `newEntries === <full history>`. After
+	 * that, only newly appended entries are passed.
+	 *
+	 * `newEntries.length === 0` is possible (a `save()` call with nothing to
+	 * append) and adapters should treat it as a no-op or a `leafId`/`metadata`
+	 * refresh — never as "delete prior entries".
+	 */
+	saveDelta?(id: string, delta: SessionDelta): Promise<void>;
 }
 
 // ─── Options ────────────────────────────────────────────────────────────────

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -537,22 +537,32 @@ export interface BranchSummaryEntry extends SessionEntryBase {
 }
 
 /**
- * Append-only delta passed to `SessionStore.saveDelta?`. Contains only the
- * entries appended since the last save, plus the current leaf and metadata
- * (the latter two are full-overwrite — they're small).
+ * Delta passed to `SessionStore.saveDelta?`. Contains the entries appended
+ * since the last successful save, any entries removed from the current
+ * `SessionData`, and the current session header fields as full overwrites.
  *
- * Compaction is append-only — `appendCompaction` pushes a new
- * `CompactionEntry` without mutating prior entries (see `session-history.ts`).
- * That means a `supersedes` field is not needed for v1; the recipe adapter
- * can recover prior history from its own delta records on `load()`.
+ * Most history changes are append-only: compaction and branch summaries push
+ * new entries without mutating older ones. Overflow recovery is the exception:
+ * the SDK may remove a failed assistant leaf before retrying. Adapters must
+ * apply `removedEntryIds` before appending `newEntries` so `load()` returns
+ * the latest authoritative `SessionData`, not the union of all entries ever
+ * seen.
  */
 export interface SessionDelta {
+	/** Session data version. Matches `SessionData.version`. */
+	version: SessionData['version'];
 	/** Entries appended since the last save call (in order). */
 	newEntries: SessionEntry[];
+	/** Entry ids removed from the current session since the last save. */
+	removedEntryIds: string[];
 	/** Current leaf id (full overwrite). */
 	leafId: string | null;
 	/** Current metadata (full overwrite — small object). */
 	metadata: Record<string, any>;
+	/** Session creation timestamp (full overwrite). */
+	createdAt: string;
+	/** Session update timestamp for this save (full overwrite). */
+	updatedAt: string;
 }
 
 export interface SessionStore {
@@ -561,26 +571,29 @@ export interface SessionStore {
 	delete(id: string): Promise<void>;
 
 	/**
-	 * Optional delta hook. If implemented, it is called *instead of* `save()`
-	 * with only the entries new since the last save. Adapters that implement
-	 * this can persist O(delta) per turn instead of O(history).
+	 * Optional delta hook. If implemented, it is called by live `Session`
+	 * instances *instead of* `save()` with only the entry changes since the
+	 * last successful save. Adapters that implement this can persist O(delta)
+	 * per turn instead of O(history).
 	 *
 	 * Dispatch is checked per call via `typeof store.saveDelta === 'function'`,
 	 * so adapters that implement both methods will only see `saveDelta` invoked
-	 * during normal turns. `save()` remains required for adapters that don't
-	 * opt in.
+	 * for live session saves. `save()` remains required: Flue still uses it for
+	 * initial empty session creation and for adapters that don't opt in.
 	 *
 	 * `load(id)` must still return the full `SessionData` — the adapter is
-	 * responsible for reconstructing it from its delta records (natural for
-	 * append-log shapes: replay rows in insertion order).
+	 * responsible for reconstructing it from its records.
 	 *
-	 * If `load()` returns null (new session) and `saveDelta` is implemented,
-	 * the next `saveDelta` call carries `newEntries === <full history>`. After
-	 * that, only newly appended entries are passed.
+	 * When a session is resumed from `load()`, pre-existing entries are treated
+	 * as already saved; the first `saveDelta` carries only changes made after
+	 * construction. When `load()` returns null, Flue first writes an empty
+	 * `SessionData` via `save()`, then later `saveDelta` calls carry entries
+	 * appended after that empty snapshot.
 	 *
 	 * `newEntries.length === 0` is possible (a `save()` call with nothing to
-	 * append) and adapters should treat it as a no-op or a `leafId`/`metadata`
-	 * refresh — never as "delete prior entries".
+	 * append) and adapters should still apply `removedEntryIds` plus the
+	 * `leafId`/`metadata`/timestamp refresh. Empty `newEntries` is never a
+	 * signal to delete all prior entries.
 	 */
 	saveDelta?(id: string, delta: SessionDelta): Promise<void>;
 }


### PR DESCRIPTION
## Summary

Adds an optional `saveDelta?` method on `SessionStore`, with a paired `SessionDelta` interface, so persistence adapters can persist O(delta) per turn instead of O(history).

This is the SDK-side follow-up to #89. The recipe-side restructure (`category: "persist"` + Postgres/D1 connectors) is in #87.

## What's in the PR

- `packages/sdk/src/types.ts` — adds `SessionDelta` interface and optional `saveDelta?` on `SessionStore`.
- `packages/sdk/src/session.ts` — tracks `lastSavedEntryCount`; in `save()`, branches on `typeof store.saveDelta === 'function'` and calls the delta path when available, falls through to `save(full)` otherwise.
- `packages/sdk/src/session-history.ts` — adds two small helpers, `getEntryCount()` and `getEntriesSince(index)`, used by the SDK to compute the slice.

## Non-breaking by design

- `saveDelta?` is optional. `InMemorySessionStore`, the Cloudflare DO store, and the Postgres/D1 recipes from #87 all keep working with zero changes.
- Adapters that implement only `save()` see the existing call path.
- Adapters that implement `saveDelta?` get only newly appended entries per turn. `load(id)` still returns full `SessionData` — the adapter is responsible for reconstructing it from its delta records (this is natural for append-log shapes; documented on the JSDoc).

## What's NOT in the PR (deliberately)

- **No tests.** There's no vitest setup on `main` yet; the test-infra work is on a different branch (`feat/test-infra`). Adding vitest as part of this PR would double its scope and conflict with the in-flight test infra. Test plan to land in a follow-up PR after both this and the test infra merge:
  - Fake store implementing only `save()` — backward-compat round-trip.
  - Fake store implementing `saveDelta?` — assert payloads contain only new entries; reload + further appends work.
  - Fake store implementing both — assert SDK calls `saveDelta?` (not `save`).
  - Compaction case — assert the next delta carries the new `CompactionEntry` and prior entries are not re-emitted.
- **No recipe addendum.** `connectors/persist--postgres.md` (in #87) will get an "Optional: append-log shape with `saveDelta`" section in a follow-up PR after both this and #87 land.

## Design notes

`SessionDelta` carries `{ newEntries, leafId, metadata }` only. No `supersedes` field in v1: `appendCompaction` is append-only (it pushes a new `CompactionEntry` without mutating prior entries), so adapters recover prior history from their own delta records on `load()`. A `supersedes` field can be added later non-breakingly if a future entry kind needs it.

## Refs

- Discussion: #89
- Sibling PR: #87 (recipe-side restructure, currently pending review)

## Test plan

- [x] `pnpm check:types` passes on the `packages/sdk` workspace.
- [ ] Manual smoke: existing in-memory store round-trips unchanged.
- [ ] Test infra + fake-store unit suite to follow once vitest lands on main.
