### PR TITLE
fix(runtime): hydrate Cloudflare AI binding model from pi-ai catalog

### DIFF
--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -1,6 +1,8 @@
 /** Runtime provider registries consumed by `resolveModel` and Session. */
 
 import {
+	getModel,
+	type KnownProvider,
 	registerApiProvider as piRegisterApiProvider,
 	type Api,
 	type Model,
@@ -244,9 +246,16 @@ export function resolveRegisteredModel(
 }
 
 /**
- * Construct a pi-ai Model from a registered provider template. User-defined
- * providers do not have catalog metadata, so cost and context limits default
- * to zero. apiKey flows through `getApiKey`; it is not part of pi-ai's Model.
+ * Construct a pi-ai Model from a registered provider template.
+ *
+ * For HTTP registrations (`HttpProviderRegistration`), there is no catalog
+ * metadata available, so cost and context limits default to zero. apiKey
+ * flows through `getApiKey`; it is not part of pi-ai's Model.
+ *
+ * For Cloudflare AI binding registrations, pi-ai's `cloudflare-workers-ai`
+ * provider catalog declares real `contextWindow`, `maxTokens`, `cost`,
+ * `reasoning`, and `input` for every supported `@cf/*` model id. We hydrate
+ * from there when an entry exists, falling back to zeros otherwise.
  */
 function buildModelFromRegistration(
 	name: string,
@@ -254,17 +263,31 @@ function buildModelFromRegistration(
 	modelId: string,
 ): Model<Api> {
 	if (isCloudflareBindingRegistration(def)) {
+		// pi-ai's `cloudflare-workers-ai` catalog has metadata (contextWindow,
+		// maxTokens, cost, reasoning, input) for every @cf/* model id Cloudflare
+		// exposes via Workers AI. Mirror those fields onto the binding-backed
+		// Model so Flue's compaction trigger evaluates against a real window
+		// instead of the hardcoded zero (which makes `shouldCompact` true on
+		// every turn). Unknown ids fall through to the existing zero defaults.
+		//
+		// `getModel` is typed for literal model ids; the same `as KnownProvider` /
+		// `as never` cast pattern is used in `internal.ts` (`resolveModel`).
+		const catalog = getModel(
+			'cloudflare-workers-ai' as KnownProvider,
+			modelId as never,
+		);
+
 		const base: Model<Api> = {
 			id: modelId,
-			name: modelId,
+			name: catalog?.name ?? modelId,
 			api: CLOUDFLARE_AI_BINDING_API,
 			provider: def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER,
 			baseUrl: '',
-			reasoning: false,
-			input: ['text'],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 0,
-			maxTokens: 0,
+			reasoning: catalog?.reasoning ?? false,
+			input: catalog?.input ?? ['text'],
+			cost: catalog?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+			contextWindow: catalog?.contextWindow ?? 0,
+			maxTokens: catalog?.maxTokens ?? 0,
 		};
 		return attachModelBinding(base, def.binding, def.gateway);
 	}


### PR DESCRIPTION


## Summary

- Look up the model id in pi-ai's `cloudflare-workers-ai` catalog when
  resolving a `CloudflareAIBindingRegistration` in `buildModelFromRegistration`.
  Hydrate `contextWindow`, `maxTokens`, `cost`, `reasoning`, and `input` from
  the catalog when present.
- Fall back to the existing zero defaults when the catalog has no entry, so
  the change is strictly additive for unknown model ids.

Closes #132 (filed alongside this PR).

## Why

Every `cloudflare/<model-id>` model string resolves through
`buildModelFromRegistration`'s Cloudflare-binding branch. That branch
hardcodes `contextWindow: 0` and `maxTokens: 0` on the resulting `Model<Api>`.
It's auto-registered by the generated server entry on `--target cloudflare`,
and exercised by the bundled `examples/cloudflare/` agent. Downstream,
`shouldCompact` in `packages/runtime/src/compaction.ts` evaluates

```ts
return contextTokens > contextWindow - settings.reserveTokens;
// = contextTokens > 0 - 16384
// = always true after turn 1
```

…which surfaces in `wrangler tail` as

```
[flue:compaction] Threshold reached — N tokens used, window 0, reserve 16384, triggering compaction
[flue:compaction] Nothing to compact (no valid cut point found)
```

on every turn after the first. Preventive compaction's threshold is
structurally wrong for the entire binding-mode path. (Overflow recovery still
works *if* pi-ai's `isContextOverflow` regex matches the binding's error
string — currently unverified for Workers AI.)

The metadata Flue needs is already in pi-ai's catalog under the
`cloudflare-workers-ai` provider key. For example, `cloudflare-workers-ai` →
`@cf/moonshotai/kimi-k2.6` declares `contextWindow: 256000, maxTokens:
256000`, with real `cost`, `reasoning`, and `input` fields. The fix is to
look that entry up when the registration is a binding, and copy those values
onto the binding-backed Model literal. Unknown model ids fall through to the
existing zero defaults, so no behaviour changes for non-catalog models.

The JSDoc above `buildModelFromRegistration` (*"User-defined providers do not
have catalog metadata, so cost and context limits default to zero"*) remains
accurate for the HTTP branch (`HttpProviderRegistration`); only the binding
branch gains catalog hydration.

## Code path · before / after

```
                                  BEFORE                       AFTER
                                  ──────                       ─────

  init({ model:                    ┌─ pi-ai catalog                ─┐
   'cloudflare/                    │  cloudflare-workers-ai/        │
    @cf/moonshotai/                │  @cf/moonshotai/kimi-k2.6 ───╮ │
    kimi-k2.6' })                  │  → contextWindow: 256000    │ │
        │                          │  → maxTokens:     256000    │ │
        ▼                          │  → reasoning:     true      │ │
  resolveRegisteredModel           │  → input: [text,image]      │ │
        │                          │  → cost: real numbers       │ │
        ▼                          └─────────────────────────────┼─┘
  buildModelFromRegistration                                     │
   (binding branch)                              getModel(…) ◀───╯
        │                                              │
        ▼                                              ▼
   Model<Api> {                              Model<Api> {
     contextWindow: 0,        ❌                contextWindow: 256000,  ✓
     maxTokens:     0,        ❌                maxTokens:     256000,  ✓
     reasoning:     false,    ❌                reasoning:     true,    ✓
     input:        ['text'],  ❌                input:    [text,image], ✓
     cost:          0,0,0,0,  ❌                cost:     0.95/4/…,     ✓
   }                                         }   (unknown id ⇒ zeros)
        │                                              │
        ▼                                              ▼
  shouldCompact(usage):                       shouldCompact(usage):
   usage.tokens > 0 - 16384                    usage.tokens > 256000-16384
   = true on every turn ❌                     = false until ~239,616  ✓
        │                                              │
        ▼                                              ▼
  wrangler tail (every turn):                 wrangler tail:
   [flue:compaction] Threshold                 (silent on normal turns;
     reached — window 0 …                      fires only at real
   [flue:compaction] Nothing                   overflow)
     to compact
```

## What this PR does not change

- HTTP provider behaviour (`HttpProviderRegistration`) is unchanged. The
  reasoning is in the JSDoc: user-defined providers genuinely have no catalog
  metadata. Only the binding branch gets the lookup.
- `AgentInit.compaction` and a public `session.compact()` are tracked in the
  companion Issue; they would belong in separate PRs.
- The `cloudflare-workers-ai` catalog entry for a given model id is the
  authority. Flue does not second-guess pi-ai's numbers — if Cloudflare ships
  a new model and pi-ai's catalog lags, Flue still falls back to zeros for
  that id (same as today).

## Verification

```bash
pnpm install
pnpm --filter @flue/runtime run check:types     # ✓ clean
pnpm --filter @flue/runtime run build           # ✓ 24 files, 247kB
pnpm exec biome lint packages/runtime/src/runtime/providers.ts   # ✓ no errors
```

(The repo doesn't currently have a test runner wired up — no `vitest` /
`*.test.ts` / `test` script anywhere. I didn't want to introduce a test
framework as part of a bug-fix PR. Happy to follow up with one if you'd
like to take that step.)

End-to-end smoke test (kept out of the PR — pasted here for the
reviewer's convenience) that round-trips through the edited
`resolveRegisteredModel` path via the built `dist/`:

```js
const stubBinding = { run: async () => { throw new Error('stub'); } };
const app = await import('./packages/runtime/dist/app.mjs');
const internal = await import('./packages/runtime/dist/internal.mjs');
app.registerProvider('cloudflare', {
  api: 'cloudflare-ai-binding', binding: stubBinding,
});
const known = internal.resolveModel('cloudflare/@cf/moonshotai/kimi-k2.6');
// known.contextWindow === 256000  (was 0 on main)
// known.maxTokens     === 256000  (was 0 on main)
// known.reasoning     === true    (was false on main)
// known.input         === ['text','image']  (was ['text'] on main)
const unknown = internal.resolveModel('cloudflare/@cf/unknown/nope');
// unknown.contextWindow === 0     (unchanged — fall-through)
```

Manual repro on a deployed Cloudflare Worker, using the existing
`examples/cloudflare/.flue/agents/with-cloudflare-binding.ts`:

```bash
cd examples/cloudflare
npx wrangler dev  # in one terminal
npx wrangler tail # in another

# Trigger any multi-turn flow, e.g. the "multiturn" test:
curl -X POST http://localhost:8787/agents/with-cloudflare-binding/test-1 \
  -H 'content-type: application/json' \
  -d '{"test":"multiturn"}'
```

- **Before this PR**: `wrangler tail` emits
  `[flue:compaction] Threshold reached — N tokens used, window 0, reserve 16384, triggering compaction`
  followed by `Nothing to compact (no valid cut point found)` on every turn
  after the first.
- **After this PR**: no spurious compaction log. Preventive compaction only
  fires when cumulative context approaches
  `contextWindow - reserveTokens` (~239,616 tokens for Kimi K2.6).

## Note for the reviewer

The hydration uses the catalog value rather than hard-coded literals
(`catalog?.contextWindow ?? 0`, etc.) so the fix is robust to future pi-ai
catalog updates and to Cloudflare adding new models. If pi-ai's catalog
later lags Cloudflare's released model list, Flue silently falls back to
zeros for the lagging id — same behaviour as today.

---

