### PR TITLE
fix: resolve --env paths relative to cwd, not --root

### DIFF
--- a/packages/cli/bin/flue.ts
+++ b/packages/cli/bin/flue.ts
@@ -968,10 +968,10 @@ async function run(args: RunArgs) {
 	const output = cfg.output;
 	const serverPath = path.join(output, 'server.mjs');
 
-	// Resolve --env paths relative to the project root before building.
+	// Resolve --env paths relative to cwd (where the user invoked flue), not root.
 	let resolvedEnvFiles: string[];
 	try {
-		resolvedEnvFiles = resolveEnvFiles(args.envFiles, root);
+		resolvedEnvFiles = resolveEnvFiles(args.envFiles, process.cwd());
 	} catch (err) {
 		console.error(err instanceof Error ? err.message : String(err));
 		process.exit(1);

--- a/packages/cli/src/lib/dev.ts
+++ b/packages/cli/src/lib/dev.ts
@@ -119,10 +119,8 @@ export async function dev(options: DevOptions): Promise<void> {
 	const output = path.resolve(options.output ?? path.join(root, 'dist'));
 	const port = options.port ?? DEFAULT_DEV_PORT;
 
-	// Resolve env files up front so a typo errors before we kick off a build.
-	// Resolved against root (the project root) so relative paths feel
-	// natural — "the path they look like from where I ran flue".
-	const envFiles = resolveEnvFiles(options.envFiles, root);
+	// Resolve --env paths relative to cwd.
+	const envFiles = resolveEnvFiles(options.envFiles, process.cwd());
 	for (const f of envFiles) {
 		console.error(`[flue] Loading env from: ${f}`);
 	}


### PR DESCRIPTION
## Problem

When `--root` is set to a subdirectory (e.g. `flue dev --root .flue`), `--env` paths are resolved relative to `--root` rather than the working directory where the user invoked the CLI.

This means `--env .flue/.env.local` fails with:

```
[flue] Dev server failed: [flue] --env points at a path that doesn't exist: .flue/.env.local
```

because Flue looks for `.flue/.flue/.env.local` instead.

## Fix

Resolve `--env` paths relative to `process.cwd()` in both `dev()` and the CLI `run()` entrypoint. Absolute paths are unaffected.

This matches the expectation set by the help text (`--env <path>` with no mention of `--root` relativity) and how other CLI tools handle this pattern.

## Repro

```bash
mkdir myproject && cd myproject
mkdir .flue && echo 'FOO=bar' > .flue/.env.local
# Before fix: fails
flue dev --root .flue --env .flue/.env.local
# After fix: works
flue dev --root .flue --env .flue/.env.local
```
