### PR TITLE
feat(providers): passthrough additional properties

### DIFF
--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -51,6 +51,10 @@ export interface HttpProviderRegistration {
 	 * and `configureProvider()` overrides. Defaults to the registry name.
 	 */
 	provider?: string;
+	/** Context window size. Used by compaction logic. Defaults to 0 if unset. */
+	contextWindow?: number;
+	/** Max output tokens. Sent as max_tokens in requests. Defaults to 0 if unset. */
+	maxTokens?: number;
 }
 
 export interface CloudflareAIBindingRegistration {
@@ -75,6 +79,10 @@ export interface CloudflareAIBindingRegistration {
 	 * See https://developers.cloudflare.com/ai-gateway/integrations/worker-binding-methods/.
 	 */
 	gateway?: CloudflareGatewayOptions | false;
+	/** Context window size. Defaults to 0 if unset. */
+	contextWindow?: number;
+	/** Max output tokens. Defaults to 0 if unset. */
+	maxTokens?: number;
 }
 
 /**
@@ -263,8 +271,8 @@ function buildModelFromRegistration(
 			reasoning: false,
 			input: ['text'],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 0,
-			maxTokens: 0,
+			contextWindow: def.contextWindow ?? 0,
+			maxTokens: def.maxTokens ?? 0,
 		};
 		return attachModelBinding(base, def.binding, def.gateway);
 	}
@@ -278,8 +286,8 @@ function buildModelFromRegistration(
 		reasoning: false,
 		input: ['text'],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 0,
-		maxTokens: 0,
+		contextWindow: def.contextWindow ?? 0,
+		maxTokens: def.maxTokens ?? 0,
 		headers: def.headers,
 	};
 }

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -281,7 +281,7 @@ function buildModelFromRegistration(
 					input: ['text'],
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 					contextWindow: def.contextWindow ?? 0,
-			    maxTokens: def.maxTokens ?? 0,
+					maxTokens: def.maxTokens ?? 0,
 				};
 		return attachModelBinding(base, def.binding, def.gateway);
 	}


### PR DESCRIPTION
## Summary

This allows users to configure providers that don't accept `contextWindow: 0` and/or `maxTokens: 0` (litellm errors on `max_completion_tokens: 0`).

Maintains existing behavior of defaulting to `0` if not set by user.

_Side-note: seems like `contextWindow` and `maxTokens` should be configured per model, not at provider level (otherwise it needs to be set to the lowest-common-denominator approximation across all supported models)? Going to create a separate PR for this. Current change unblocks integration. Edit: see #138_

## Validation

- `npx pnpm@9.12.3 --filter @flue/runtime run check:types`
- `npx pnpm@9.12.3 --filter @flue/runtime run build`