### PR TITLE
feat(providers): enable per-model provider configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,20 @@
 
 - **`cloudflare/<model>` resolutions now carry real `contextWindow`, `maxTokens`, `cost`, `reasoning`, and `input` metadata.** Previously the binding branch of `buildModelFromRegistration` synthesized a model from scratch with `contextWindow: 0`, which made `shouldCompact` evaluate `contextTokens > 0 - reserveTokens` as true on every turn after the first — spamming `[flue:compaction] Threshold reached — window 0` and running no-op compaction prep on every turn. Resolution now hydrates from pi-ai's `cloudflare-workers-ai` catalog when the model id is known. Uncatalogued ids (embeddings, image-gen, anything outside pi-ai's chat-completion subset of Workers AI) fall back to zero metadata, and `shouldCompact` now treats `contextWindow <= 0` as unknown and skips the threshold check — overflow recovery still runs. Fixes #132.
 
+- **`registerProvider(...)` now accepts `contextWindow`, `maxTokens`, and per-model overrides for HTTP providers.** Registered HTTP providers (litellm, openrouter, vLLM, custom OpenAI-compatible proxies, etc.) had no way to declare model metadata, so resolved models hardcoded `contextWindow: 0` and `maxTokens: 0` — same bug class as #132 on the binding side. Now the registration accepts provider-level defaults (`contextWindow`, `maxTokens`) and a `models: Record<string, { contextWindow?, maxTokens? }>` map for per-model overrides. Per-model overrides win over provider-level defaults; unset stays `0`, which `shouldCompact` treats as unknown.
+
+  ```ts
+  registerProvider('litellm', {
+    api: 'openai-completions',
+    baseUrl: 'http://localhost:4000/v1',
+    contextWindow: 128000,
+    maxTokens: 16000,
+    models: {
+      'gpt-4o-mini': { contextWindow: 128000, maxTokens: 16384 },
+    },
+  });
+  ```
+
 ## 0.5.3
 
 ### New Features

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -51,6 +51,10 @@ export interface HttpProviderRegistration {
 	 * and `configureProvider()` overrides. Defaults to the registry name.
 	 */
 	provider?: string;
+	/** Context window size. Used by compaction logic. Defaults to 0 if unset. */
+	contextWindow?: number;
+	/** Max output tokens. Sent as max_tokens in requests. Defaults to 0 if unset. */
+	maxTokens?: number;
 }
 
 export interface CloudflareAIBindingRegistration {
@@ -75,6 +79,10 @@ export interface CloudflareAIBindingRegistration {
 	 * See https://developers.cloudflare.com/ai-gateway/integrations/worker-binding-methods/.
 	 */
 	gateway?: CloudflareGatewayOptions | false;
+	/** Context window size. Defaults to 0 if unset. */
+	contextWindow?: number;
+	/** Max output tokens. Defaults to 0 if unset. */
+	maxTokens?: number;
 }
 
 /**
@@ -263,8 +271,8 @@ function buildModelFromRegistration(
 			reasoning: false,
 			input: ['text'],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 0,
-			maxTokens: 0,
+			contextWindow: def.contextWindow ?? 0,
+			maxTokens: def.maxTokens ?? 0,
 		};
 		return attachModelBinding(base, def.binding, def.gateway);
 	}
@@ -278,8 +286,8 @@ function buildModelFromRegistration(
 		reasoning: false,
 		input: ['text'],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: 0,
-		maxTokens: 0,
+		contextWindow: def.contextWindow ?? 0,
+		maxTokens: def.maxTokens ?? 0,
 		headers: def.headers,
 	};
 }

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -281,7 +281,7 @@ function buildModelFromRegistration(
 					input: ['text'],
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 					contextWindow: def.contextWindow ?? 0,
-			    maxTokens: def.maxTokens ?? 0,
+					maxTokens: def.maxTokens ?? 0,
 				};
 		return attachModelBinding(base, def.binding, def.gateway);
 	}

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -51,10 +51,12 @@ export interface HttpProviderRegistration {
 	 * and `configureProvider()` overrides. Defaults to the registry name.
 	 */
 	provider?: string;
-	/** Context window size. Used by compaction logic. Defaults to 0 if unset. */
+	/** Context window size fallback for any model not listed in {@link models}. Defaults to 0. */
 	contextWindow?: number;
-	/** Max output tokens. Sent as max_tokens in requests. Defaults to 0 if unset. */
+	/** Max output tokens fallback for any model not listed in {@link models}. Defaults to 0. */
 	maxTokens?: number;
+	/** Per-model overrides for context window and max tokens. Takes precedence over the provider-level fields. */
+	models?: Record<string, { contextWindow?: number; maxTokens?: number }>;
 }
 
 export interface CloudflareAIBindingRegistration {
@@ -79,10 +81,12 @@ export interface CloudflareAIBindingRegistration {
 	 * See https://developers.cloudflare.com/ai-gateway/integrations/worker-binding-methods/.
 	 */
 	gateway?: CloudflareGatewayOptions | false;
-	/** Context window size. Defaults to 0 if unset. */
+	/** Context window size fallback for any model not listed in {@link models}. Defaults to 0. */
 	contextWindow?: number;
-	/** Max output tokens. Defaults to 0 if unset. */
+	/** Max output tokens fallback for any model not listed in {@link models}. Defaults to 0. */
 	maxTokens?: number;
+	/** Per-model overrides for context window and max tokens. Takes precedence over the provider-level fields. */
+	models?: Record<string, { contextWindow?: number; maxTokens?: number }>;
 }
 
 /**
@@ -271,8 +275,8 @@ function buildModelFromRegistration(
 			reasoning: false,
 			input: ['text'],
 			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: def.contextWindow ?? 0,
-			maxTokens: def.maxTokens ?? 0,
+			contextWindow: def.models?.[modelId]?.contextWindow ?? def.contextWindow ?? 0,
+			maxTokens: def.models?.[modelId]?.maxTokens ?? def.maxTokens ?? 0,
 		};
 		return attachModelBinding(base, def.binding, def.gateway);
 	}
@@ -286,8 +290,8 @@ function buildModelFromRegistration(
 		reasoning: false,
 		input: ['text'],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-		contextWindow: def.contextWindow ?? 0,
-		maxTokens: def.maxTokens ?? 0,
+		contextWindow: def.models?.[modelId]?.contextWindow ?? def.contextWindow ?? 0,
+		maxTokens: def.models?.[modelId]?.maxTokens ?? def.maxTokens ?? 0,
 		headers: def.headers,
 	};
 }

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -53,11 +53,18 @@ export interface HttpProviderRegistration {
 	 * and `configureProvider()` overrides. Defaults to the registry name.
 	 */
 	provider?: string;
-	/** Context window size fallback for any model not listed in {@link models}. Defaults to 0. */
+	/**
+	 * Default `contextWindow` (in tokens) for every model resolved through
+	 * this registration. Overridden per-model via {@link models}. Unset is
+	 * `0`, which the runtime treats as "unknown".
+	 */
 	contextWindow?: number;
-	/** Max output tokens fallback for any model not listed in {@link models}. Defaults to 0. */
+	/**
+	 * Default `maxTokens` for every model resolved through this registration.
+	 * Overridden per-model via {@link models}. Unset is `0`.
+	 */
 	maxTokens?: number;
-	/** Per-model overrides for context window and max tokens. Takes precedence over the provider-level fields. */
+	/** Per-model overrides for {@link contextWindow} and {@link maxTokens}, keyed by model id. */
 	models?: Record<string, { contextWindow?: number; maxTokens?: number }>;
 }
 
@@ -83,12 +90,6 @@ export interface CloudflareAIBindingRegistration {
 	 * See https://developers.cloudflare.com/ai-gateway/integrations/worker-binding-methods/.
 	 */
 	gateway?: CloudflareGatewayOptions | false;
-	/** Context window size fallback for any model not listed in {@link models}. Defaults to 0. */
-	contextWindow?: number;
-	/** Max output tokens fallback for any model not listed in {@link models}. Defaults to 0. */
-	maxTokens?: number;
-	/** Per-model overrides for context window and max tokens. Takes precedence over the provider-level fields. */
-	models?: Record<string, { contextWindow?: number; maxTokens?: number }>;
 }
 
 /**
@@ -259,8 +260,9 @@ export function resolveRegisteredModel(
 
 /**
  * Construct a pi-ai Model from a registered provider template. Binding
- * registrations inherit catalog metadata from `cloudflare-workers-ai`;
- * HTTP registrations have no catalog and default cost/limits to zero.
+ * registrations hydrate metadata from pi-ai's `cloudflare-workers-ai`
+ * catalog; HTTP registrations supply their own metadata, with any unset
+ * fields defaulting to zero.
  */
 function buildModelFromRegistration(
 	name: string,
@@ -284,8 +286,8 @@ function buildModelFromRegistration(
 					reasoning: false,
 					input: ['text'],
 					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-					contextWindow: def.contextWindow ?? 0,
-					maxTokens: def.maxTokens ?? 0,
+					contextWindow: 0,
+					maxTokens: 0,
 				};
 		return attachModelBinding(base, def.binding, def.gateway);
 	}


### PR DESCRIPTION
### Summary

Builds on top of #134 to add per-model configuration.

## Validation

- `npx pnpm@9.12.3 --filter @flue/runtime run check:types`
- `npx pnpm@9.12.3 --filter @flue/runtime run build`