### PR TITLE
fix(sdk): consolidate isBashLike duck-check and reject fs:null

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -1,7 +1,7 @@
 import { discoverSessionContext } from './context.ts';
 import { Harness } from './harness.ts';
 import { assertRoleExists } from './roles.ts';
-import { bashFactoryToSessionEnv, createCwdSessionEnv } from './sandbox.ts';
+import { bashFactoryToSessionEnv, createCwdSessionEnv, isBashLike } from './sandbox.ts';
 import type {
 	AgentConfig,
 	AgentInit,
@@ -195,31 +195,14 @@ function serializeLogError(error: Error): Record<string, unknown> {
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-/** Duck-type detection for just-bash Bash instances. */
-function isBashLike(value: unknown): value is BashLike {
-	return (
-		typeof value === 'object' &&
-		value !== null &&
-		'exec' in value &&
-		'getCwd' in value &&
-		'fs' in value &&
-		typeof (value as any).exec === 'function' &&
-		typeof (value as any).getCwd === 'function' &&
-		typeof (value as any).fs === 'object'
-	);
-}
-
 function isBashFactory(value: unknown): value is BashFactory {
 	return typeof value === 'function';
 }
 
 function isSandboxFactory(value: unknown): value is SandboxFactory {
-	return (
-		typeof value === 'object' &&
-		value !== null &&
-		'createSessionEnv' in value &&
-		typeof (value as any).createSessionEnv === 'function'
-	);
+	if (typeof value !== 'object' || value === null) return false;
+	if (!('createSessionEnv' in value)) return false;
+	return typeof value.createSessionEnv === 'function';
 }
 
 /** Resolve sandbox option to SessionEnv: empty → local → BashFactory → platform hook → SandboxFactory. */

--- a/packages/sdk/src/sandbox.test.ts
+++ b/packages/sdk/src/sandbox.test.ts
@@ -1,0 +1,68 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { isBashLike } from './sandbox.ts';
+
+const validBashLike = {
+	exec: () => ({ stdout: '', stderr: '', exitCode: 0 }),
+	getCwd: () => '/tmp',
+	fs: {
+		readFile: () => '',
+		writeFile: () => {},
+		resolvePath: (a: string, b: string) => `${a}/${b}`,
+	},
+};
+
+describe('isBashLike', () => {
+	it('accepts an object with the required bash-like shape', () => {
+		assert.equal(isBashLike(validBashLike), true);
+	});
+
+	it('rejects null', () => {
+		assert.equal(isBashLike(null), false);
+	});
+
+	it('rejects undefined', () => {
+		assert.equal(isBashLike(undefined), false);
+	});
+
+	it('rejects primitive values', () => {
+		assert.equal(isBashLike('bash'), false);
+		assert.equal(isBashLike(42), false);
+		assert.equal(isBashLike(true), false);
+	});
+
+	it('rejects objects missing exec', () => {
+		const { exec: _exec, ...withoutExec } = validBashLike;
+		assert.equal(isBashLike(withoutExec), false);
+	});
+
+	it('rejects objects missing getCwd', () => {
+		const { getCwd: _getCwd, ...withoutGetCwd } = validBashLike;
+		assert.equal(isBashLike(withoutGetCwd), false);
+	});
+
+	it('rejects objects missing fs', () => {
+		const { fs: _fs, ...withoutFs } = validBashLike;
+		assert.equal(isBashLike(withoutFs), false);
+	});
+
+	it('rejects objects whose exec is not a function', () => {
+		assert.equal(isBashLike({ ...validBashLike, exec: 'bash' }), false);
+	});
+
+	it('rejects objects whose getCwd is not a function', () => {
+		assert.equal(isBashLike({ ...validBashLike, getCwd: '/tmp' }), false);
+	});
+
+	it('rejects objects whose fs is null', () => {
+		// Regression: `typeof null === 'object'`, so a naive typeof check without an
+		// explicit null guard mistakenly accepts `{ ..., fs: null }`. A bash-like
+		// object with a null fs is unusable — the caller would crash on the first
+		// fs.readFile() call instead of failing fast at assertion time.
+		assert.equal(isBashLike({ ...validBashLike, fs: null }), false);
+	});
+
+	it('rejects objects whose fs is a primitive', () => {
+		assert.equal(isBashLike({ ...validBashLike, fs: 'filesystem' }), false);
+	});
+});

--- a/packages/sdk/src/sandbox.ts
+++ b/packages/sdk/src/sandbox.ts
@@ -121,18 +121,21 @@ function createBashSessionEnv(bash: BashLike): SessionEnv {
 }
 
 function assertBashLike(value: unknown): asserts value is BashLike {
-	if (
-		typeof value !== 'object' ||
-		value === null ||
-		!('exec' in value) ||
-		!('getCwd' in value) ||
-		!('fs' in value) ||
-		typeof (value as any).exec !== 'function' ||
-		typeof (value as any).getCwd !== 'function' ||
-		typeof (value as any).fs !== 'object'
-	) {
+	if (!isBashLike(value)) {
 		throw new Error('[flue] BashFactory must return a Bash-like object.');
 	}
+}
+
+/** Duck-type detection for just-bash Bash instances. */
+export function isBashLike(value: unknown): value is BashLike {
+	if (typeof value !== 'object' || value === null) return false;
+	if (!('exec' in value) || !('getCwd' in value) || !('fs' in value)) return false;
+	return (
+		typeof value.exec === 'function' &&
+		typeof value.getCwd === 'function' &&
+		typeof value.fs === 'object' &&
+		value.fs !== null
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

- collapse the duplicate bash-like duck-check into one exported `isBashLike` in `sandbox.ts`
- `assertBashLike` now delegates to it — one source of truth
- add `value.fs !== null` guard so `{ ..., fs: null }` no longer passes
- drop the `as any` casts in both duck-checks; `in` narrowings make them unnecessary
- add `packages/sdk/src/sandbox.test.ts` covering the shape and the null-fs regression (uses built-in `node:test`, no new runtime deps)

## Why

`packages/sdk/src/sandbox.ts` had an `assertBashLike` (throw-on-fail) and `packages/sdk/src/client.ts` had an `isBashLike` (boolean). The bodies were identical — same five checks in the same order, each with a trailing `as any` trio. Two copies of the same guard is a drift hazard; any future tweak has to land in both places.

Both copies had the same subtle bug: `typeof value.fs === 'object'` with no null guard. Because `typeof null === 'object'`, an object like `{ exec: fn, getCwd: fn, fs: null }` was accepted as a valid `BashLike`. A null `fs` is useless — the caller would crash inside `createBashSessionEnv` on the first `fs.readFile(...)` call rather than getting the clear "BashFactory must return a Bash-like object" error at validation time. The before/after reproduction below confirms it:

![before vs. after](https://raw.githubusercontent.com/zhoufengen/flue/pr-media/before-after.png)

The `as any` casts pre-date TS 4.9's narrowing improvements — after `'exec' in value`, TS types `value.exec` as `unknown`, and `typeof value.exec === 'function'` is enough. Removing them is pure cleanup, no behavior change.

## Verification

- `pnpm run check:types` in `packages/sdk/` — green
- `pnpm run build` in `packages/sdk/` — green
- new tests: `node --import tsx --test packages/sdk/src/sandbox.test.ts` — 11/11 passing, including the `fs: null` regression

![test suite output](https://raw.githubusercontent.com/zhoufengen/flue/pr-media/tests-pass.png)

The tests use `node:test` + `node:assert` (no new runtime deps; Node ≥ 22.18 is already required) and `tsx` (already a root devDependency) to strip types. I didn't wire a `test` script into `packages/sdk/package.json` — that's a maintainer call on the test story overall. Happy to add one if you'd like; happy to drop the test file if you'd rather the refactor land alone.
