### PR TITLE
Refactor context discovery around ContextSource

### DIFF
--- a/packages/runtime/src/client.ts
+++ b/packages/runtime/src/client.ts
@@ -1,4 +1,4 @@
-import { discoverSessionContext } from './context.ts';
+import { contextSourceFromSessionEnv, discoverSessionContext } from './context.ts';
 import { Harness } from './harness.ts';
 import { assertRoleExists } from './roles.ts';
 import { dispatchGlobalEvent } from './runtime/events.ts';
@@ -133,7 +133,7 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 				const baseEnv = await resolveSessionEnv(config.id, sandbox, config, options.cwd);
 				const env = options.cwd ? createCwdSessionEnv(baseEnv, options.cwd) : baseEnv;
 				const store: SessionStore = options.persist ?? config.defaultStore;
-				const localContext = await discoverSessionContext(env);
+				const localContext = await discoverSessionContext(contextSourceFromSessionEnv(env));
 
 				// Harness-level model override. Per-call `model` on prompt()/skill() still wins
 				// because resolveModelForCall() applies it on top of this default.

--- a/packages/runtime/src/context.test.ts
+++ b/packages/runtime/src/context.test.ts
@@ -1,0 +1,86 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+	type ContextSource,
+	discoverSessionContext,
+	resolveSkillFilePath,
+} from './context.ts';
+
+test('discovers project context from a read-only ContextSource', async () => {
+	const source = createMemoryContextSource();
+
+	const context = await discoverSessionContext(source);
+
+	assert.equal(context.skills.review?.name, 'review');
+	assert.equal(context.skills.review?.description, 'review a patch');
+	assert.match(context.systemPrompt, /Use repo conventions\./);
+	assert.match(context.systemPrompt, /Available Skills/);
+	assert.match(context.systemPrompt, /\*\*review\*\* — review a patch/);
+	assert.match(context.systemPrompt, /Working directory: \/workspace/);
+	assert.match(context.systemPrompt, /Directory structure:\nAGENTS\.md\n\.agents/);
+});
+
+test('resolves path-based skills through ContextSource', async () => {
+	const source = createMemoryContextSource();
+
+	await assert.doesNotReject(async () => {
+		assert.equal(
+			await resolveSkillFilePath(source, source.cwd, 'review/SKILL.md'),
+			'/workspace/.agents/skills/review/SKILL.md',
+		);
+	});
+	assert.equal(await resolveSkillFilePath(source, source.cwd, 'missing/SKILL.md'), null);
+});
+
+function createMemoryContextSource(): ContextSource {
+	const directories = new Set([
+		'/workspace',
+		'/workspace/.agents',
+		'/workspace/.agents/skills',
+		'/workspace/.agents/skills/review',
+	]);
+	const files = new Map([
+		['/workspace/AGENTS.md', 'Use repo conventions.'],
+		[
+			'/workspace/.agents/skills/review/SKILL.md',
+			`---
+name: review
+description: review a patch
+---
+
+Read the diff carefully.`,
+		],
+	]);
+	const normalize = (path: string) => (path.startsWith('/') ? path : `/workspace/${path}`);
+
+	return {
+		cwd: '/workspace',
+		async readFile(path) {
+			const normalized = normalize(path);
+			const content = files.get(normalized);
+			if (content === undefined) throw new Error(`missing file: ${normalized}`);
+			return content;
+		},
+		async stat(path) {
+			const normalized = normalize(path);
+			return {
+				isFile: files.has(normalized),
+				isDirectory: directories.has(normalized),
+				isSymbolicLink: false,
+				size: files.get(normalized)?.length ?? 0,
+				mtime: new Date(0),
+			};
+		},
+		async readdir(path) {
+			const normalized = normalize(path);
+			if (normalized === '/workspace') return ['AGENTS.md', '.agents'];
+			if (normalized === '/workspace/.agents/skills') return ['review'];
+			return [];
+		},
+		async exists(path) {
+			const normalized = normalize(path);
+			return files.has(normalized) || directories.has(normalized);
+		},
+		resolvePath: normalize,
+	};
+}

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -1,8 +1,21 @@
 /**
- * Context discovery: reads AGENTS.md and .agents/skills/ from a session's
- * working directory. Used at runtime by the session initialisation path.
+ * Context discovery: reads AGENTS.md and .agents/skills/ from a read-only
+ * project context source. Used at runtime by the session initialisation path.
  */
-import type { SessionEnv, Skill } from './types.ts';
+import type { FileStat, SessionEnv, Skill } from './types.ts';
+
+export interface ContextSource {
+	cwd: string;
+	readFile(path: string): Promise<string>;
+	stat(path: string): Promise<FileStat>;
+	readdir(path: string): Promise<string[]>;
+	exists(path: string): Promise<boolean>;
+	resolvePath(path: string): string;
+}
+
+export function contextSourceFromSessionEnv(env: SessionEnv): ContextSource {
+	return env;
+}
 
 // ─── Frontmatter Parsing ────────────────────────────────────────────────────
 
@@ -41,13 +54,13 @@ export function parseFrontmatterFile(content: string, defaultName: string): Fron
 // ─── Context Discovery ──────────────────────────────────────────────────────
 
 /** Read AGENTS.md (and CLAUDE.md if present) from a directory. Returns concatenated contents. */
-export async function readAgentsMd(env: SessionEnv, basePath: string): Promise<string> {
+export async function readAgentsMd(source: ContextSource, basePath: string): Promise<string> {
 	const parts: string[] = [];
 
 	for (const filename of ['AGENTS.md', 'CLAUDE.md']) {
 		const filePath = basePath.endsWith('/') ? basePath + filename : `${basePath}/${filename}`;
-		if (await env.exists(filePath)) {
-			const content = await env.readFile(filePath);
+		if (await source.exists(filePath)) {
+			const content = await source.readFile(filePath);
 			parts.push(content.trim());
 		}
 	}
@@ -76,12 +89,12 @@ export function skillsDirIn(basePath: string): string {
  * skills; only the model does, and it reads the file itself.
  */
 export async function resolveSkillFilePath(
-	env: SessionEnv,
+	source: ContextSource,
 	basePath: string,
 	relPath: string,
 ): Promise<string | null> {
 	const filePath = `${skillsDirIn(basePath)}/${relPath}`;
-	if (!(await env.exists(filePath))) return null;
+	if (!(await source.exists(filePath))) return null;
 	return filePath;
 }
 
@@ -96,30 +109,30 @@ export async function resolveSkillFilePath(
  * Skills" registry (name + description).
  */
 export async function discoverLocalSkills(
-	env: SessionEnv,
+	source: ContextSource,
 	basePath: string,
 ): Promise<Record<string, Skill>> {
 	const skillsDir = skillsDirIn(basePath);
 
-	if (!(await env.exists(skillsDir))) return {};
+	if (!(await source.exists(skillsDir))) return {};
 
 	const skills: Record<string, Skill> = {};
-	const entries = await env.readdir(skillsDir);
+	const entries = await source.readdir(skillsDir);
 
 	for (const entry of entries) {
 		const skillDir = `${skillsDir}/${entry}`;
 
 		try {
-			const s = await env.stat(skillDir);
+			const s = await source.stat(skillDir);
 			if (!s.isDirectory) continue;
 		} catch {
 			continue;
 		}
 
 		const skillMdPath = `${skillDir}/SKILL.md`;
-		if (!(await env.exists(skillMdPath))) continue;
+		if (!(await source.exists(skillMdPath))) continue;
 
-		const content = await env.readFile(skillMdPath);
+		const content = await source.readFile(skillMdPath);
 		const parsed = parseFrontmatterFile(content, entry);
 		skills[parsed.name] = {
 			name: parsed.name,
@@ -186,16 +199,16 @@ export function composeSystemPrompt(
 
 /** Discover AGENTS.md, local skills, and directory listing from the session's cwd. */
 export async function discoverSessionContext(
-	env: SessionEnv,
+	source: ContextSource,
 ): Promise<{ systemPrompt: string; skills: Record<string, Skill> }> {
-	const cwd = env.cwd;
+	const cwd = source.cwd;
 
-	const agentsMd = await readAgentsMd(env, cwd);
-	const skills = await discoverLocalSkills(env, cwd);
+	const agentsMd = await readAgentsMd(source, cwd);
+	const skills = await discoverLocalSkills(source, cwd);
 
 	let directoryListing: string[] | undefined;
 	try {
-		directoryListing = await env.readdir(cwd);
+		directoryListing = await source.readdir(cwd);
 	} catch {
 		// readdir failed (e.g., cwd doesn't exist yet) — skip silently
 	}

--- a/packages/runtime/src/harness.ts
+++ b/packages/runtime/src/harness.ts
@@ -1,5 +1,5 @@
 import { createCallHandle } from './abort.ts';
-import { discoverSessionContext } from './context.ts';
+import { contextSourceFromSessionEnv, discoverSessionContext } from './context.ts';
 import { assertRoleExists } from './roles.ts';
 import { createCwdSessionEnv, createFlueFs } from './sandbox.ts';
 import { type CreateTaskSessionOptions, deleteSessionTree, Session } from './session.ts';
@@ -135,7 +135,7 @@ export class Harness implements FlueHarness {
 		const taskEnv = options.cwd
 			? createCwdSessionEnv(options.parentEnv, options.parentEnv.resolvePath(options.cwd))
 			: options.parentEnv;
-		const localContext = await discoverSessionContext(taskEnv);
+		const localContext = await discoverSessionContext(contextSourceFromSessionEnv(taskEnv));
 		const taskConfig: AgentConfig = {
 			...this.config,
 			systemPrompt: localContext.systemPrompt,


### PR DESCRIPTION
## Summary

- introduce an internal `ContextSource` read-only surface for project context discovery
- make AGENTS.md / CLAUDE.md, local skill discovery, path-based skill resolution, and cwd listing read from `ContextSource` instead of full `SessionEnv`
- adapt today's `SessionEnv` behavior through `contextSourceFromSessionEnv()`, so existing sandbox behavior is unchanged
- add a focused `node:test` smoke proving context discovery works from a read-only source with no shell/write API

Refs #57.

## Why

This keeps `SessionEnv` as the hands layer while giving project context its own smaller boundary. That should make the later “project context without sandbox execution” direction easier without forcing sandbox connectors to own AGENTS.md / skills loading.

## Verification

- `pnpm --filter @flue/sdk check:types`
- `pnpm --filter @flue/sdk build`
- `node --import tsx --test packages/sdk/src/context.test.ts`
- `pnpm --filter @flue/cli build`
- `pnpm exec biome check packages/sdk/src/context.ts packages/sdk/src/client.ts packages/sdk/src/harness.ts packages/sdk/src/context.test.ts`
- `git diff --check`

Note: the first CLI build attempt hit the local sandbox's known `tsx` IPC pipe EPERM; rerunning the same command outside the sandbox passed.