### PR TITLE
Update Cloudflare website link in sandbox connector

### DIFF
--- a/connectors/sandbox--cloudflare.md
+++ b/connectors/sandbox--cloudflare.md
@@ -2,7 +2,7 @@
 {
   "category": "sandbox",
   "website": "https://developers.cloudflare.com/sandbox",
-  "aliases": ["@cloudflare/sandbox", "cloudflare-sandbox", "cf-sandbox"]
+  "aliases": ["@cloudflare/sandbox"]
 }
 ---
 

--- a/connectors/sandbox--cloudflare.md
+++ b/connectors/sandbox--cloudflare.md
@@ -1,7 +1,7 @@
 ---
 {
   "category": "sandbox",
-  "website": "https://developers.cloudflare.com/containers",
+  "website": "https://developers.cloudflare.com/sandbox",
   "aliases": ["@cloudflare/sandbox", "cloudflare-sandbox", "cf-sandbox"]
 }
 ---


### PR DESCRIPTION
Link to Cloudflare's Sandbox docs instead of their Container docs - was a bit confused when I saw the container reference from the `flue add` command.