### PR TITLE
Support stdin for shell execution

### DIFF
--- a/connectors/sandbox.md
+++ b/connectors/sandbox.md
@@ -58,6 +58,11 @@ These are the things that aren't obvious from the spec or the example.
   primitive (`AbortSignal`, process kill, cancel token); otherwise leave
   it alone. The SDK does pre/post `signal.aborted` checks at the
   `SandboxApi` boundary, so you don't need to add them yourself.
+- **Standard input.** `SandboxApi.exec()` also receives `stdin` when the
+  caller uses `agent.shell(cmd, { stdin })` or `session.shell(cmd,
+  { stdin })`. Forward it to the provider's native stdin option. If the
+  provider cannot attach stdin to the process, throw a clear unsupported
+  error when `stdin` is set; never silently drop it.
 - **Credentials.** If the provider needs secrets at runtime, never invent
   values for them. Let the project's conventions (`AGENTS.md`, an existing
   `.env` / `.dev.vars`, a secret manager, CI vars, etc.) decide where they

--- a/docs/sandbox-connector-spec.md
+++ b/docs/sandbox-connector-spec.md
@@ -108,12 +108,18 @@ export interface SandboxApi {
     options?: {
       cwd?: string;
       env?: Record<string, string>;
+      stdin?: string;
       timeout?: number;
       signal?: AbortSignal;
     },
   ): Promise<{ stdout: string; stderr: string; exitCode: number }>;
 }
 ```
+
+`stdin` is the exact standard input string for the command. Connectors should
+forward it to a provider-native stdin option. If the provider cannot attach
+stdin to a process, reject when `stdin` is set instead of silently dropping
+the input.
 
 `timeout` is the **primary** cancellation contract — every connector should
 honor it by forwarding to the provider SDK's native timeout option.
@@ -197,16 +203,23 @@ Delete a file or directory. Honor `options.recursive` and `options.force`.
 
 ### `exec(command, options?) → Promise<{ stdout, stderr, exitCode }>`
 
-Run a shell command. Honor `options.cwd`, `options.env`, and
-`options.timeout`. If your provider's SDK doesn't expose a native timeout
-option, translate `timeout` into an `AbortSignal.timeout(ms)` and pass it
-to whatever the SDK accepts — or, as a last resort, race the call against
-a `setTimeout` and reject. Connectors **must** make a best-effort attempt
-at honoring `timeout`: it's how the LLM bash tool tells the agent "stop
-this command after N seconds and let me retry." Returning a 124-shaped
-`ShellResult` (`exitCode: 124`, `stderr` describing the timeout) on
-deadline expiry matches the convention used by other Flue connectors and
-the `timeout(1)` utility.
+Run a shell command. Honor `options.cwd`, `options.env`,
+`options.stdin`, and `options.timeout`. `stdin` should be passed as
+standard input, not interpolated into `command`; this keeps shell quoting,
+large text bodies, and secret-bearing input separate from the command line.
+If the provider SDK has no way to attach stdin to the spawned process,
+throw a clear unsupported-error when `options.stdin` is present. Never
+silently ignore stdin.
+
+If your provider's SDK doesn't expose a native timeout option, translate
+`timeout` into an `AbortSignal.timeout(ms)` and pass it to whatever the SDK
+accepts — or, as a last resort, race the call against a `setTimeout` and
+reject. Connectors **must** make a best-effort attempt at honoring
+`timeout`: it's how the LLM bash tool tells the agent "stop this command
+after N seconds and let me retry." Returning a 124-shaped `ShellResult`
+(`exitCode: 124`, `stderr` describing the timeout) on deadline expiry
+matches the convention used by other Flue connectors and the `timeout(1)`
+utility.
 
 If your provider's SDK *also* supports an `AbortSignal`, forward
 `options.signal` too — this gives SDK-level callers (`agent.shell(cmd,

--- a/packages/sdk/src/agent-client.ts
+++ b/packages/sdk/src/agent-client.ts
@@ -55,6 +55,7 @@ export class AgentClient implements FlueAgent {
 			const result = await env.exec(command, {
 				env: options?.env,
 				cwd: options?.cwd,
+				stdin: options?.stdin,
 				signal,
 			});
 			return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -204,6 +204,7 @@ function createEditTool(env: SessionEnv): AgentTool<typeof EditParams> {
 
 const BashParams = Type.Object({
 	command: Type.String({ description: 'Bash command to execute' }),
+	stdin: Type.Optional(Type.String({ description: 'Standard input to pass to the command' })),
 	timeout: Type.Optional(Type.Number({ description: 'Timeout in seconds' })),
 });
 
@@ -254,6 +255,7 @@ function createBashTool(env: SessionEnv): AgentTool<typeof BashParams> {
 				);
 			try {
 				const result = await env.exec(params.command, {
+					stdin: params.stdin,
 					timeout: params.timeout,
 					signal: execSignal,
 				});

--- a/packages/sdk/src/cloudflare/cf-sandbox.ts
+++ b/packages/sdk/src/cloudflare/cf-sandbox.ts
@@ -94,6 +94,7 @@ export async function cfSandboxToSessionEnv(
 			execOpts?: {
 				cwd?: string;
 				env?: Record<string, string>;
+				stdin?: string;
 				timeout?: number;
 				signal?: AbortSignal;
 			},
@@ -109,6 +110,7 @@ export async function cfSandboxToSessionEnv(
 			const result = await sandbox.exec(command, {
 				cwd: execOpts?.cwd,
 				env: execOpts?.env,
+				stdin: execOpts?.stdin,
 				timeout: timeoutMs,
 			});
 

--- a/packages/sdk/src/sandbox.ts
+++ b/packages/sdk/src/sandbox.ts
@@ -22,6 +22,7 @@ export function createCwdSessionEnv(parentEnv: SessionEnv, cwd: string): Session
 			parentEnv.exec(cmd, {
 				cwd: opts?.cwd ?? scopedCwd,
 				env: opts?.env,
+				stdin: opts?.stdin,
 				timeout: opts?.timeout,
 				signal: opts?.signal,
 			}),
@@ -79,7 +80,12 @@ function createBashSessionEnv(
 			const exec = bash.exec as unknown as (
 				this: BashLike,
 				command: string,
-				options?: { cwd?: string; env?: Record<string, string>; signal?: AbortSignal },
+				options?: {
+					cwd?: string;
+					env?: Record<string, string>;
+					stdin?: string;
+					signal?: AbortSignal;
+				},
 			) => Promise<ShellResult>;
 
 			// Just-bash has no native timeout option. Translate `timeout`
@@ -98,7 +104,9 @@ function createBashSessionEnv(
 			const result = await exec.call(
 				bash,
 				cmd,
-				opts ? { cwd: opts.cwd, env: opts.env, signal: mergedSignal } : undefined,
+				opts
+					? { cwd: opts.cwd, env: opts.env, stdin: opts.stdin, signal: mergedSignal }
+					: undefined,
 			);
 			if (opts?.signal?.aborted) throw abortErrorFor(opts.signal);
 			return result;
@@ -173,6 +181,11 @@ function assertBashLike(value: unknown): asserts value is BashLike {
  *     should ignore it; the deadline is still enforced via `timeout`.
  *
  * Connectors that support both should observe whichever fires first.
+ *
+ * `stdin?: string` is the exact standard input for the command. Connectors
+ * should forward it to a provider-native stdin option. If the provider
+ * cannot attach stdin to a process, reject when `stdin` is set rather than
+ * silently dropping input.
  */
 export interface SandboxApi {
 	readFile(path: string): Promise<string>;
@@ -188,6 +201,7 @@ export interface SandboxApi {
 		options?: {
 			cwd?: string;
 			env?: Record<string, string>;
+			stdin?: string;
 			timeout?: number;
 			signal?: AbortSignal;
 		},
@@ -208,6 +222,7 @@ export function createSandboxSessionEnv(api: SandboxApi, cwd: string): SessionEn
 			options?: {
 				cwd?: string;
 				env?: Record<string, string>;
+				stdin?: string;
 				timeout?: number;
 				signal?: AbortSignal;
 			},
@@ -225,6 +240,7 @@ export function createSandboxSessionEnv(api: SandboxApi, cwd: string): SessionEn
 			const result = await api.exec(command, {
 				cwd: options?.cwd ?? cwd,
 				env: options?.env,
+				stdin: options?.stdin,
 				timeout: options?.timeout,
 				signal,
 			});

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -400,7 +400,7 @@ export class Session implements FlueSession {
 				// tool-use round.
 				const toolCallId = crypto.randomUUID();
 
-				// Per-call cwd/env, when set, are part of the call's identity
+				// Per-call cwd/env/stdin, when set, are part of the call's identity
 				// and need to be visible in the transcript. Without them the
 				// model can't tell on a later turn that a command ran with
 				// overrides — making questions like "what cwd was that run
@@ -412,6 +412,7 @@ export class Session implements FlueSession {
 				const args: Record<string, unknown> = { command };
 				if (options?.cwd !== undefined) args.cwd = options.cwd;
 				if (options?.env !== undefined) args.env = options.env;
+				if (options?.stdin !== undefined) args.stdin = options.stdin;
 
 				this.emit({ type: 'tool_start', toolName: 'bash', toolCallId, args });
 
@@ -422,6 +423,7 @@ export class Session implements FlueSession {
 					const result = await env.exec(command, {
 						env: options?.env,
 						cwd: options?.cwd,
+						stdin: options?.stdin,
 						signal,
 					});
 					const shellResult: ShellResult = {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -106,6 +106,7 @@ export interface SessionEnv {
 		options?: {
 			cwd?: string;
 			env?: Record<string, string>;
+			stdin?: string;
 			/**
 			 * Wall-clock deadline hint in seconds. Forwarded to the underlying
 			 * sandbox connector's native timeout option (E2B `timeoutMs`,
@@ -594,6 +595,7 @@ export interface TaskOptions<S extends v.GenericSchema | undefined = undefined> 
 export interface ShellOptions {
 	env?: Record<string, string>;
 	cwd?: string;
+	stdin?: string;
 	commands?: Command[];
 	/** Cancel this call. See `CallHandle`. */
 	signal?: AbortSignal;
@@ -619,7 +621,12 @@ export interface SandboxFactory {
 export interface BashLike {
 	exec(
 		command: string,
-		options?: { cwd?: string; env?: Record<string, string>; signal?: AbortSignal },
+		options?: {
+			cwd?: string;
+			env?: Record<string, string>;
+			stdin?: string;
+			signal?: AbortSignal;
+		},
 	): Promise<ShellResult>;
 	getCwd(): string;
 	fs: {


### PR DESCRIPTION
## Summary

- add `stdin?: string` to shell execution options across the public SDK boundary
- thread stdin through agent/session shell calls, the LLM bash tool, scoped envs, just-bash, and the Cloudflare sandbox wrapper
- document the sandbox connector contract: forward provider-native stdin or reject when unsupported, instead of silently dropping input

## Why

The homepage examples use `session.shell(..., { stdin })` for command patterns like `--body-file -` / `--file -`, but the SDK did not expose or pass stdin through the runtime boundary yet. This makes stdin a real process primitive without pretending every sandbox provider supports it.

## Verification

- `pnpm run check:types`
- smoke-tested built `@flue/sdk/sandbox` with just-bash: `env.exec('cat', { stdin: 'hello stdin\n' })` returned the stdin text on stdout
