### PR TITLE
feat(sdk): ProviderSettings.storeResponses for OpenAI Responses API

### DIFF
--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -51,6 +51,7 @@ import type {
 	PromptResponse,
 	PromptResultResponse,
 	PromptUsage,
+	ProvidersConfig,
 	SessionData,
 	SessionEnv,
 	SessionStore,
@@ -120,6 +121,30 @@ interface InternalTaskResult<T> {
 interface InternalTaskOptions<S extends v.GenericSchema | undefined> extends TaskOptions<S> {
 	inheritedModel?: string;
 	inheritedThinkingLevel?: ThinkingLevel;
+}
+
+/**
+ * Build an `onPayload` hook that injects `store: <bool>` into OpenAI Responses
+ * API request payloads when the user has set
+ * `providers.openai.storeResponses`. Returns undefined when the knob is unset
+ * so pi-ai's default (no hook) keeps applying. The hook is a no-op for any
+ * model whose `api !== 'openai-responses'` (Codex, Azure, Anthropic, etc.).
+ *
+ * Resolves the user-facing 404 reported in flue#77: pi-ai hardcodes
+ * `store: false` on the OpenAI Responses provider, so item references
+ * (`fc_*`, `msg_*`) emitted on subsequent multi-turn calls 404 against items
+ * the server never persisted.
+ */
+function buildOpenAIStorePayloadHook(
+	providers: ProvidersConfig | undefined,
+): ((payload: unknown, model: Model<any>) => unknown) | undefined {
+	const storeResponses = providers?.openai?.storeResponses;
+	if (storeResponses === undefined) return undefined;
+	return (payload, model) => {
+		if (model.api !== 'openai-responses') return undefined;
+		if (typeof payload !== 'object' || payload === null) return undefined;
+		return { ...(payload as Record<string, unknown>), store: storeResponses };
+	};
 }
 
 /** In-memory session store. Sessions persist for the lifetime of the process. */
@@ -214,6 +239,7 @@ export class Session implements FlueSession {
 			},
 			getApiKey: (provider) => this.getProviderApiKey(provider),
 			toolExecution: 'parallel',
+			onPayload: buildOpenAIStorePayloadHook(this.config.providers),
 		});
 
 		this.eventCallback = options.onAgentEvent;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -161,6 +161,18 @@ export interface ProviderSettings {
 	 * come from the agent's runtime env instead of process-global env vars.
 	 */
 	apiKey?: string;
+	/**
+	 * Persist OpenAI Responses API calls server-side so that `msg_*` / `fc_*`
+	 * item references emitted on later turns resolve. Required for multi-turn
+	 * `session.task()` flows that rely on item-id linkage (see flue#77). Only
+	 * applied when the resolved model's `api === "openai-responses"`; ignored
+	 * for Codex, Azure, and other provider APIs.
+	 *
+	 * Default unset → pi-ai's current behavior (`store: false`). Note: enabling
+	 * this opts the conversation into OpenAI's server-side storage and its
+	 * retention policy.
+	 */
+	storeResponses?: boolean;
 }
 
 export type ProvidersConfig = Record<string, ProviderSettings>;


### PR DESCRIPTION
## Summary

Adds an opt-in `providers.openai.storeResponses?: boolean` knob on `ProviderSettings`. When set, the SDK injects `store: <bool>` into OpenAI Responses API request payloads via an `onPayload` hook on the underlying agent runtime. Default unset preserves current behavior.

Resolves the multi-turn 404 reported in #77.

## Why

pi-ai (`@mariozechner/pi-ai`) hardcodes `store: false` on the OpenAI Responses provider. The conversation converter then emits per-item references (`fc_*`, `msg_*`) on subsequent turns, but those items never get persisted server-side. So a second `session.prompt()` or `session.task()` call on the same session returns a 404 from OpenAI: "Items are not persisted when store is set to false."

The runtime exposes an `onPayload` hook that lets us mutate the request just before it's sent. Wiring `store: true` through that hook is non-breaking and avoids forking pi-ai.

## What's in this PR

- `packages/sdk/src/types.ts` — adds `storeResponses?: boolean` to `ProviderSettings`. Doc-commented with the multi-turn use case + the data-retention trade-off.
- `packages/sdk/src/session.ts`:
  - Adds a private `buildOpenAIStorePayloadHook(providers)` helper that returns an `onPayload` callback (or `undefined` when the knob is unset).
  - The callback is `model.api === 'openai-responses'` guarded — it's a no-op for Codex (which rejects `store: true`), Azure, Anthropic, and every other provider.
  - Wires the hook into the `Agent` constructor at session init.

Net diff: +38 / -0 across 2 files.

## Non-breaking by design

- Default unset → no hook is attached → pi-ai's existing payload (`store: false`) ships unchanged.
- `model.api` guard means non-OpenAI-Responses models never see the mutation.
- Codex specifically rejects `store: true` server-side; the guard prevents that path from ever firing for `openai-codex-responses`.

## Usage

```ts
init({
  providers: { openai: { storeResponses: true } },
});
```

## What's NOT in the PR

- **No tests.** No vitest setup on `main` yet; matching the same deferral pattern as #95. Fake-stream + payload-assertion tests will land in a follow-up after the test infra branch (`feat/test-infra`) merges.

## Design notes

The flat `storeResponses: boolean` shape was chosen over a nested `openai: { store: boolean }` for readability. If reviewers prefer the nested shape (e.g. to keep room for future Responses-only flags like `service_tier` or `prompt_cache_retention`), happy to reshape — discussed in MEMO.

The naming (`storeResponses` vs `store`) is intentional. `store` would be ambiguous with persistence-layer concepts (the `SessionStore` interface uses the same word for client-side persistence). `storeResponses` makes it clear this is server-side conversation storage on the provider, distinct from any local persistence the user has wired up.

## Open question (verified, no blocker)

Per RECIPE.md analysis: in pi-ai's openai-responses provider, the conversation converter currently passes per-item `id`s but does not set `previous_response_id`. OpenAI's Responses API supports both linking strategies. Setting `store: true` alone is sufficient — the per-item references resolve once items are persisted. If a future change wants to also pass `previous_response_id`, the same `onPayload` hook is the right seam.

## Refs

- Discussion: #77
- Companion PR: #95 (`saveDelta?` hook, also non-breaking SDK addition)

## Test plan

- [x] `pnpm check:types` passes on the `packages/sdk` workspace.
- [ ] Manual smoke: a multi-turn `session.task()` against `openai/gpt-5` succeeds when `storeResponses: true` is set.
- [ ] Fake-stream + payload-assertion test suite to follow once vitest lands on main.
