### PR TITLE
Support local sandbox process env policy

### DIFF
--- a/packages/cli/src/lib/build-plugin-node.ts
+++ b/packages/cli/src/lib/build-plugin-node.ts
@@ -107,8 +107,8 @@ async function createDefaultEnv() {
  * when flue itself is running inside an external sandbox / container /
  * CI runner that already provides the isolation boundary.
  */
-async function createLocalEnv() {
-  return createLocalSessionEnv();
+async function createLocalEnv(options) {
+  return createLocalSessionEnv(options);
 }
 
 // Default persistence store for Node — in-memory, process lifetime.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -43,6 +43,7 @@
 	},
 	"scripts": {
 		"build": "tsdown",
+		"check:local-env": "tsx scripts/local-process-env-smoke.ts",
 		"check:types": "tsc --noEmit",
 		"prepublishOnly": "cp ../../README.md ."
 	},

--- a/packages/runtime/scripts/local-process-env-smoke.ts
+++ b/packages/runtime/scripts/local-process-env-smoke.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { createFlueContext, InMemorySessionStore } from '../src/internal.ts';
+import { createLocalSessionEnv } from '../src/node/local-env.ts';
+import type { AgentConfig, FlueContext } from '../src/types.ts';
+
+const secretKey = 'FLUE_LOCAL_PROCESS_ENV_SECRET';
+const visibleKey = 'FLUE_LOCAL_PROCESS_ENV_VISIBLE';
+const perCallKey = 'FLUE_LOCAL_PROCESS_ENV_PER_CALL';
+const nodePath = shellQuote(process.execPath);
+
+process.env[secretKey] = 'should-not-leak';
+
+const agentConfig: AgentConfig = {
+	systemPrompt: '',
+	skills: {},
+	roles: {},
+	model: undefined,
+	resolveModel: () => undefined,
+};
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function envProbeCommand(keys: string[]): string {
+	const script = `process.stdout.write(JSON.stringify(${JSON.stringify(
+		keys,
+	)}.reduce((acc, key) => { acc[key] = process.env[key] ?? null; return acc; }, {})))`;
+	return `${nodePath} -e ${shellQuote(script)}`;
+}
+
+async function readChildEnv(
+	env: ReturnType<typeof createLocalSessionEnv>,
+	keys: string[],
+	options?: { env?: Record<string, string> },
+): Promise<Record<string, string | null>> {
+	const result = await env.exec(envProbeCommand(keys), options);
+	assert.equal(result.exitCode, 0, result.stderr);
+	return JSON.parse(result.stdout);
+}
+
+function createTestContext(id: string, root: string): FlueContext {
+	return createFlueContext({
+		id,
+		runId: `${id}-run`,
+		payload: {},
+		env: process.env,
+		agentConfig,
+		createDefaultEnv: async () => createLocalSessionEnv({ cwd: root }),
+		createLocalEnv: async (options) => createLocalSessionEnv({ cwd: root, ...options }),
+		defaultStore: new InMemorySessionStore(),
+	});
+}
+
+const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), 'flue-local-env-')));
+
+const inherited = createLocalSessionEnv({ cwd: root });
+const inheritedEnv = await readChildEnv(inherited, [secretKey]);
+assert.equal(inheritedEnv[secretKey], 'should-not-leak');
+
+const limited = createLocalSessionEnv({ cwd: root, processEnv: 'limited' });
+const limitedEnv = await readChildEnv(limited, [secretKey, 'PATH', 'HOME']);
+assert.equal(limitedEnv[secretKey], null);
+assert.equal(limitedEnv.PATH, process.env.PATH ?? null);
+assert.equal(limitedEnv.HOME, process.env.HOME ?? null);
+
+const explicit = createLocalSessionEnv({
+	cwd: root,
+	processEnv: {
+		[visibleKey]: 'yes',
+	},
+});
+const explicitEnv = await readChildEnv(explicit, [visibleKey, secretKey, 'PATH']);
+assert.equal(explicitEnv[visibleKey], 'yes');
+assert.equal(explicitEnv[secretKey], null);
+assert.equal(explicitEnv.PATH, null);
+
+const overlaidEnv = await readChildEnv(explicit, [visibleKey, perCallKey, secretKey], {
+	env: { [perCallKey]: 'call' },
+});
+assert.equal(overlaidEnv[visibleKey], 'yes');
+assert.equal(overlaidEnv[perCallKey], 'call');
+assert.equal(overlaidEnv[secretKey], null);
+
+const ctx = createTestContext('local-process-env', root);
+const harness = await ctx.init({
+	model: false,
+	sandbox: 'local',
+	processEnv: { [visibleKey]: 'ctx' },
+});
+const harnessEnv = JSON.parse((await harness.shell(envProbeCommand([visibleKey, secretKey]))).stdout);
+assert.equal(harnessEnv[visibleKey], 'ctx');
+assert.equal(harnessEnv[secretKey], null);
+
+await assert.rejects(
+	() =>
+		createTestContext('non-local-process-env', root).init({
+			model: false,
+			processEnv: 'limited',
+		}),
+	/processEnv.*sandbox: "local"/,
+);

--- a/packages/runtime/src/client.ts
+++ b/packages/runtime/src/client.ts
@@ -24,7 +24,7 @@ export interface FlueContextConfig {
 	env: Record<string, any>;
 	agentConfig: AgentConfig;
 	createDefaultEnv: () => Promise<SessionEnv>;
-	createLocalEnv: () => Promise<SessionEnv>;
+	createLocalEnv: (options?: { processEnv?: AgentInit['processEnv'] }) => Promise<SessionEnv>;
 	defaultStore: SessionStore;
 	/**
 	 * Platform-specific sandbox resolver hook. Called before default resolution.
@@ -120,6 +120,9 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 			if (options.model !== false && typeof options.model !== 'string') {
 				throw new Error('[flue] init({ model }) must be a model string or false.');
 			}
+			if (options.processEnv !== undefined && options.sandbox !== 'local') {
+				throw new Error('[flue] init({ processEnv }) is only supported with sandbox: "local".');
+			}
 
 			const name = options.name ?? 'default';
 			if (initializedHarnessNames.has(name)) {
@@ -130,7 +133,13 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 			try {
 				assertRoleExists(config.agentConfig.roles, options.role);
 				const sandbox = options.sandbox;
-				const baseEnv = await resolveSessionEnv(config.id, sandbox, config, options.cwd);
+				const baseEnv = await resolveSessionEnv(
+					config.id,
+					sandbox,
+					config,
+					options.cwd,
+					options.processEnv,
+				);
 				const env = options.cwd ? createCwdSessionEnv(baseEnv, options.cwd) : baseEnv;
 				const store: SessionStore = options.persist ?? config.defaultStore;
 				const localContext = await discoverSessionContext(env);
@@ -235,12 +244,13 @@ async function resolveSessionEnv(
 	sandbox: AgentInit['sandbox'],
 	config: FlueContextConfig,
 	cwd: string | undefined,
+	processEnv: AgentInit['processEnv'],
 ): Promise<SessionEnv> {
 	if (sandbox === undefined || sandbox === 'empty') {
 		return config.createDefaultEnv();
 	}
 	if (sandbox === 'local') {
-		return config.createLocalEnv();
+		return config.createLocalEnv({ processEnv });
 	}
 	if (isBashFactory(sandbox)) {
 		return bashFactoryToSessionEnv(sandbox);

--- a/packages/runtime/src/node/local-env.ts
+++ b/packages/runtime/src/node/local-env.ts
@@ -15,17 +15,23 @@ import * as path from 'node:path';
 import { promisify } from 'node:util';
 
 import { abortErrorFor } from '../abort.ts';
-import type { FileStat, SessionEnv, ShellResult } from '../types.ts';
+import type { FileStat, LocalProcessEnv, SessionEnv, ShellResult } from '../types.ts';
 
 const execAsync = promisify(execCb);
 
 export interface LocalSessionEnvOptions {
 	/** Working directory. Defaults to `process.cwd()`. */
 	cwd?: string;
+	/**
+	 * Base environment inherited by child processes. Defaults to `process.env`.
+	 * Per-call `exec({ env })` values are layered on top of this base.
+	 */
+	processEnv?: LocalProcessEnv;
 }
 
 export function createLocalSessionEnv(options: LocalSessionEnvOptions = {}): SessionEnv {
 	const cwd = path.resolve(options.cwd ?? process.cwd());
+	const baseEnv = resolveLocalProcessEnv(options.processEnv);
 
 	const resolvePath = (p: string): string => (path.isAbsolute(p) ? p : path.resolve(cwd, p));
 
@@ -52,7 +58,7 @@ export function createLocalSessionEnv(options: LocalSessionEnvOptions = {}): Ses
 			try {
 				const { stdout, stderr } = await execAsync(command, {
 					cwd: opts?.cwd ? resolvePath(opts.cwd) : cwd,
-					env: opts?.env ? { ...process.env, ...opts.env } : process.env,
+					env: opts?.env ? { ...baseEnv, ...opts.env } : baseEnv,
 					signal: mergedSignal,
 					// Return strings (not Buffers) and lift the default 1MB cap.
 					encoding: 'utf8',
@@ -136,4 +142,23 @@ export function createLocalSessionEnv(options: LocalSessionEnvOptions = {}): Ses
 		cwd,
 		resolvePath,
 	};
+}
+
+function resolveLocalProcessEnv(policy: LocalProcessEnv | undefined): NodeJS.ProcessEnv {
+	if (policy === undefined || policy === 'inherit') return process.env;
+	if (policy === 'limited') return limitedProcessEnv(process.env);
+	return { ...policy };
+}
+
+function limitedProcessEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+	const limited: NodeJS.ProcessEnv = {};
+	copyEnvValue(limited, env, 'PATH');
+	copyEnvValue(limited, env, 'Path');
+	copyEnvValue(limited, env, 'HOME');
+	return limited;
+}
+
+function copyEnvValue(target: NodeJS.ProcessEnv, source: NodeJS.ProcessEnv, key: string): void {
+	const value = source[key];
+	if (typeof value === 'string') target[key] = value;
 }

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -288,6 +288,15 @@ export interface FlueLogger {
 	error(message: string, attributes?: Record<string, unknown>): void;
 }
 
+/**
+ * Base environment policy for Node's `sandbox: 'local'` child processes.
+ *
+ * - `'inherit'`: pass `process.env` through. Default, preserving current behavior.
+ * - `'limited'`: pass only PATH/Path and HOME from `process.env`.
+ * - object: exact base environment. Per-call `shell({ env })` values are still overlaid.
+ */
+export type LocalProcessEnv = 'inherit' | 'limited' | Record<string, string>;
+
 /** Harness options. A default model is required unless explicitly disabled with `model: false`. */
 export interface AgentInit {
 	/** Harness name. Defaults to `"default"`. */
@@ -306,6 +315,12 @@ export interface AgentInit {
 	 * - `SandboxFactory`: Connector-wrapped external sandbox (Daytona, CF Containers, etc.).
 	 */
 	sandbox?: 'empty' | 'local' | SandboxFactory | BashFactory;
+
+	/**
+	 * Base child-process environment for `sandbox: 'local'` on Node. Ignored for
+	 * every other sandbox mode, where the sandbox connector owns its environment.
+	 */
+	processEnv?: LocalProcessEnv;
 
 	/** Defaults to platform store (in-memory on Node, DO SQLite on Cloudflare). */
 	persist?: SessionStore;
@@ -721,4 +736,3 @@ export type FlueEvent = (
 };
 
 export type FlueEventCallback = (event: FlueEvent) => void | Promise<void>;
-


### PR DESCRIPTION
## Summary

- add init({ processEnv }) for sandbox: local with inherit, limited, and exact-object modes
- use the selected base env for local child processes, with per-call shell env values layered on top
- fail loudly when processEnv is passed with non-local sandboxes
- add a focused local env smoke check

Fixes #116.

## Verification

- pnpm --filter @flue/sdk build
- pnpm --filter @flue/sdk check:types
- pnpm --filter @flue/sdk check:local-env
- pnpm exec biome check --diagnostic-level=error packages/sdk/src/types.ts packages/sdk/src/client.ts packages/sdk/src/node/local-env.ts packages/sdk/src/build-plugin-node.ts packages/sdk/scripts/local-process-env-smoke.ts packages/sdk/package.json

Note: if #121 lands first, this should rebase mechanically onto the @flue/core package layout.