### PR TITLE
feat(sdk): images on prompt() / skill() / task()

### DIFF
--- a/examples/hello-world/.flue/agents/with-image.ts
+++ b/examples/hello-world/.flue/agents/with-image.ts
@@ -1,0 +1,29 @@
+import type { FlueContext } from '@flue/sdk';
+import * as v from 'valibot';
+
+export const triggers = { webhook: true };
+
+// A 1×1 fully-yellow PNG. The model should describe a tiny solid-yellow image.
+const TEST_PNG_BASE64 =
+	'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+
+export default async function ({ init }: FlueContext) {
+	// Sonnet has more reliable vision than Haiku for tiny test images.
+	const agent = await init({ model: 'anthropic/claude-sonnet-4-6' });
+	const session = await agent.session();
+
+	const image = { type: 'image' as const, data: TEST_PNG_BASE64, mimeType: 'image/png' };
+
+	// Non-schema branch — tests the direct harness.prompt path.
+	const plain = await session.prompt('What color is this image?', { images: [image] });
+	console.log('[with-image] plain:', plain.text);
+
+	// Schema branch — tests runWithResultTools (used by skill() and any prompt with `result`).
+	const structured = await session.prompt('What color is this image?', {
+		images: [image],
+		result: v.object({ sawImage: v.boolean(), color: v.string() }),
+	});
+	console.log('[with-image] structured:', structured.result);
+
+	return { plain: plain.text, structured: structured.result };
+}

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -1,7 +1,14 @@
 /** Internal session implementation. Not exported publicly — wrapped by FlueSession. */
-import { Agent } from '@mariozechner/pi-agent-core';
+
 import type { AgentMessage, AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core';
-import type { AssistantMessage, Model, ToolResultMessage, UserMessage } from '@mariozechner/pi-ai';
+import { Agent } from '@mariozechner/pi-agent-core';
+import type {
+	AssistantMessage,
+	ImageContent,
+	Model,
+	ToolResultMessage,
+	UserMessage,
+} from '@mariozechner/pi-ai';
 import type * as v from 'valibot';
 import { abortErrorFor, createCallHandle } from './abort.ts';
 import {
@@ -12,33 +19,32 @@ import {
 	type TaskToolResultDetails,
 } from './agent.ts';
 import {
+	type CompactionSettings,
 	calculateContextTokens,
 	compact,
 	DEFAULT_COMPACTION_SETTINGS,
 	isContextOverflow,
 	prepareCompaction,
 	shouldCompact,
-	type CompactionSettings,
 } from './compaction.ts';
+import { resolveSkillFilePath, skillsDirIn } from './context.ts';
+import { mergeCommands, createScopedEnv as scopeSessionEnv } from './env-utils.ts';
 import {
 	buildPromptText,
 	buildResultFollowUpPrompt,
 	buildSkillByNamePrompt,
 	buildSkillByPathPrompt,
 	createResultTools,
-	ResultUnavailableError,
 	type ResultToolBundle,
+	ResultUnavailableError,
 } from './result.ts';
-import { addUsage, emptyUsage, fromProviderUsage } from './usage.ts';
-import { resolveSkillFilePath, skillsDirIn } from './context.ts';
-import { createScopedEnv as scopeSessionEnv, mergeCommands } from './env-utils.ts';
 import {
 	assertRoleExists,
 	resolveEffectiveRole as resolveEffectiveRoleName,
 	resolveRoleModel,
 	resolveRoleThinkingLevel,
 } from './roles.ts';
-import { SessionHistory, type ContextEntry, type MessageSource } from './session-history.ts';
+import { type ContextEntry, type MessageSource, SessionHistory } from './session-history.ts';
 import type {
 	AgentConfig,
 	CallHandle,
@@ -61,6 +67,7 @@ import type {
 	ThinkingLevel,
 	ToolDef,
 } from './types.ts';
+import { addUsage, emptyUsage, fromProviderUsage } from './usage.ts';
 
 const MAX_TASK_DEPTH = 4;
 
@@ -278,6 +285,7 @@ export class Session implements FlueSession {
 					role: options?.role,
 					model: options?.model,
 					thinkingLevel: options?.thinkingLevel,
+					images: options?.images,
 					source: 'prompt',
 					errorLabel: 'prompt',
 					callSite: 'this prompt() call',
@@ -350,6 +358,7 @@ export class Session implements FlueSession {
 					role: options?.role,
 					model: options?.model,
 					thinkingLevel: options?.thinkingLevel,
+					images: options?.images,
 					source: 'skill',
 					errorLabel: `skill("${name}")`,
 					callSite: `this skill("${name}") call`,
@@ -607,11 +616,7 @@ export class Session implements FlueSession {
 		const previousSystemPrompt = this.harness.state.systemPrompt;
 		const previousThinkingLevel = this.harness.state.thinkingLevel;
 
-		const resolvedModel = this.resolveModelForCall(
-			options.model,
-			options.role,
-			options.callSite,
-		);
+		const resolvedModel = this.resolveModelForCall(options.model, options.role, options.callSite);
 		this.harness.state.model = resolvedModel;
 		this.harness.state.systemPrompt = this.buildSystemPrompt(options.role);
 		this.harness.state.thinkingLevel = this.resolveThinkingLevelForCall(
@@ -740,6 +745,7 @@ export class Session implements FlueSession {
 					options?.thinkingLevel ??
 					(roleThinkingLevel !== undefined ? undefined : options?.inheritedThinkingLevel),
 				tools: options?.tools,
+				images: options?.images,
 				signal,
 			};
 			if (schema) childOptions.result = schema;
@@ -909,10 +915,7 @@ export class Session implements FlueSession {
 			isError,
 			timestamp,
 		};
-		this.history.appendMessages(
-			[userMessage, assistantMessage, toolResultMessage],
-			'shell',
-		);
+		this.history.appendMessages([userMessage, assistantMessage, toolResultMessage], 'shell');
 		this.harness.state.messages = this.history.buildContext();
 		await this.save();
 	}
@@ -1172,6 +1175,7 @@ export class Session implements FlueSession {
 		role: string | undefined;
 		model: string | undefined;
 		thinkingLevel: ThinkingLevel | undefined;
+		images: ImageContent[] | undefined;
 		source: MessageSource;
 		errorLabel: string;
 		callSite: string;
@@ -1211,6 +1215,7 @@ export class Session implements FlueSession {
 						args.source,
 						args.errorLabel,
 						args.signal,
+						args.images,
 					);
 					return {
 						result,
@@ -1219,7 +1224,7 @@ export class Session implements FlueSession {
 					};
 				}
 
-				await this.harness.prompt(args.promptText);
+				await this.harness.prompt(args.promptText, args.images);
 				await this.harness.waitForIdle();
 				await this.syncHarnessMessagesSince(beforeLength, args.source);
 				await this.checkLatestAssistantForCompaction();
@@ -1255,13 +1260,16 @@ export class Session implements FlueSession {
 		source: MessageSource,
 		errorLabel: string,
 		signal: AbortSignal,
+		initialImages?: ImageContent[],
 	): Promise<T> {
 		let nextPrompt: string = initialPrompt;
 		let cursor = beforeLength;
 		const MAX_FOLLOWUPS = 32;
 		for (let attempt = 0; attempt <= MAX_FOLLOWUPS; attempt++) {
 			if (signal.aborted) throw abortErrorFor(signal);
-			await this.harness.prompt(nextPrompt);
+			// Images attach only on the first turn — retry follow-ups carry text
+			// only, so we don't re-bill image bytes on every result-tool retry.
+			await this.harness.prompt(nextPrompt, attempt === 0 ? initialImages : undefined);
 			await this.harness.waitForIdle();
 			await this.syncHarnessMessagesSince(cursor, source);
 			cursor = this.harness.state.messages.length;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,8 +1,15 @@
-import type { Model, TSchema } from '@mariozechner/pi-ai';
 import type { AgentMessage, ThinkingLevel } from '@mariozechner/pi-agent-core';
+import type { ImageContent, Model, TSchema } from '@mariozechner/pi-ai';
 import type * as v from 'valibot';
 
 export type { ThinkingLevel };
+
+/**
+ * Inline image content attached to a `prompt()`, `skill()`, or `task()` call.
+ * Re-exports pi-ai's `ImageContent` shape: `{ type: 'image', data: base64, mimeType }`.
+ * The selected model must support vision input.
+ */
+export type PromptImage = ImageContent;
 
 // ─── Skill ──────────────────────────────────────────────────────────────────
 
@@ -184,7 +191,10 @@ export interface AgentConfig {
 	/** Provider runtime settings applied when resolving models. */
 	providers?: ProvidersConfig;
 	/** Resolve model config to a Model instance. Throws on invalid model strings. */
-	resolveModel: (model: ModelConfig | undefined, providers?: ProvidersConfig) => Model<any> | undefined;
+	resolveModel: (
+		model: ModelConfig | undefined,
+		providers?: ProvidersConfig,
+	) => Model<any> | undefined;
 	/**
 	 * Agent-wide default reasoning effort. Per-call and role-level values override
 	 * this. Defaults to `"off"` (matching pi-agent-core's default) when unset.
@@ -506,6 +516,8 @@ export interface PromptOptions<S extends v.GenericSchema | undefined = undefined
 	thinkingLevel?: ThinkingLevel;
 	/** Cancel this call. See `CallHandle`. */
 	signal?: AbortSignal;
+	/** Images attached to this user message. Requires a vision-capable model. */
+	images?: PromptImage[];
 }
 
 export interface SkillOptions<S extends v.GenericSchema | undefined = undefined> {
@@ -519,6 +531,8 @@ export interface SkillOptions<S extends v.GenericSchema | undefined = undefined>
 	thinkingLevel?: ThinkingLevel;
 	/** Cancel this call. See `CallHandle`. */
 	signal?: AbortSignal;
+	/** Images attached to the skill's user message. Requires a vision-capable model. */
+	images?: PromptImage[];
 }
 
 export interface TaskOptions<S extends v.GenericSchema | undefined = undefined> {
@@ -533,6 +547,8 @@ export interface TaskOptions<S extends v.GenericSchema | undefined = undefined> 
 	cwd?: string;
 	/** Cancel this task. See `CallHandle`. */
 	signal?: AbortSignal;
+	/** Images attached to the task's initial user message. Requires a vision-capable model. */
+	images?: PromptImage[];
 }
 
 export interface ShellOptions {


### PR DESCRIPTION
## Summary

Surfaces inline image attachments on `session.prompt()`, `session.skill()`, and the initial turn of `session.task()`. The underlying engine (`@mariozechner/pi-agent-core`) already supports vision via `Agent.prompt(input, images?)`; this PR plumbs that through Flue's session API so vision-capable models can score, classify, or reason about rendered output.

```ts
const response = await session.prompt('Describe the rendered hero.', {
  images: [{ type: 'image', data: base64Png, mimeType: 'image/png' }],
  result: v.object({ summary: v.string(), score: v.number() }),
});

await session.skill('reviewer', {
  args: { brief, build },
  images: [{ type: 'image', data: base64Png, mimeType: 'image/png' }],
  result: ReviewSchema,
});
```

`PromptImage` is a re-export of pi-ai's `ImageContent` shape: `{ type: 'image', data: base64, mimeType }`.

## Design choices

- **First-turn-only attachment in the result-tools loop.** `runWithResultTools` may iterate up to 33 turns. Images attach only when `attempt === 0`; retry follow-ups carry text only, so we don't re-bill image bytes on every result-tool retry.
- **`PromptImage` aliases pi-ai's `ImageContent`.** Single source of truth; if pi-ai's shape evolves, Flue's API tracks automatically. Happy to redefine as a structural copy if you'd prefer decoupling.
- **`task()` images attach only to the initial child-session prompt**, matching the result-tools precedent — children continuing the task body should re-attach explicitly if needed.
- **Per-call only.** Skipped a top-level `init({ images })` that would attach to every prompt — easy to misuse, and per-call is more explicit.

## Changes

- `packages/sdk/src/types.ts` — new `PromptImage` re-export of pi-ai's `ImageContent`. Optional `images?: PromptImage[]` on `PromptOptions`, `SkillOptions`, `TaskOptions`.
- `packages/sdk/src/session.ts` — `prompt()` / `skill()` forward `options.images` into `runPromptCall`. `runPromptCall` carries `images?: ImageContent[]` and passes it to `harness.prompt(text, images)` on the non-schema path. `runWithResultTools` accepts `initialImages?` and attaches only on `attempt === 0`. `task()` forwards `options.images` into the child session's `prompt()` call.
- `examples/hello-world/.flue/agents/with-image.ts` (new) — minimal vision agent exercising both the non-schema and schema branches against a 1×1 test PNG.

The diff also includes Biome-driven import reordering on the touched files — those are pre-existing project lint normalizations, not behavior changes.

## Verification

Run from a clean checkout:

```
$ cd packages/sdk
$ pnpm run build       # clean, 274.34 kB total dist
$ pnpm run check:types # clean (0 errors)

$ cd ../../examples/hello-world
$ ANTHROPIC_API_KEY=... node ../../packages/cli/dist/flue.js \
    run with-image --target node --id smoke-1
[with-image] plain: I can see that the image is yellow. It appears to be a small, solid yellow rectangle or swatch.
[with-image] structured: { sawImage: true, color: 'yellow' }
```

Both the non-schema (direct `harness.prompt`) and schema (`runWithResultTools`) branches deliver the structured `ImageContent` to the Anthropic vision API.

## Notes

- Per-turn `usage` for image-bearing requests already flows through #84's machinery — vision input tokens land in `response.usage.input` automatically. No usage-aggregation changes needed here.
- **Model caveat for reviewers reproducing locally:** I tested with `claude-sonnet-4-6` (reliable). On `claude-haiku-4-5`, the schema branch correctly describes the image, but the non-schema branch sometimes has the model hallucinate "I don't have the ability to view images" — same plumbing, same `ImageContent` on the wire, the model just lies about its own capabilities for that call. Not a patch issue; mentioning it so the test instruction in `AGENTS.md` (use Haiku for cheap testing) doesn't lead to a false-negative reproduction.
- Strictly additive. Existing call sites unchanged. No tests included by request; happy to add as a follow-up alongside broader test infra.
- Happy to convert this to a Discussion first if you'd prefer to RFC the API shape before reviewing code.
