### PR TITLE
Support recursive skill discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,10 +115,11 @@ export default async function ({ init, payload }: FlueContext) {
   });
   const session = await harness.session();
 
-  // Skills can be referenced either by their frontmatter `name:` (shown below)
-  // or by a relative path under `.agents/skills/` — e.g.
-  // `session.skill('triage/reproduce.md', ...)`. Path references are handy for
-  // skill packs that group multiple stages under one directory.
+  // Skills can live anywhere under `.agents/skills/` as `SKILL.md` files.
+  // Reference them by frontmatter `name:` (shown below), or by a relative path
+  // under `.agents/skills/` — e.g. `session.skill('triage/reproduce.md', ...)`.
+  // Nested packs work too: `.agents/skills/review/security/SKILL.md` can expose
+  // `name: security-review` while living beside other review skills.
   const { data } = await session.skill('triage', {
     // Pass arguments to any prompt or skill.
     args: { issueNumber: payload.issueNumber },

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -373,11 +373,11 @@ This is built in when you deploy with `--target cloudflare`. No extra configurat
 
 ## Sandbox context
 
-`AGENTS.md` and skills are optional workspace-context files that the agent reads from its sandbox at `init()` time. They live at conventional paths inside whatever sandbox the agent is using — Flue looks for `<cwd>/AGENTS.md` and `<cwd>/.agents/skills/<name>/SKILL.md`. Whatever's there gets loaded; whatever isn't, doesn't. Most agents don't need either to do useful work.
+`AGENTS.md` and skills are optional workspace-context files that the agent reads from its sandbox at `init()` time. They live at conventional paths inside whatever sandbox the agent is using — Flue looks for `<cwd>/AGENTS.md` and `SKILL.md` files anywhere under `<cwd>/.agents/skills/`. Whatever's there gets loaded; whatever isn't, doesn't. Most agents don't need either to do useful work.
 
 If you want to use them, put them in your sandbox. How you do that depends on which sandbox you're using: upload to R2 for an R2-backed virtual sandbox, `COPY` them in for a container, or write them in via `session.shell()` on a sandbox you control.
 
-**Skills** are reusable agent tasks defined as markdown files in `.agents/skills/`. They give the agent a focused instruction set for a specific job:
+**Skills** are reusable agent tasks defined as markdown files in `.agents/skills/`. Flue discovers `SKILL.md` files recursively, so grouped skill packs like `.agents/skills/review/security/SKILL.md` work alongside flat skills. Skills give the agent a focused instruction set for a specific job:
 
 `.agents/skills/greet/SKILL.md`:
 

--- a/docs/deploy-github-actions.md
+++ b/docs/deploy-github-actions.md
@@ -193,7 +193,7 @@ const { data } = await session.prompt(`Review this PR:\n${diff}`, {
 
 The agent reads `AGENTS.md` and skills from its sandbox at runtime. CI agents typically use `sandbox: 'local'`, which mounts the runner's checkout — so any files in your repo are visible automatically.
 
-**Skills** are reusable agent tasks defined as markdown files in `.agents/skills/`. They give the agent a focused instruction set for a specific job:
+**Skills** are reusable agent tasks defined as markdown files in `.agents/skills/`. Flue discovers `SKILL.md` files recursively, so grouped skill packs like `.agents/skills/review/security/SKILL.md` work alongside flat skills. Skills give the agent a focused instruction set for a specific job:
 
 `.agents/skills/triage/SKILL.md`:
 

--- a/docs/deploy-gitlab-ci.md
+++ b/docs/deploy-gitlab-ci.md
@@ -221,7 +221,7 @@ const { data } = await session.prompt(`Review this MR:\n${diff}`, {
 
 The agent reads `AGENTS.md` and skills from its sandbox at runtime. CI agents typically use `sandbox: 'local'`, which mounts the runner's checkout — so any files in your repo are visible automatically.
 
-**Skills** are reusable agent tasks defined as markdown files in `.agents/skills/`. They give the agent a focused instruction set for a specific job:
+**Skills** are reusable agent tasks defined as markdown files in `.agents/skills/`. Flue discovers `SKILL.md` files recursively, so grouped skill packs like `.agents/skills/review/security/SKILL.md` work alongside flat skills. Skills give the agent a focused instruction set for a specific job:
 
 `.agents/skills/triage/SKILL.md`:
 

--- a/docs/deploy-node.md
+++ b/docs/deploy-node.md
@@ -133,7 +133,7 @@ const analysis = await session.prompt("Analyze this quarter's metrics", {
 
 The agent reads `AGENTS.md` and skills from its sandbox at runtime. With `sandbox: 'local'`, that's your real project root, so any files there are visible. With the default virtual sandbox the filesystem starts empty — you'd set up context via `session.shell()` or skip these features for simple prompt-and-response agents.
 
-**Skills** are reusable agent tasks defined as markdown files in `.agents/skills/`. They give the agent a focused instruction set for a specific job:
+**Skills** are reusable agent tasks defined as markdown files in `.agents/skills/`. Flue discovers `SKILL.md` files recursively, so grouped skill packs like `.agents/skills/review/security/SKILL.md` work alongside flat skills. Skills give the agent a focused instruction set for a specific job:
 
 `.agents/skills/summarize/SKILL.md`:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -115,10 +115,11 @@ export default async function ({ init, payload }: FlueContext) {
   });
   const session = await harness.session();
 
-  // Skills can be referenced either by their frontmatter `name:` (shown below)
-  // or by a relative path under `.agents/skills/` — e.g.
-  // `session.skill('triage/reproduce.md', ...)`. Path references are handy for
-  // skill packs that group multiple stages under one directory.
+  // Skills can live anywhere under `.agents/skills/` as `SKILL.md` files.
+  // Reference them by frontmatter `name:` (shown below), or by a relative path
+  // under `.agents/skills/` — e.g. `session.skill('triage/reproduce.md', ...)`.
+  // Nested packs work too: `.agents/skills/review/security/SKILL.md` can expose
+  // `name: security-review` while living beside other review skills.
   const { data } = await session.skill('triage', {
     // Pass arguments to any prompt or skill.
     args: { issueNumber: payload.issueNumber },

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -60,6 +60,20 @@ export function skillsDirIn(basePath: string): string {
 	return basePath.endsWith('/') ? `${basePath}.agents/skills` : `${basePath}/.agents/skills`;
 }
 
+function joinPath(base: string, entry: string): string {
+	return base.endsWith('/') ? `${base}${entry}` : `${base}/${entry}`;
+}
+
+function joinRelativePath(base: string, entry: string): string {
+	return base ? `${base}/${entry}` : entry;
+}
+
+function skillFileRelativePath(relativeDir: string): string {
+	return joinRelativePath(relativeDir, 'SKILL.md');
+}
+
+const IGNORED_SKILL_DISCOVERY_DIRS = new Set(['.git', 'node_modules']);
+
 /**
  * Resolve a skill referenced by relative path under `.agents/skills/`,
  * returning the absolute filesystem path or `null` if the file doesn't
@@ -80,13 +94,13 @@ export async function resolveSkillFilePath(
 	basePath: string,
 	relPath: string,
 ): Promise<string | null> {
-	const filePath = `${skillsDirIn(basePath)}/${relPath}`;
+	const filePath = joinPath(skillsDirIn(basePath), relPath);
 	if (!(await env.exists(filePath))) return null;
 	return filePath;
 }
 
 /**
- * Discover skills from `.agents/skills/<name>/SKILL.md` under basePath.
+ * Discover recursive `SKILL.md` files under `.agents/skills/`.
  *
  * Skill bodies are intentionally not retained — at call time the model
  * reads the file from disk itself, which keeps relative references
@@ -104,28 +118,54 @@ export async function discoverLocalSkills(
 	if (!(await env.exists(skillsDir))) return {};
 
 	const skills: Record<string, Skill> = {};
-	const entries = await env.readdir(skillsDir);
 
-	for (const entry of entries) {
-		const skillDir = `${skillsDir}/${entry}`;
+	async function visit(dir: string, relativeDir: string): Promise<void> {
+		const skillMdPath = joinPath(dir, 'SKILL.md');
 
-		try {
-			const s = await env.stat(skillDir);
-			if (!s.isDirectory) continue;
-		} catch {
-			continue;
+		if (relativeDir && (await env.exists(skillMdPath))) {
+			const defaultName = relativeDir.split('/').pop() || relativeDir;
+			const content = await env.readFile(skillMdPath);
+			const parsed = parseFrontmatterFile(content, defaultName);
+			const existing = skills[parsed.name];
+
+			if (existing) {
+				throw new Error(
+					`[flue] Duplicate skill name "${parsed.name}" discovered at:\n` +
+						`- ${existing.path}\n` +
+						`- ${skillMdPath}\n\n` +
+						`Skill names must be unique within a session. Rename one skill, or call one by relative path under .agents/skills/.`,
+				);
+			}
+
+			skills[parsed.name] = {
+				name: parsed.name,
+				description: parsed.description,
+				path: skillMdPath,
+				relativePath: skillFileRelativePath(relativeDir),
+			};
+
+			return;
 		}
 
-		const skillMdPath = `${skillDir}/SKILL.md`;
-		if (!(await env.exists(skillMdPath))) continue;
+		const entries = await env.readdir(dir);
 
-		const content = await env.readFile(skillMdPath);
-		const parsed = parseFrontmatterFile(content, entry);
-		skills[parsed.name] = {
-			name: parsed.name,
-			description: parsed.description,
-		};
+		for (const entry of entries.sort((a, b) => a.localeCompare(b))) {
+			if (IGNORED_SKILL_DISCOVERY_DIRS.has(entry)) continue;
+
+			const entryPath = joinPath(dir, entry);
+
+			try {
+				const s = await env.stat(entryPath);
+				if (!s.isDirectory) continue;
+			} catch {
+				continue;
+			}
+
+			await visit(entryPath, joinRelativePath(relativeDir, entry));
+		}
 	}
+
+	await visit(skillsDir, '');
 
 	return skills;
 }
@@ -158,12 +198,13 @@ export function composeSystemPrompt(
 			'',
 			'## Available Skills',
 			'',
-			'Each skill below is documented in a markdown file under `.agents/skills/` (relative to your working directory). The default location is `.agents/skills/<name>/SKILL.md`. When asked to run a skill, read its file from disk and follow the instructions there literally — the skill body is not provided inline.',
+			'Each skill below is documented in a `SKILL.md` file under `.agents/skills/` (relative to your working directory). When asked to run a skill, read its listed file from disk and follow the instructions there literally — the skill body is not provided inline.',
 			'',
 		);
 		for (const skill of skillEntries) {
 			const desc = skill.description ? ` — ${skill.description}` : '';
-			parts.push(`- **${skill.name}**${desc}`);
+			const skillPath = skill.relativePath ? ` (\`.agents/skills/${skill.relativePath}\`)` : '';
+			parts.push(`- **${skill.name}**${desc}${skillPath}`);
 		}
 	}
 

--- a/packages/runtime/src/result.ts
+++ b/packages/runtime/src/result.ts
@@ -1,6 +1,7 @@
 import type { AgentTool } from '@mariozechner/pi-agent-core';
 import { toJsonSchema } from '@valibot/to-json-schema';
 import * as v from 'valibot';
+import type { Skill } from './types.ts';
 
 /**
  * Names of the framework-injected tools used to capture schema-typed results.
@@ -31,17 +32,20 @@ export function buildResultFollowUpPrompt(): string {
  * Build the user-facing prompt text for a `session.skill('<name>')` call,
  * where `<name>` is a name registered in the session's skill registry.
  *
- * The system prompt's "Available Skills" list tells the model where the
- * skill lives (`.agents/skills/<name>/SKILL.md`) and how to run it (read
- * the file, follow its instructions). The per-call message just names
- * the skill plus any arguments — no inlined body, no path hint.
+ * The system prompt's "Available Skills" list tells the model which skills
+ * exist. The per-call message repeats the exact file path so nested skills
+ * don't rely on the default `.agents/skills/<name>/SKILL.md` convention.
  */
 export function buildSkillByNamePrompt(
-	name: string,
+	skill: Skill,
 	args?: Record<string, unknown>,
 	schema?: v.GenericSchema,
 ): string {
-	const parts: string[] = [`Run the skill named "${name}".`];
+	const parts: string[] = [`Run the skill named "${skill.name}".`];
+
+	if (skill.path) {
+		parts.push('', `The file can be found at ${skill.path}.`);
+	}
 
 	if (args && Object.keys(args).length > 0) {
 		parts.push('', 'Arguments:', JSON.stringify(args, null, 2));

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -570,7 +570,23 @@ export class Session implements FlueSession {
 	skill(name: string, options?: SkillOptions<v.GenericSchema | undefined>): CallHandle<any> {
 		return createCallHandle(options?.signal, (signal) =>
 			this.runOperation('skill', signal, async () => {
-				// Registered skill names and relative skill paths use different prompts.
+				// Skills can be referenced two ways. The shape determines the
+				// per-call user-message format; the model reads the file
+				// itself in both cases.
+				//
+				//   1. By registered name. Looked up in `this.config.skills`,
+				//      populated at init time from `.agents/skills/**/SKILL.md`
+				//      frontmatter. The system prompt's "Available Skills"
+				//      list tells the model name + description + path.
+				//
+				//   2. By relative path under `.agents/skills/` (e.g.
+				//      `'triage/reproduce.md'`). The skill isn't in the
+				//      registry, so we hand the model the resolved absolute
+				//      path explicitly. Triggered only when `name` looks
+				//      like a path (contains `/` or ends in `.md`/`.markdown`)
+				//      — otherwise typos of registered names fail fast with
+				//      a helpful error rather than silently fall through to
+				//      a path lookup that's also going to miss.
 				const looksLikePath = name.includes('/') || /\.(md|markdown)$/i.test(name);
 				const schema = resolveSchemaOption(options);
 
@@ -585,11 +601,12 @@ export class Session implements FlueSession {
 					}
 					promptText = buildSkillByPathPrompt(name, resolvedPath, options?.args, schema);
 				} else {
-					if (!this.config.skills[name]) {
+					const skill = this.config.skills[name];
+					if (!skill) {
 						const available = Object.keys(this.config.skills).join(', ') || '(none)';
 						throw new Error(
 							`[flue] Skill "${name}" not registered. Available: ${available}.\n\n` +
-								`Skills are discovered at init() time from ${skillsDirIn(this.env.cwd)}/<name>/SKILL.md ` +
+								`Skills are discovered at init() time from ${skillsDirIn(this.env.cwd)}/**/SKILL.md ` +
 								`inside the session's sandbox. If you expected "${name}" to be there, make sure ` +
 								`the SKILL.md file exists at that path before calling init() — the default ` +
 								`empty sandbox starts with no files, so it has no skills unless you put them there.\n\n` +
@@ -597,7 +614,7 @@ export class Session implements FlueSession {
 								`(e.g. "triage/reproduce.md").`,
 						);
 					}
-					promptText = buildSkillByNamePrompt(name, options?.args, schema);
+					promptText = buildSkillByNamePrompt(skill, options?.args, schema);
 				}
 
 				return this.runPromptCall({

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -25,6 +25,8 @@ export type PromptImage = ImageContent;
 export interface Skill {
 	name: string;
 	description: string;
+	path?: string;
+	relativePath?: string;
 }
 
 // ─── Role ───────────────────────────────────────────────────────────────────
@@ -721,4 +723,3 @@ export type FlueEvent = (
 };
 
 export type FlueEventCallback = (event: FlueEvent) => void | Promise<void>;
-


### PR DESCRIPTION
## Summary

- discover `SKILL.md` files recursively under `.agents/skills/`
- store each discovered skill's exact file path in the registry, then include that path in both the system prompt and registered-name skill prompt
- stop traversal once a directory is identified as a skill root, so support files under a skill package are not misregistered as separate skills
- fail fast on duplicate frontmatter `name:` values instead of silently shadowing one skill with another
- update docs to describe grouped/nested skill packs

Refs #100.

## Verification

- `pnpm --filter @flue/sdk check:types`
- `pnpm --filter @flue/sdk build`
- recursive discovery smoke via `pnpm exec tsx -e ...`
- `git diff --check`
- `pnpm exec biome check packages/sdk/src/context.ts packages/sdk/src/result.ts packages/sdk/src/session.ts` returned no errors; it still reports existing warnings in `result.ts` / `session.ts` around `any` and non-null assertions