### PR TITLE
Add task lifecycle telemetry

### DIFF
--- a/packages/cli/bin/flue.ts
+++ b/packages/cli/bin/flue.ts
@@ -1,16 +1,16 @@
 #!/usr/bin/env node
-import { spawn, type ChildProcess } from 'node:child_process';
+import { type ChildProcess, spawn } from 'node:child_process';
 import * as fs from 'node:fs';
 import path from 'node:path';
-import { determineAgent } from '@vercel/detect-agent';
-import { build, dev, DEFAULT_DEV_PORT, parseEnvFiles, resolveEnvFiles } from '@flue/sdk';
+import { build, DEFAULT_DEV_PORT, dev, parseEnvFiles, resolveEnvFiles } from '@flue/sdk';
 import {
+	type FlueConfig,
 	resolveConfig,
 	resolveConfigPath,
-	type FlueConfig,
 	type UserFlueConfig,
 } from '@flue/sdk/config';
-import { CONNECTORS, CATEGORY_ROOTS } from './_connectors.generated.ts';
+import { determineAgent } from '@vercel/detect-agent';
+import { CATEGORY_ROOTS, CONNECTORS } from './_connectors.generated.ts';
 
 /**
  * Resolve the merged config for a CLI command. The CLI's responsibility is
@@ -482,6 +482,27 @@ function flushBuffers() {
 	flushThinkingBuffer();
 }
 
+function truncateInline(value: string, max = 120): string {
+	return value.length > max ? `${value.slice(0, max)}...` : value;
+}
+
+function formatDuration(ms: number | undefined): string | undefined {
+	if (typeof ms !== 'number' || !Number.isFinite(ms)) return undefined;
+	if (ms < 1000) return `${ms}ms`;
+	return `${(ms / 1000).toFixed(ms < 10_000 ? 1 : 0)}s`;
+}
+
+function formatTaskUsage(usage: unknown): string | undefined {
+	if (!usage || typeof usage !== 'object') return undefined;
+	const promptUsage = usage as { totalTokens?: unknown; cost?: { total?: unknown } };
+	const tokens = typeof promptUsage.totalTokens === 'number' ? promptUsage.totalTokens : undefined;
+	const cost = typeof promptUsage.cost?.total === 'number' ? promptUsage.cost.total : undefined;
+	const parts: string[] = [];
+	if (tokens !== undefined) parts.push(`tokens=${tokens.toLocaleString()}`);
+	if (cost !== undefined && cost > 0) parts.push(`cost=$${cost.toFixed(4)}`);
+	return parts.length > 0 ? parts.join(' ') : undefined;
+}
+
 function logEvent(event: any) {
 	switch (event.type) {
 		case 'agent_start':
@@ -559,6 +580,34 @@ function logEvent(event: any) {
 		case 'turn_end':
 			flushBuffers();
 			break;
+
+		case 'task_start': {
+			flushBuffers();
+			const label = truncateInline(event.description || event.prompt || event.taskId || 'task');
+			const details = [
+				event.role ? `role=${event.role}` : undefined,
+				event.cwd ? `cwd=${event.cwd}` : undefined,
+			].filter(Boolean);
+			console.error(`[flue] task:start  ${label}${details.length ? `  ${details.join(' ')}` : ''}`);
+			break;
+		}
+
+		case 'task_end': {
+			flushBuffers();
+			const status = event.isError ? 'error' : 'done';
+			const details = [
+				formatDuration(event.durationMs),
+				formatTaskUsage(event.usage),
+			].filter(Boolean);
+			const resultPreview =
+				event.isError && typeof event.result === 'string'
+					? `  ${truncateInline(event.result, 180)}`
+					: '';
+			console.error(
+				`[flue] task:${status}   ${details.length ? details.join(' ') : event.taskId}${resultPreview}`,
+			);
+			break;
+		}
 
 		case 'compaction_start':
 			flushBuffers();

--- a/packages/sdk/src/agent.ts
+++ b/packages/sdk/src/agent.ts
@@ -1,6 +1,6 @@
 import type { AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core';
 import { type Static, Type } from '@mariozechner/pi-ai';
-import type { Role, SessionEnv } from './types.ts';
+import type { PromptModel, PromptUsage, Role, SessionEnv } from './types.ts';
 
 const MAX_READ_LINES = 2000;
 const MAX_READ_BYTES = 50 * 1024;
@@ -28,9 +28,16 @@ export interface TaskToolParams {
 export interface TaskToolResultDetails {
 	taskId: string;
 	sessionId: string;
+	workId: string;
+	parentWorkId?: string;
 	messageId?: string;
 	role?: string;
 	cwd?: string;
+	usage?: PromptUsage;
+	model?: PromptModel;
+	durationMs: number;
+	startedAt: string;
+	endedAt: string;
 }
 
 export interface CreateToolsOptions {

--- a/packages/sdk/src/session.ts
+++ b/packages/sdk/src/session.ts
@@ -28,7 +28,6 @@ import {
 	shouldCompact,
 } from './compaction.ts';
 import { resolveSkillFilePath, skillsDirIn } from './context.ts';
-import { createFlueFs } from './sandbox.ts';
 import {
 	buildPromptText,
 	buildResultFollowUpPrompt,
@@ -38,13 +37,14 @@ import {
 	type ResultToolBundle,
 	ResultUnavailableError,
 } from './result.ts';
-import { getProviderConfiguration, getRegisteredApiKey } from './runtime/providers.ts';
 import {
 	assertRoleExists,
 	resolveEffectiveRole as resolveEffectiveRoleName,
 	resolveRoleModel,
 	resolveRoleThinkingLevel,
 } from './roles.ts';
+import { getProviderConfiguration, getRegisteredApiKey } from './runtime/providers.ts';
+import { createFlueFs } from './sandbox.ts';
 
 import type {
 	AgentConfig,
@@ -55,6 +55,7 @@ import type {
 	FlueEventCallback,
 	FlueFs,
 	FlueSession,
+	FlueWorkKind,
 	MessageEntry,
 	PromptModel,
 	PromptOptions,
@@ -126,9 +127,16 @@ interface InternalTaskResult<T> {
 	text: string;
 	taskId: string;
 	sessionId: string;
+	workId: string;
+	parentWorkId?: string;
 	messageId?: string;
 	role?: string;
 	cwd?: string;
+	usage?: PromptUsage;
+	model?: PromptModel;
+	durationMs: number;
+	startedAt: string;
+	endedAt: string;
 }
 
 /**
@@ -149,6 +157,14 @@ function resolveSchemaOption(
 interface InternalTaskOptions<S extends v.GenericSchema | undefined> extends TaskOptions<S> {
 	inheritedModel?: string;
 	inheritedThinkingLevel?: ThinkingLevel;
+	description?: string;
+	parentWorkId?: string;
+}
+
+interface ActiveWork {
+	workId: string;
+	kind: FlueWorkKind;
+	childUsage: PromptUsage;
 }
 
 /** In-memory session store. Sessions persist for the lifetime of the process. */
@@ -409,6 +425,7 @@ export class Session implements FlueSession {
 	private agentTools: ToolDef[];
 	private deleted = false;
 	private activeOperation: string | undefined;
+	private activeWork: ActiveWork | undefined;
 	private activeTasks = new Set<Session>();
 	private sessionRole: string | undefined;
 	private taskDepth: number;
@@ -913,6 +930,8 @@ export class Session implements FlueSession {
 				role: params.role ?? inheritedRole,
 				inheritedModel,
 				inheritedThinkingLevel,
+				description: params.description,
+				parentWorkId: this.activeWork?.workId,
 				cwd: params.cwd,
 				tools,
 			},
@@ -924,9 +943,16 @@ export class Session implements FlueSession {
 			details: {
 				taskId: result.taskId,
 				sessionId: result.sessionId,
+				workId: result.workId,
+				parentWorkId: result.parentWorkId,
 				messageId: result.messageId,
 				role: result.role,
 				cwd: result.cwd,
+				usage: result.usage,
+				model: result.model,
+				durationMs: result.durationMs,
+				startedAt: result.startedAt,
+				endedAt: result.endedAt,
 			},
 		};
 	}
@@ -950,6 +976,10 @@ export class Session implements FlueSession {
 		if (signal?.aborted) throw abortErrorFor(signal);
 
 		const taskId = crypto.randomUUID();
+		const workId = crypto.randomUUID();
+		const parentWorkId = options?.parentWorkId;
+		const startedAtMs = Date.now();
+		const startedAt = new Date(startedAtMs).toISOString();
 		const requestedRole = options?.role ?? this.sessionRole ?? this.config.role;
 		let child: Session | undefined;
 		let abortListener: (() => void) | undefined;
@@ -957,10 +987,15 @@ export class Session implements FlueSession {
 		this.emit({
 			type: 'task_start',
 			taskId,
+			workId,
+			parentWorkId,
 			prompt: text,
+			description: options?.description,
 			role: requestedRole,
 			cwd: options?.cwd,
+			startedAt,
 			parentSessionId: this.id,
+			workKind: 'task',
 		});
 
 		try {
@@ -999,30 +1034,56 @@ export class Session implements FlueSession {
 			if (schema) childOptions.schema = schema;
 
 			const output: any = await child.prompt(text, childOptions as any);
+			const usage = getPromptUsage(output);
+			const model = getPromptModel(output);
+			if (usage && parentWorkId) this.addChildUsageToActiveWork(parentWorkId, usage);
+			const endedAtMs = Date.now();
+			const endedAt = new Date(endedAtMs).toISOString();
+			const durationMs = endedAtMs - startedAtMs;
 			const taskResult: InternalTaskResult<any> = {
 				output,
 				text: typeof output?.text === 'string' ? output.text : child.getAssistantText(),
 				taskId,
 				sessionId: child.id,
+				workId,
+				parentWorkId,
 				messageId: child.getLatestAssistantMessageId(),
 				role,
 				cwd: options?.cwd,
+				usage,
+				model,
+				durationMs,
+				startedAt,
+				endedAt,
 			};
 			this.emit({
 				type: 'task_end',
 				taskId,
+				workId,
+				parentWorkId,
 				isError: false,
 				result: taskResult.text,
+				usage,
+				model,
+				durationMs,
+				endedAt,
 				parentSessionId: this.id,
+				workKind: 'task',
 			});
 			return taskResult;
 		} catch (error) {
+			const endedAtMs = Date.now();
 			this.emit({
 				type: 'task_end',
 				taskId,
+				workId,
+				parentWorkId,
 				isError: true,
 				result: getErrorMessage(error),
+				durationMs: endedAtMs - startedAtMs,
+				endedAt: new Date(endedAtMs).toISOString(),
 				parentSessionId: this.id,
+				workKind: 'task',
 			});
 			throw error;
 		} finally {
@@ -1037,12 +1098,18 @@ export class Session implements FlueSession {
 	// ─── Internal ────────────────────────────────────────────────────────────
 
 	private async runOperation<T>(
-		operation: string,
+		operation: FlueWorkKind,
 		signal: AbortSignal | undefined,
 		fn: () => Promise<T>,
 	): Promise<T> {
 		return this.runExclusive(operation, async () => {
 			if (signal?.aborted) throw abortErrorFor(signal);
+			const previousWork = this.activeWork;
+			this.activeWork = {
+				workId: crypto.randomUUID(),
+				kind: operation,
+				childUsage: emptyUsage(),
+			};
 
 			// Mirror Session.abort() for the duration of this call.
 			// shell() doesn't use the harness/compaction/tasks — these
@@ -1068,7 +1135,11 @@ export class Session implements FlueSession {
 				throw surfaced;
 			} finally {
 				signal?.removeEventListener('abort', onAbort);
-				this.emit({ type: 'idle' });
+				try {
+					this.emit({ type: 'idle' });
+				} finally {
+					this.activeWork = previousWork;
+				}
 			}
 		});
 	}
@@ -1090,7 +1161,17 @@ export class Session implements FlueSession {
 	}
 
 	private emit(event: FlueEvent): void {
-		this.eventCallback?.({ ...event, sessionId: this.id });
+		const activeWork = this.activeWork;
+		const workEvent =
+			activeWork && event.workId === undefined
+				? { ...event, workId: activeWork.workId, workKind: activeWork.kind }
+				: event;
+		this.eventCallback?.({ ...workEvent, sessionId: this.id });
+	}
+
+	private addChildUsageToActiveWork(parentWorkId: string, usage: PromptUsage): void {
+		if (!this.activeWork || this.activeWork.workId !== parentWorkId) return;
+		this.activeWork.childUsage = addUsage(this.activeWork.childUsage, usage);
 	}
 
 	private assertActive(): void {
@@ -1380,6 +1461,12 @@ export class Session implements FlueSession {
 		return totals;
 	}
 
+	private aggregateUsageWithActiveChildUsage(beforeLeafId: string | null): PromptUsage {
+		const directUsage = this.aggregateUsageSince(beforeLeafId);
+		if (!this.activeWork) return directUsage;
+		return addUsage(directUsage, this.activeWork.childUsage);
+	}
+
 	private getAssistantText(): string {
 		const messages = this.harness.state.messages;
 		for (let i = messages.length - 1; i >= 0; i--) {
@@ -1477,7 +1564,7 @@ export class Session implements FlueSession {
 					return {
 						data: result,
 						result,
-						usage: this.aggregateUsageSince(beforeLeafId),
+						usage: this.aggregateUsageWithActiveChildUsage(beforeLeafId),
 						model,
 					};
 				}
@@ -1490,7 +1577,7 @@ export class Session implements FlueSession {
 
 				return {
 					text: this.getAssistantText(),
-					usage: this.aggregateUsageSince(beforeLeafId),
+					usage: this.aggregateUsageWithActiveChildUsage(beforeLeafId),
 					model,
 				};
 			},
@@ -1589,6 +1676,21 @@ export async function deleteSessionTree(
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function getPromptUsage(output: unknown): PromptUsage | undefined {
+	if (!output || typeof output !== 'object') return undefined;
+	const usage = (output as { usage?: unknown }).usage;
+	if (!usage || typeof usage !== 'object') return undefined;
+	return usage as PromptUsage;
+}
+
+function getPromptModel(output: unknown): PromptModel | undefined {
+	if (!output || typeof output !== 'object') return undefined;
+	const model = (output as { model?: unknown }).model;
+	if (!model || typeof model !== 'object') return undefined;
+	if (typeof (model as { id?: unknown }).id !== 'string') return undefined;
+	return model as PromptModel;
 }
 
 function redactEnvValues(env: Record<string, string>): Record<string, string> {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -458,6 +458,26 @@ export interface PromptModel {
 	id: string;
 }
 
+export type FlueWorkKind =
+	| 'prompt'
+	| 'skill'
+	| 'task'
+	| 'tool'
+	| 'shell'
+	| (string & {});
+
+export interface FlueWorkRef {
+	workId: string;
+	parentWorkId?: string;
+	kind: FlueWorkKind;
+	name?: string;
+	sessionId?: string;
+	parentSessionId?: string;
+	taskId?: string;
+	role?: string;
+	cwd?: string;
+}
+
 export interface PromptResponse {
 	text: string;
 	usage: PromptUsage;
@@ -653,12 +673,40 @@ export type FlueEvent = (
 	| { type: 'tool_start'; toolName: string; toolCallId: string; args?: any }
 	| { type: 'tool_end'; toolName: string; toolCallId: string; isError: boolean; result?: any }
 	| { type: 'turn_end' }
-	| { type: 'task_start'; taskId: string; prompt: string; role?: string; cwd?: string }
-	| { type: 'task_end'; taskId: string; isError: boolean; result?: any }
+	| {
+			type: 'task_start';
+			taskId: string;
+			workId: string;
+			parentWorkId?: string;
+			prompt: string;
+			description?: string;
+			role?: string;
+			cwd?: string;
+			startedAt: string;
+	  }
+	| {
+			type: 'task_end';
+			taskId: string;
+			workId: string;
+			parentWorkId?: string;
+			isError: boolean;
+			result?: unknown;
+			usage?: PromptUsage;
+			model?: PromptModel;
+			durationMs: number;
+			endedAt: string;
+	  }
 	| { type: 'compaction_start'; reason: 'threshold' | 'overflow'; estimatedTokens: number }
 	| { type: 'compaction_end'; messagesBefore: number; messagesAfter: number }
 	| { type: 'idle' }
-) & { sessionId?: string; parentSessionId?: string; taskId?: string };
+) & {
+	sessionId?: string;
+	parentSessionId?: string;
+	taskId?: string;
+	workId?: string;
+	parentWorkId?: string;
+	workKind?: FlueWorkKind;
+};
 
 export type FlueEventCallback = (event: FlueEvent) => void;
 


### PR DESCRIPTION
this is a small runtime slice from the task telemetry direction in #107.

summary:
- add stable workId/parentWorkId fields and a shared FlueWorkRef type
- emit richer task_start/task_end events with timing, usage, model, role, cwd
- include task telemetry in task tool result details
- roll child task usage into the enclosing prompt/skill response usage
- show task start/done/error lines in flue run

intentionally not doing artifacts/workspace storage here. this just gives task execution a clean event spine that #107/#110 can build on.

verification:
- pnpm --filter @flue/sdk check:types
- pnpm --filter @flue/sdk build
- pnpm --filter @flue/cli build
- pnpm exec biome check packages/sdk/src/types.ts packages/sdk/src/agent.ts packages/sdk/src/session.ts packages/cli/bin/flue.ts