### PR TITLE
fix: hydrate Cloudflare binding models from pi-ai catalog (#132)

### DIFF
--- a/packages/runtime/src/compaction.ts
+++ b/packages/runtime/src/compaction.ts
@@ -145,6 +145,11 @@ export function shouldCompact(
 	settings: CompactionSettings,
 ): boolean {
 	if (!settings.enabled) return false;
+	// Treat a non-positive window as "unknown" — registered providers without
+	// catalog metadata default to 0, and a literal zero-token window isn't a
+	// real configuration. Skipping the threshold here avoids triggering
+	// compaction every turn for those callers. Overflow recovery still runs.
+	if (contextWindow <= 0) return false;
 	return contextTokens > contextWindow - settings.reserveTokens;
 }
 

--- a/packages/runtime/src/compaction.ts
+++ b/packages/runtime/src/compaction.ts
@@ -145,10 +145,7 @@ export function shouldCompact(
 	settings: CompactionSettings,
 ): boolean {
 	if (!settings.enabled) return false;
-	// Treat a non-positive window as "unknown" — registered providers without
-	// catalog metadata default to 0, and a literal zero-token window isn't a
-	// real configuration. Skipping the threshold here avoids triggering
-	// compaction every turn for those callers. Overflow recovery still runs.
+	// `contextWindow <= 0` means unknown — skip threshold; overflow recovery still runs.
 	if (contextWindow <= 0) return false;
 	return contextTokens > contextWindow - settings.reserveTokens;
 }

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -1,6 +1,8 @@
 /** Runtime provider registries consumed by `resolveModel` and Session. */
 
 import {
+	getModel,
+	type KnownProvider,
 	registerApiProvider as piRegisterApiProvider,
 	type Api,
 	type Model,
@@ -244,9 +246,13 @@ export function resolveRegisteredModel(
 }
 
 /**
- * Construct a pi-ai Model from a registered provider template. User-defined
- * providers do not have catalog metadata, so cost and context limits default
- * to zero. apiKey flows through `getApiKey`; it is not part of pi-ai's Model.
+ * Construct a pi-ai Model from a registered provider template.
+ *
+ * HTTP registrations have no catalog metadata available, so cost and context
+ * limits default to zero. Binding registrations hydrate metadata from pi-ai's
+ * `cloudflare-workers-ai` catalog when the model id is known (same `@cf/...`
+ * id space), falling back to zeros otherwise. apiKey flows through
+ * `getApiKey`; it is not part of pi-ai's Model.
  */
 function buildModelFromRegistration(
 	name: string,
@@ -254,18 +260,33 @@ function buildModelFromRegistration(
 	modelId: string,
 ): Model<Api> {
 	if (isCloudflareBindingRegistration(def)) {
-		const base: Model<Api> = {
-			id: modelId,
-			name: modelId,
-			api: CLOUDFLARE_AI_BINDING_API,
-			provider: def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER,
-			baseUrl: '',
-			reasoning: false,
-			input: ['text'],
-			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-			contextWindow: 0,
-			maxTokens: 0,
-		};
+		// Workers AI binding model ids match pi-ai's `cloudflare-workers-ai`
+		// catalog entries (`@cf/<vendor>/<name>`). Inherit `contextWindow`,
+		// `maxTokens`, `cost`, `reasoning`, `input`, `name` from the catalog
+		// so compaction thresholds and usage accounting are accurate; override
+		// the transport-specific fields (`api`, `provider`, `baseUrl`).
+		// `getModel`'s types narrow to a literal id, but at runtime it returns
+		// `undefined` for unknown ids — same pattern used in `resolveModel`.
+		const catalog = getModel('cloudflare-workers-ai' as KnownProvider, modelId as never);
+		const base: Model<Api> = catalog
+			? {
+					...catalog,
+					api: CLOUDFLARE_AI_BINDING_API,
+					provider: def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER,
+					baseUrl: '',
+				}
+			: {
+					id: modelId,
+					name: modelId,
+					api: CLOUDFLARE_AI_BINDING_API,
+					provider: def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER,
+					baseUrl: '',
+					reasoning: false,
+					input: ['text'],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 0,
+					maxTokens: 0,
+				};
 		return attachModelBinding(base, def.binding, def.gateway);
 	}
 

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -246,13 +246,9 @@ export function resolveRegisteredModel(
 }
 
 /**
- * Construct a pi-ai Model from a registered provider template.
- *
- * HTTP registrations have no catalog metadata available, so cost and context
- * limits default to zero. Binding registrations hydrate metadata from pi-ai's
- * `cloudflare-workers-ai` catalog when the model id is known (same `@cf/...`
- * id space), falling back to zeros otherwise. apiKey flows through
- * `getApiKey`; it is not part of pi-ai's Model.
+ * Construct a pi-ai Model from a registered provider template. Binding
+ * registrations inherit catalog metadata from `cloudflare-workers-ai`;
+ * HTTP registrations have no catalog and default cost/limits to zero.
  */
 function buildModelFromRegistration(
 	name: string,
@@ -260,34 +256,24 @@ function buildModelFromRegistration(
 	modelId: string,
 ): Model<Api> {
 	if (isCloudflareBindingRegistration(def)) {
-		// Workers AI binding model ids match pi-ai's `cloudflare-workers-ai`
-		// catalog entries (`@cf/<vendor>/<name>`). Inherit `contextWindow`,
-		// `maxTokens`, `cost`, `reasoning`, `input`, `name` from the catalog
-		// so compaction thresholds and usage accounting are accurate; override
-		// the transport-specific fields (`api`, `provider`, `baseUrl`).
-		// `getModel`'s types narrow to a literal id, but at runtime it returns
-		// `undefined` for unknown ids — same pattern used in `resolveModel`.
 		const catalog = getModel('cloudflare-workers-ai' as KnownProvider, modelId as never);
-		const base: Model<Api> = catalog
-			? {
-					...catalog,
-					api: CLOUDFLARE_AI_BINDING_API,
-					provider: def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER,
-					baseUrl: '',
-				}
-			: {
-					id: modelId,
-					name: modelId,
-					api: CLOUDFLARE_AI_BINDING_API,
-					provider: def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER,
-					baseUrl: '',
-					reasoning: false,
-					input: ['text'],
-					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-					contextWindow: 0,
-					maxTokens: 0,
-				};
-		return attachModelBinding(base, def.binding, def.gateway);
+		if (!catalog) {
+			throw new Error(
+				`[flue] Unknown Workers AI model "${modelId}". ` +
+					`Not present in @mariozechner/pi-ai's "cloudflare-workers-ai" catalog. ` +
+					`Check the model id, or upgrade pi-ai if Cloudflare recently shipped it.`,
+			);
+		}
+		return attachModelBinding(
+			{
+				...catalog,
+				api: CLOUDFLARE_AI_BINDING_API,
+				provider: def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER,
+				baseUrl: '',
+			},
+			def.binding,
+			def.gateway,
+		);
 	}
 
 	return {

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -260,8 +260,7 @@ function buildModelFromRegistration(
 		if (!catalog) {
 			throw new Error(
 				`[flue] Unknown Workers AI model "${modelId}". ` +
-					`Not present in @mariozechner/pi-ai's "cloudflare-workers-ai" catalog. ` +
-					`Check the model id, or upgrade pi-ai if Cloudflare recently shipped it.`,
+					`Not present in @mariozechner/pi-ai's "cloudflare-workers-ai" catalog.`,
 			);
 		}
 		return attachModelBinding(

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -256,23 +256,26 @@ function buildModelFromRegistration(
 	modelId: string,
 ): Model<Api> {
 	if (isCloudflareBindingRegistration(def)) {
+		// pi-ai's catalog covers only the chat-completion subset of Workers AI;
+		// fall back to zero metadata for ids it doesn't know. The `shouldCompact`
+		// guard treats `contextWindow <= 0` as unknown.
 		const catalog = getModel('cloudflare-workers-ai' as KnownProvider, modelId as never);
-		if (!catalog) {
-			throw new Error(
-				`[flue] Unknown Workers AI model "${modelId}". ` +
-					`Not present in @mariozechner/pi-ai's "cloudflare-workers-ai" catalog.`,
-			);
-		}
-		return attachModelBinding(
-			{
-				...catalog,
-				api: CLOUDFLARE_AI_BINDING_API,
-				provider: def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER,
-				baseUrl: '',
-			},
-			def.binding,
-			def.gateway,
-		);
+		const provider = def.provider ?? CLOUDFLARE_AI_BINDING_PROVIDER;
+		const base: Model<Api> = catalog
+			? { ...catalog, api: CLOUDFLARE_AI_BINDING_API, provider, baseUrl: '' }
+			: {
+					id: modelId,
+					name: modelId,
+					api: CLOUDFLARE_AI_BINDING_API,
+					provider,
+					baseUrl: '',
+					reasoning: false,
+					input: ['text'],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 0,
+					maxTokens: 0,
+				};
+		return attachModelBinding(base, def.binding, def.gateway);
 	}
 
 	return {


### PR DESCRIPTION
## Summary

Closes #132. `cloudflare/<model>` resolution now hydrates `contextWindow`, `maxTokens`, `cost`, `reasoning`, `input`, and `name` from pi-ai's `cloudflare-workers-ai` catalog when the model id is known. Uncatalogued ids (embeddings, image-gen, anything outside pi-ai's chat-completion subset of Workers AI) fall back gracefully to zero metadata. Adds a `contextWindow <= 0` guard in `shouldCompact` so unknown windows can never silently flip the threshold-based compaction trigger to permanently true.

## Why

`buildModelFromRegistration`'s binding branch synthesized a `Model<Api>` from scratch with `contextWindow: 0`. Downstream:

```
shouldCompact: contextTokens > contextWindow - reserveTokens
             = contextTokens > 0 - 16384
             = true on every turn after the first
```

…producing the `Threshold reached — window 0` log spam and running no-op compaction prep on every turn for every `cloudflare/...` user.

The binding model id space (`@cf/<vendor>/<name>`) overlaps with pi-ai's `cloudflare-workers-ai` catalog, so for the 8 chat models pi-ai currently catalogues we can pull the real metadata. The registration itself stays (it's the only thing that wires up `env.AI.run()` as a transport; pi-ai has no binding-mode provider of its own).

## What changed

`packages/runtime/src/runtime/providers.ts`
- `buildModelFromRegistration` binding branch: look up `cloudflare-workers-ai/<modelId>` via `getModel`. If found, spread the catalog model and override the transport fields (`api: cloudflare-ai-binding`, `provider: <unchanged default>`, `baseUrl: ''`). If not, fall back to zero metadata with the binding still attached — pi-ai's catalog only covers the chat-completion subset of Workers AI, so non-chat ids (embeddings, image, etc.) need to keep working.
- Provider slug (`workers-ai`) intentionally unchanged. Alignment with pi-ai's `cloudflare-workers-ai` slug is deferred to the architectural follow-up issue (#140).

`packages/runtime/src/compaction.ts`
- `shouldCompact` now treats `contextWindow <= 0` as "unknown" and skips threshold-based compaction. Overflow recovery still runs. Benefits **all** custom registered providers, not just the binding — HTTP registrations also default to `contextWindow: 0` and would have hit the same bug class.

## Verification

Manual checks against the built runtime (fake binding, so we don't need a CF account to verify resolution):

- `resolveModel('cloudflare/@cf/moonshotai/kimi-k2.6')` → `contextWindow: 256000`, `maxTokens: 256000`, real `cost` / `reasoning` / `input`, `name: 'Kimi K2.6'`, `api: 'cloudflare-ai-binding'`, `baseUrl: ''`, binding + gateway attached.
- `resolveModel('cloudflare/@cf/baai/bge-large-en-v1.5')` (uncatalogued embedding model) → resolves with `contextWindow: 0`, binding still attached.
- `shouldCompact(99999, 0, { enabled: true, reserveTokens: 16384, ... })` → `false` (new guard).
- `shouldCompact(200000, 200000, ...)` → `true` (threshold still fires for real windows).
- `shouldCompact(999999, 200000, { enabled: false, ... })` → `false` (enabled flag unaffected).

Also verified:
- `workers-ai-provider.ts` only reads `model.id` / `model.api` / `model.provider` — the catalog spread doesn't leak unexpected fields into the transport path.
- `tsc --noEmit` clean across `@flue/runtime` and `@flue/cli`.
- `biome lint` on the changed files: no new diagnostics added.
- `flue build --target cloudflare` on `examples/cloudflare` succeeds.

## Follow-up

#140 proposes the deeper architectural fix: reshape the binding as a transport override of `cloudflare-workers-ai` rather than a parallel `cloudflare/` provider. That issue also covers the provider-slug alignment question.