### PR TITLE
Add builtinTools for developer-controlled tool sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@
 
 ### Fixes & Other Changes
 
+- **Agents can now narrow built-in tools with `builtinTools`.** Pass `builtinTools` to `init()`, `harness.session()`, or a single `prompt()` / `skill()` / `task()` call to expose only selected built-ins (`read`, `write`, `edit`, `bash`, `grep`, `glob`, `task`). Omitting the option preserves the existing full built-in tool set.
+
 - **`cloudflare/<model>` resolutions now carry real `contextWindow`, `maxTokens`, `cost`, `reasoning`, and `input` metadata.** Previously the binding branch of `buildModelFromRegistration` synthesized a model from scratch with `contextWindow: 0`, which made `shouldCompact` evaluate `contextTokens > 0 - reserveTokens` as true on every turn after the first — spamming `[flue:compaction] Threshold reached — window 0` and running no-op compaction prep on every turn. Resolution now hydrates from pi-ai's `cloudflare-workers-ai` catalog when the model id is known. Uncatalogued ids (embeddings, image-gen, anything outside pi-ai's chat-completion subset of Workers AI) fall back to zero metadata, and `shouldCompact` now treats `contextWindow <= 0` as unknown and skips the threshold check — overflow recovery still runs. Fixes #132.
 
 ## 0.5.3

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ export default async function ({ init, payload }: FlueContext) {
 
 ### Support Agent
 
-A support agent can also run in a virtual sandbox, but we now add a file-system using an R2 bucket. The knowledge base is stored in R2 and mounted directly into the harness filesystem — the agent searches it with its built-in tools (grep, glob, read). Skills are also defined in the bucket that help the agent perform its task.
+A support agent can also run in a virtual sandbox, but we now add a file-system using an R2 bucket. The knowledge base is stored in R2 and mounted directly into the harness filesystem — the agent searches it with a focused built-in tool set (`read`, `grep`, `glob`). Skills are also defined in the bucket that help the agent perform its task.
 
 Because this agent is deployed to Cloudflare, message history and session state are automatically persisted for you. So you (or your customer) can revisit this support session days, weeks, or years later and pick up exactly where you left off.
 
@@ -70,11 +70,13 @@ export const triggers = { webhook: true };
 
 export default async function ({ init, payload, env }: FlueContext) {
   // Mount the R2 knowledge base bucket as the harness filesystem.
-  // The agent can grep, glob, and read articles with bash, but
+  // The agent can grep, glob, and read articles, but
   // without needing to spin up an entire container sandbox.
   const sandbox = await getVirtualSandbox(env.KNOWLEDGE_BASE);
   const harness = await init({ sandbox, model: 'openrouter/moonshotai/kimi-k2.6' });
-  const session = await harness.session();
+  const session = await harness.session('support', {
+    builtinTools: ['read', 'grep', 'glob'],
+  });
 
   return await session.prompt(
     `You are a support agent. Search the knowledge base for articles
@@ -188,6 +190,25 @@ export default async function ({ init, payload, env }: FlueContext) {
   // and then stream back the progress and final results.
   return await session.prompt(payload.prompt);
 }
+```
+
+### Built-In Tools
+
+By default, every session can use all built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `glob`, and `task`. Use `builtinTools` to narrow that set at the harness, session, or call level. The nearest option wins.
+
+```ts
+const harness = await init({
+  model: 'anthropic/claude-sonnet-4-6',
+  builtinTools: ['read', 'grep', 'glob'],
+});
+
+const session = await harness.session('planner', {
+  builtinTools: ['read', 'grep', 'glob', 'task'],
+});
+
+await session.prompt('Search the knowledge base for billing docs.', {
+  builtinTools: ['read', 'grep', 'glob'],
+});
 ```
 
 ### Remote MCP Tools

--- a/apps/www/src/code-snippets.ts
+++ b/apps/www/src/code-snippets.ts
@@ -38,11 +38,13 @@ export const triggers = { webhook: true };
 export default async function ({ init, payload, env }: FlueContext) {
   // Mount your R2 bucket (declared as a binding in wrangler.jsonc) as
   // the agent's filesystem at /workspace, backed by Durable Object
-  // SQLite + R2 under the hood. The agent searches it with bash —
-  // grep, glob, read — without spinning up a container.
+  // SQLite + R2 under the hood. The agent searches it with read,
+  // grep, and glob without spinning up a container.
   const sandbox = await getVirtualSandbox(env.KNOWLEDGE_BASE_BUCKET);
   const harness = await init({ sandbox, model: 'openrouter/moonshotai/kimi-k2.6' });
-  const session = await harness.session();
+  const session = await harness.session('support', {
+    builtinTools: ['read', 'grep', 'glob'],
+  });
   // Prompt! The agent harness includes your workspace AGENTS.md,
   // skills, and roles (aka subagents) to complete your task as 
   // desired. Use \`session.skill()\` to call a skill directly.

--- a/docs/deploy-cloudflare.md
+++ b/docs/deploy-cloudflare.md
@@ -171,7 +171,7 @@ EOF`);
 }
 ```
 
-The agent can use its built-in tools — grep, glob, read — to search and read these files. This is still running on a virtual sandbox (no container), so it's fast and cheap.
+The agent can use its built-in tools — `grep`, `glob`, `read` — to search and read these files. You can pass `builtinTools: ['read', 'grep', 'glob']` when opening the session to keep this kind of agent read-only. This is still running on a virtual sandbox (no container), so it's fast and cheap.
 
 ## R2-backed agents
 
@@ -179,7 +179,7 @@ Inline files work for small, static content. But for larger datasets — a knowl
 
 ### The support agent pattern
 
-This is one of the most powerful patterns on Cloudflare: a support agent that searches a knowledge base to answer customer questions. The knowledge base lives in R2, and Flue mounts it as the sandbox filesystem — the agent searches it with grep, glob, and read, just like a real filesystem.
+This is one of the most powerful patterns on Cloudflare: a support agent that searches a knowledge base to answer customer questions. The knowledge base lives in R2, and Flue mounts it as the sandbox filesystem — the agent searches it with `grep`, `glob`, and `read`, just like a real filesystem.
 
 `.flue/agents/support.ts`:
 
@@ -192,7 +192,9 @@ export const triggers = { webhook: true };
 export default async function ({ init, payload, env }: FlueContext) {
   const sandbox = await getVirtualSandbox(env.KNOWLEDGE_BASE);
   const harness = await init({ sandbox, model: 'openrouter/moonshotai/kimi-k2.6' });
-  const session = await harness.session();
+  const session = await harness.session('support', {
+    builtinTools: ['read', 'grep', 'glob'],
+  });
 
   return await session.prompt(
     `You are a support agent. Search the knowledge base for articles

--- a/docs/deploy-github-actions.md
+++ b/docs/deploy-github-actions.md
@@ -162,7 +162,7 @@ export default async function ({ init, payload }: FlueContext) {
 }
 ```
 
-If you want a tighter boundary — the agent can call a specific operation but never see the underlying token — wrap the operation as a custom tool with `init({ tools: [...] })`. The tool implementation reads the secret from `process.env`; the agent only sees the tool's parameters and result.
+If you want a tighter boundary — the agent can call a specific operation but never see the underlying token — wrap the operation as a custom tool with `init({ tools: [...] })`. The tool implementation reads the secret from `process.env`; the agent only sees the tool's parameters and result. You can also pass `builtinTools` on `init()`, `harness.session()`, or a single `prompt()` / `skill()` / `task()` call to remove built-ins that workflow does not need.
 
 ### Roles
 

--- a/docs/deploy-gitlab-ci.md
+++ b/docs/deploy-gitlab-ci.md
@@ -190,7 +190,7 @@ export default async function ({ init, payload }: FlueContext) {
 }
 ```
 
-If you want a tighter boundary — the agent can call a specific operation but never see the underlying token — wrap the operation as a custom tool with `init({ tools: [...] })`. The tool implementation reads the secret from `process.env`; the agent only sees the tool's parameters and result.
+If you want a tighter boundary — the agent can call a specific operation but never see the underlying token — wrap the operation as a custom tool with `init({ tools: [...] })`. The tool implementation reads the secret from `process.env`; the agent only sees the tool's parameters and result. You can also pass `builtinTools` on `init()`, `harness.session()`, or a single `prompt()` / `skill()` / `task()` call to remove built-ins that workflow does not need.
 
 ### Roles
 

--- a/docs/deploy-node.md
+++ b/docs/deploy-node.md
@@ -201,7 +201,19 @@ export default async function ({ init, payload }: FlueContext) {
 }
 ```
 
-The agent reads, searches, and modifies files via its built-in tools — read, write, edit, grep, glob, bash. Anything on `$PATH` (`git`, `npm`, `gh`, `docker`) is reachable from the bash tool, and env vars set on the runner are visible to the binaries the agent runs. That's the model: the host environment is the agent's environment.
+The agent reads, searches, and modifies files via its built-in tools — `read`, `write`, `edit`, `grep`, `glob`, `bash`. Anything on `$PATH` (`git`, `npm`, `gh`, `docker`) is reachable from the bash tool, and env vars set on the runner are visible to the binaries the agent runs. That's the model: the host environment is the agent's environment.
+
+Use `builtinTools` when a session or one prompt needs a narrower surface:
+
+```typescript
+const session = await harness.session('reviewer', {
+  builtinTools: ['read', 'grep', 'glob', 'bash'],
+});
+
+await session.prompt('Plan the change without editing files.', {
+  builtinTools: ['read', 'grep', 'glob'],
+});
+```
 
 ### When to use it
 

--- a/examples/hello-world/.flue/agents/with-builtin-tools.ts
+++ b/examples/hello-world/.flue/agents/with-builtin-tools.ts
@@ -1,0 +1,26 @@
+import type { FlueContext } from '@flue/runtime';
+
+export const triggers = { webhook: true };
+
+/**
+ * Built-in tool allowlist example.
+ *
+ * The agent can search and read the knowledge base, but cannot call bash,
+ * write files, edit files, or spawn task sessions.
+ */
+export default async function ({ init, payload }: FlueContext) {
+	const harness = await init({ model: 'anthropic/claude-sonnet-4-6' });
+	const session = await harness.session('readonly-support', {
+		builtinTools: ['read', 'grep', 'glob'],
+	});
+
+	await session.fs.mkdir('/knowledge-base', { recursive: true });
+	await session.fs.writeFile(
+		'/knowledge-base/billing.md',
+		'Refunds are available within 30 days of purchase. Contact billing support for exceptions.',
+	);
+
+	return await session.prompt(
+		`Search /knowledge-base and answer this customer question: ${payload.message}`,
+	);
+}

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -56,7 +56,7 @@ export default async function ({ init, payload }: FlueContext) {
 
 ### Support Agent
 
-A support agent can also run in a virtual sandbox, but we now add a file-system using an R2 bucket. The knowledge base is stored in R2 and mounted directly into the harness filesystem — the agent searches it with its built-in tools (grep, glob, read). Skills are also defined in the bucket that help the agent perform its task.
+A support agent can also run in a virtual sandbox, but we now add a file-system using an R2 bucket. The knowledge base is stored in R2 and mounted directly into the harness filesystem — the agent searches it with a focused built-in tool set (`read`, `grep`, `glob`). Skills are also defined in the bucket that help the agent perform its task.
 
 Because this agent is deployed to Cloudflare, message history and session state are automatically persisted for you. So you (or your customer) can revisit this support session days, weeks, or years later and pick up exactly where you left off.
 
@@ -70,11 +70,13 @@ export const triggers = { webhook: true };
 
 export default async function ({ init, payload, env }: FlueContext) {
   // Mount the R2 knowledge base bucket as the harness filesystem.
-  // The agent can grep, glob, and read articles with bash, but
+  // The agent can grep, glob, and read articles, but
   // without needing to spin up an entire container sandbox.
   const sandbox = await getVirtualSandbox(env.KNOWLEDGE_BASE);
   const harness = await init({ sandbox, model: 'openrouter/moonshotai/kimi-k2.6' });
-  const session = await harness.session();
+  const session = await harness.session('support', {
+    builtinTools: ['read', 'grep', 'glob'],
+  });
 
   return await session.prompt(
     `You are a support agent. Search the knowledge base for articles
@@ -188,6 +190,25 @@ export default async function ({ init, payload, env }: FlueContext) {
   // and then stream back the progress and final results.
   return await session.prompt(payload.prompt);
 }
+```
+
+### Built-In Tools
+
+By default, every session can use all built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `glob`, and `task`. Use `builtinTools` to narrow that set at the harness, session, or call level. The nearest option wins.
+
+```ts
+const harness = await init({
+  model: 'anthropic/claude-sonnet-4-6',
+  builtinTools: ['read', 'grep', 'glob'],
+});
+
+const session = await harness.session('planner', {
+  builtinTools: ['read', 'grep', 'glob', 'task'],
+});
+
+await session.prompt('Search the knowledge base for billing docs.', {
+  builtinTools: ['read', 'grep', 'glob'],
+});
 ```
 
 ### Remote MCP Tools

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -56,7 +56,7 @@ export default async function ({ init, payload }: FlueContext) {
 
 ### Support Agent
 
-A support agent can also run in a virtual sandbox, but we now add a file-system using an R2 bucket. The knowledge base is stored in R2 and mounted directly into the harness filesystem — the agent searches it with its built-in tools (grep, glob, read). Skills are also defined in the bucket that help the agent perform its task.
+A support agent can also run in a virtual sandbox, but we now add a file-system using an R2 bucket. The knowledge base is stored in R2 and mounted directly into the harness filesystem — the agent searches it with a focused built-in tool set (`read`, `grep`, `glob`). Skills are also defined in the bucket that help the agent perform its task.
 
 Because this agent is deployed to Cloudflare, message history and session state are automatically persisted for you. So you (or your customer) can revisit this support session days, weeks, or years later and pick up exactly where you left off.
 
@@ -70,11 +70,13 @@ export const triggers = { webhook: true };
 
 export default async function ({ init, payload, env }: FlueContext) {
   // Mount the R2 knowledge base bucket as the harness filesystem.
-  // The agent can grep, glob, and read articles with bash, but
+  // The agent can grep, glob, and read articles, but
   // without needing to spin up an entire container sandbox.
   const sandbox = await getVirtualSandbox(env.KNOWLEDGE_BASE);
   const harness = await init({ sandbox, model: 'openrouter/moonshotai/kimi-k2.6' });
-  const session = await harness.session();
+  const session = await harness.session('support', {
+    builtinTools: ['read', 'grep', 'glob'],
+  });
 
   return await session.prompt(
     `You are a support agent. Search the knowledge base for articles
@@ -188,6 +190,25 @@ export default async function ({ init, payload, env }: FlueContext) {
   // and then stream back the progress and final results.
   return await session.prompt(payload.prompt);
 }
+```
+
+### Built-In Tools
+
+By default, every session can use all built-in tools: `read`, `write`, `edit`, `bash`, `grep`, `glob`, and `task`. Use `builtinTools` to narrow that set at the harness, session, or call level. The nearest option wins.
+
+```ts
+const harness = await init({
+  model: 'anthropic/claude-sonnet-4-6',
+  builtinTools: ['read', 'grep', 'glob'],
+});
+
+const session = await harness.session('planner', {
+  builtinTools: ['read', 'grep', 'glob', 'task'],
+});
+
+await session.prompt('Search the knowledge base for billing docs.', {
+  builtinTools: ['read', 'grep', 'glob'],
+});
 ```
 
 ### Remote MCP Tools

--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -1,6 +1,6 @@
 import type { AgentTool, AgentToolResult } from '@mariozechner/pi-agent-core';
 import { type Static, Type } from '@mariozechner/pi-ai';
-import type { Role, SessionEnv } from './types.ts';
+import type { BuiltinToolName, Role, SessionEnv } from './types.ts';
 
 const MAX_READ_LINES = 2000;
 const MAX_READ_BYTES = 50 * 1024;
@@ -8,15 +8,29 @@ const MAX_GREP_MATCHES = 100;
 const MAX_GREP_LINE_LENGTH = 500;
 const MAX_GLOB_RESULTS = 1000;
 
-export const BUILTIN_TOOL_NAMES = new Set([
-	'read',
-	'write',
-	'edit',
-	'bash',
-	'grep',
-	'glob',
-	'task',
-]);
+const ALL_BUILTIN_TOOL_NAMES = ['read', 'write', 'edit', 'bash', 'grep', 'glob', 'task'] as const;
+
+export const BUILTIN_TOOL_NAMES = new Set<string>(ALL_BUILTIN_TOOL_NAMES);
+
+const BUILTIN_TOOL_LABELS = [...BUILTIN_TOOL_NAMES].join(', ');
+
+type BuiltinToolSet = Set<BuiltinToolName> | undefined;
+
+const BUILTIN_TOOL_FACTORIES: Record<
+	Exclude<BuiltinToolName, 'task'>,
+	(env: SessionEnv) => AgentTool<any>
+> = {
+	read: createReadTool,
+	write: createWriteTool,
+	edit: createEditTool,
+	bash: createBashTool,
+	grep: createGrepTool,
+	glob: createGlobTool,
+};
+
+const NON_TASK_BUILTIN_TOOL_NAMES = ALL_BUILTIN_TOOL_NAMES.filter(
+	(name): name is Exclude<BuiltinToolName, 'task'> => name !== 'task',
+);
 
 export interface TaskToolParams {
 	prompt: string;
@@ -34,6 +48,7 @@ export interface TaskToolResultDetails {
 }
 
 export interface CreateToolsOptions {
+	builtinTools?: readonly BuiltinToolName[];
 	task?: (
 		params: TaskToolParams,
 		signal?: AbortSignal,
@@ -42,16 +57,32 @@ export interface CreateToolsOptions {
 }
 
 export function createTools(env: SessionEnv, options?: CreateToolsOptions): AgentTool<any>[] {
-	const tools: AgentTool<any>[] = [
-		createReadTool(env),
-		createWriteTool(env),
-		createEditTool(env),
-		createBashTool(env),
-		createGrepTool(env),
-		createGlobTool(env),
-	];
-	if (options?.task) tools.push(createTaskTool(options.task, options.roles ?? {}));
+	const enabledBuiltins = enabledBuiltinTools(options?.builtinTools);
+	const tools = NON_TASK_BUILTIN_TOOL_NAMES.filter((name) =>
+		hasBuiltinTool(enabledBuiltins, name),
+	).map((name) => BUILTIN_TOOL_FACTORIES[name](env));
+	if (options?.task && hasBuiltinTool(enabledBuiltins, 'task')) {
+		tools.push(createTaskTool(options.task, options.roles ?? {}));
+	}
 	return tools;
+}
+
+function enabledBuiltinTools(tools: readonly BuiltinToolName[] | undefined): BuiltinToolSet {
+	if (tools === undefined) return undefined;
+	const enabled = new Set<BuiltinToolName>();
+	for (const name of tools) {
+		if (!BUILTIN_TOOL_NAMES.has(name)) {
+			throw new Error(
+				`[flue] Unknown built-in tool "${name}". Built-in tools: ${BUILTIN_TOOL_LABELS}`,
+			);
+		}
+		enabled.add(name);
+	}
+	return enabled;
+}
+
+function hasBuiltinTool(enabledBuiltins: BuiltinToolSet, name: BuiltinToolName): boolean {
+	return enabledBuiltins === undefined || enabledBuiltins.has(name);
 }
 
 const ReadParams = Type.Object({

--- a/packages/runtime/src/client-compat.ts
+++ b/packages/runtime/src/client-compat.ts
@@ -13,6 +13,7 @@ export type {
 	AgentInit,
 	BashFactory,
 	BashLike,
+	BuiltinToolName,
 	FileStat,
 	FlueContext,
 	FlueEvent,

--- a/packages/runtime/src/client.ts
+++ b/packages/runtime/src/client.ts
@@ -158,6 +158,7 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 						emitEvent(event);
 					},
 					options.tools,
+					options.builtinTools,
 				);
 			} catch (error) {
 				initializedHarnessNames.delete(name);

--- a/packages/runtime/src/harness.ts
+++ b/packages/runtime/src/harness.ts
@@ -5,6 +5,7 @@ import { createCwdSessionEnv, createFlueFs } from './sandbox.ts';
 import { type CreateTaskSessionOptions, deleteSessionTree, Session } from './session.ts';
 import type {
 	AgentConfig,
+	BuiltinToolName,
 	CallHandle,
 	FlueEventCallback,
 	FlueFs,
@@ -43,6 +44,7 @@ export class Harness implements FlueHarness {
 		private store: SessionStore,
 		private eventCallback?: FlueEventCallback,
 		private agentTools: ToolDef[] = [],
+		private agentBuiltinTools?: readonly BuiltinToolName[],
 	) {
 		this.fs = createFlueFs(env);
 	}
@@ -80,6 +82,16 @@ export class Harness implements FlueHarness {
 						`role ${JSON.stringify(open.role ?? null)}; cannot reopen with role ${JSON.stringify(options.role)}.`,
 				);
 			}
+			if (
+				options?.builtinTools !== undefined &&
+				!sameBuiltinTools(options.builtinTools, open.builtinTools)
+			) {
+				throw new Error(
+					`[flue] Session "${sessionName}" is already open with ` +
+						`built-in tools ${formatBuiltinTools(open.builtinTools)}; cannot reopen with ` +
+						`built-in tools ${formatBuiltinTools(options.builtinTools)}.`,
+				);
+			}
 			return open;
 		}
 
@@ -109,6 +121,7 @@ export class Harness implements FlueHarness {
 			existingData: data,
 			onAgentEvent: this.decorateEventCallback(this.eventCallback),
 			agentTools: this.agentTools,
+			sessionBuiltinTools: options?.builtinTools ?? this.agentBuiltinTools,
 			sessionRole: options?.role,
 			taskDepth: 0,
 			createTaskSession: (taskOptions) => this.createTaskSession(taskOptions),
@@ -174,6 +187,7 @@ export class Harness implements FlueHarness {
 			existingData: data,
 			onAgentEvent: eventCallback,
 			agentTools: this.agentTools,
+			sessionBuiltinTools: options.builtinTools,
 			sessionRole: options.role,
 			taskDepth: options.depth,
 			createTaskSession: (childOptions) => this.createTaskSession(childOptions),
@@ -211,4 +225,22 @@ function createEmptySessionData(): SessionData {
 		createdAt: now,
 		updatedAt: now,
 	};
+}
+
+function sameBuiltinTools(
+	left: readonly BuiltinToolName[] | undefined,
+	right: readonly BuiltinToolName[] | undefined,
+): boolean {
+	if (left === undefined || right === undefined) return left === right;
+	const leftSet = new Set(left);
+	const rightSet = new Set(right);
+	if (leftSet.size !== rightSet.size) return false;
+	for (const name of leftSet) {
+		if (!rightSet.has(name)) return false;
+	}
+	return true;
+}
+
+function formatBuiltinTools(tools: readonly BuiltinToolName[] | undefined): string {
+	return JSON.stringify(tools ?? null);
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -31,6 +31,7 @@ export type {
 	ModelConfig,
 	ToolDef,
 	ToolParameters,
+	BuiltinToolName,
 	ThinkingLevel,
 	ProviderSettings,
 } from './types.ts';

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -50,6 +50,7 @@ import { createFlueFs } from './sandbox.ts';
 import type {
 	AgentConfig,
 	BranchSummaryEntry,
+	BuiltinToolName,
 	CallHandle,
 	CompactionEntry,
 	FlueEvent,
@@ -81,6 +82,7 @@ export interface CreateTaskSessionOptions {
 	parentSession: string;
 	taskId: string;
 	parentEnv: SessionEnv;
+	builtinTools?: readonly BuiltinToolName[];
 	cwd?: string;
 	role?: string;
 	depth: number;
@@ -100,6 +102,7 @@ interface SessionInitOptions {
 	existingData: SessionData | null;
 	onAgentEvent?: FlueEventCallback;
 	agentTools?: ToolDef[];
+	sessionBuiltinTools?: readonly BuiltinToolName[];
 	sessionRole?: string;
 	taskDepth?: number;
 	createTaskSession?: CreateTaskSession;
@@ -113,6 +116,7 @@ interface SessionInitOptions {
 // defaults — the name no longer reflects what it does.
 interface RuntimeScopeOptions {
 	tools: ToolDef[];
+	builtinTools?: readonly BuiltinToolName[];
 	role?: string;
 	model?: string;
 	thinkingLevel?: ThinkingLevel;
@@ -398,6 +402,9 @@ export class Session implements FlueSession {
 	get role(): string | undefined {
 		return this.sessionRole;
 	}
+	get builtinTools(): readonly BuiltinToolName[] | undefined {
+		return this.sessionBuiltinTools;
+	}
 
 	private harness: Agent;
 	private storageKey: string;
@@ -411,6 +418,7 @@ export class Session implements FlueSession {
 	private compactionAbortController: AbortController | undefined;
 	private eventCallback: FlueEventCallback | undefined;
 	private agentTools: ToolDef[];
+	private sessionBuiltinTools: readonly BuiltinToolName[] | undefined;
 	private deleted = false;
 	private activeOperation: OperationKind | undefined;
 	private activeOperationId: string | undefined;
@@ -430,6 +438,7 @@ export class Session implements FlueSession {
 		this.fs = createFlueFs(options.env);
 		this.store = options.store;
 		this.agentTools = options.agentTools ?? [];
+		this.sessionBuiltinTools = options.sessionBuiltinTools;
 		this.sessionRole = options.sessionRole;
 		this.taskDepth = options.taskDepth ?? 0;
 		this.createTaskSession = options.createTaskSession;
@@ -453,7 +462,7 @@ export class Session implements FlueSession {
 		assertRoleExists(this.config.roles, this.sessionRole);
 
 		const tools = [
-			...this.createBuiltinTools(this.env, []),
+			...this.createBuiltinTools(this.env, [], this.sessionBuiltinTools),
 			...this.createCustomTools(this.agentTools),
 		];
 
@@ -549,6 +558,7 @@ export class Session implements FlueSession {
 					promptText: buildPromptText(text, schema),
 					schema,
 					tools: options?.tools,
+					builtinTools: options?.builtinTools,
 					role: options?.role,
 					model: options?.model,
 					thinkingLevel: options?.thinkingLevel,
@@ -604,6 +614,7 @@ export class Session implements FlueSession {
 					promptText,
 					schema,
 					tools: options?.tools,
+					builtinTools: options?.builtinTools,
 					role: options?.role,
 					model: options?.model,
 					thinkingLevel: options?.thinkingLevel,
@@ -854,14 +865,16 @@ export class Session implements FlueSession {
 	private createBuiltinTools(
 		env: SessionEnv,
 		tools: ToolDef[],
+		builtinTools: readonly BuiltinToolName[] | undefined,
 		role?: string,
 		model?: string,
 		thinkingLevel?: ThinkingLevel,
 	): AgentTool<any>[] {
 		return createTools(env, {
+			builtinTools,
 			roles: this.config.roles,
 			task: (params, signal) =>
-				this.runTaskForTool(params, tools, role, model, thinkingLevel, signal),
+				this.runTaskForTool(params, tools, builtinTools, role, model, thinkingLevel, signal),
 		});
 	}
 
@@ -876,6 +889,7 @@ export class Session implements FlueSession {
 		const previousThinkingLevel = this.harness.state.thinkingLevel;
 
 		const resolvedModel = this.resolveModelForCall(options.model, options.role, options.callSite);
+		const builtinTools = options.builtinTools ?? this.sessionBuiltinTools;
 		this.harness.state.model = resolvedModel;
 		this.harness.state.systemPrompt = this.buildSystemPrompt(options.role);
 		this.harness.state.thinkingLevel = this.resolveThinkingLevelForCall(
@@ -886,6 +900,7 @@ export class Session implements FlueSession {
 			...this.createBuiltinTools(
 				this.env,
 				options.tools,
+				builtinTools,
 				options.role,
 				options.model,
 				options.thinkingLevel,
@@ -908,6 +923,7 @@ export class Session implements FlueSession {
 	private async runTaskForTool(
 		params: TaskToolParams,
 		tools: ToolDef[],
+		builtinTools: readonly BuiltinToolName[] | undefined,
 		inheritedRole: string | undefined,
 		inheritedModel: string | undefined,
 		inheritedThinkingLevel: ThinkingLevel | undefined,
@@ -921,6 +937,7 @@ export class Session implements FlueSession {
 				inheritedThinkingLevel,
 				cwd: params.cwd,
 				tools,
+				builtinTools: builtinTools ? [...builtinTools] : undefined,
 			},
 			signal,
 		);
@@ -1017,11 +1034,13 @@ export class Session implements FlueSession {
 
 		try {
 			const role = this.resolveEffectiveRole(options?.role);
+			const builtinTools = options?.builtinTools ?? this.sessionBuiltinTools;
 
 			child = await this.createTaskSession({
 				parentSession: this.name,
 				taskId,
 				parentEnv: this.env,
+				builtinTools,
 				cwd: options?.cwd,
 				role,
 				depth: this.taskDepth + 1,
@@ -1045,6 +1064,7 @@ export class Session implements FlueSession {
 					options?.thinkingLevel ??
 					(roleThinkingLevel !== undefined ? undefined : options?.inheritedThinkingLevel),
 				tools: options?.tools,
+				builtinTools: builtinTools ? [...builtinTools] : undefined,
 				images: options?.images,
 				signal,
 			};
@@ -1503,6 +1523,7 @@ export class Session implements FlueSession {
 		promptText: string;
 		schema: v.GenericSchema | undefined;
 		tools: ToolDef[] | undefined;
+		builtinTools: readonly BuiltinToolName[] | undefined;
 		role: string | undefined;
 		model: string | undefined;
 		thinkingLevel: ThinkingLevel | undefined;
@@ -1526,6 +1547,7 @@ export class Session implements FlueSession {
 		return this.withScopedRuntime(
 			{
 				tools: args.tools ?? [],
+				builtinTools: args.builtinTools,
 				role,
 				model: args.model,
 				thinkingLevel: args.thinkingLevel,

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -65,6 +65,8 @@ export interface ToolDef<TParams extends ToolParameters = ToolParameters> {
 	execute: (args: Record<string, any>, signal?: AbortSignal) => Promise<string>;
 }
 
+export type BuiltinToolName = 'read' | 'write' | 'edit' | 'bash' | 'grep' | 'glob' | 'task';
+
 // ─── File Stat ──────────────────────────────────────────────────────────────
 
 export interface FileStat {
@@ -342,6 +344,12 @@ export interface AgentInit {
 	 * Per-call tools are added on top and must not reuse the same names.
 	 */
 	tools?: ToolDef[];
+
+	/**
+	 * Harness-wide built-in tools. Every prompt(), skill(), and task() call can use
+	 * these unless overridden at the session or call site. Defaults to all built-ins.
+	 */
+	builtinTools?: BuiltinToolName[];
 }
 
 // ─── Flue Harness (returned by init()) ──────────────────────────────────────
@@ -377,6 +385,8 @@ export interface FlueSessions {
 export interface SessionOptions {
 	/** Session-wide default role. Per-call roles override this. */
 	role?: string;
+	/** Session-wide built-in tools. Per-call built-in tools override this. */
+	builtinTools?: BuiltinToolName[];
 }
 
 // ─── Flue Session ───────────────────────────────────────────────────────────
@@ -555,6 +565,8 @@ export interface PromptOptions<S extends v.GenericSchema | undefined = undefined
 	 */
 	result?: never;
 	tools?: ToolDef[];
+	/** Built-in tools for this call. Overrides session and harness defaults. */
+	builtinTools?: BuiltinToolName[];
 	role?: string;
 	/** e.g., 'anthropic/claude-sonnet-4-20250514' */
 	model?: string;
@@ -577,6 +589,8 @@ export interface SkillOptions<S extends v.GenericSchema | undefined = undefined>
 	 */
 	result?: never;
 	tools?: ToolDef[];
+	/** Built-in tools for this call. Overrides session and harness defaults. */
+	builtinTools?: BuiltinToolName[];
 	role?: string;
 	model?: string;
 	/** Override reasoning effort for this call. See `AgentInit.thinkingLevel`. */
@@ -597,6 +611,8 @@ export interface TaskOptions<S extends v.GenericSchema | undefined = undefined> 
 	 */
 	result?: never;
 	tools?: ToolDef[];
+	/** Built-in tools for this call. Overrides session and harness defaults. */
+	builtinTools?: BuiltinToolName[];
 	role?: string;
 	model?: string;
 	/** Override reasoning effort for this call. See `AgentInit.thinkingLevel`. */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,4 +1,5 @@
 import { throwMigrationError } from './_migration.ts';
+import type { BuiltinToolName } from './types.ts';
 
 throwMigrationError();
 
@@ -11,6 +12,7 @@ export type {
 	AgentInit,
 	FlueEvent,
 	FlueEventCallback,
+	BuiltinToolName,
 	SessionData,
 	SessionStore,
 	SessionEnv,
@@ -50,5 +52,13 @@ export const resolveEnvFiles = throwMigrationError;
 export const parseEnvFiles = throwMigrationError;
 export const createTools = throwMigrationError;
 export const ResultUnavailableError = Error;
-export const BUILTIN_TOOL_NAMES: string[] = [];
+export const BUILTIN_TOOL_NAMES = [
+	'read',
+	'write',
+	'edit',
+	'bash',
+	'grep',
+	'glob',
+	'task',
+] as const satisfies readonly BuiltinToolName[];
 export const DEFAULT_DEV_PORT = 3583;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -50,8 +50,11 @@ export interface AgentInit {
 	cwd?: string;
 	persist?: SessionStore;
 	tools?: ToolDef[];
+	builtinTools?: BuiltinToolName[];
 	thinkingLevel?: ThinkingLevel;
 }
+
+export type BuiltinToolName = 'read' | 'write' | 'edit' | 'bash' | 'grep' | 'glob' | 'task';
 
 export type FlueEvent = Record<string, unknown> & { type: string };
 export type FlueEventCallback = (event: FlueEvent) => void | Promise<void>;
@@ -97,11 +100,13 @@ export interface BashLike {
 export interface SessionOptions {
 	cwd?: string;
 	parentEnv?: SessionEnv;
+	builtinTools?: BuiltinToolName[];
 }
 
 export interface PromptOptions {
 	model?: PromptModel;
 	tools?: ToolDef[];
+	builtinTools?: BuiltinToolName[];
 	signal?: AbortSignal;
 	thinkingLevel?: ThinkingLevel;
 }


### PR DESCRIPTION
## Summary

- Adds `builtinTools` to harness, session, and per-call options so developers can choose which built-in tools are visible to a model turn.
- Preserves today's default behavior when `builtinTools` is omitted: `read`, `write`, `edit`, `bash`, `grep`, `glob`, and `task` are all available.
- Updates the support-agent docs and examples to show a knowledge-base session limited to `read`, `grep`, and `glob`.

## Motivation

Flue already lets agent code attach custom tools at the harness and call scopes. This gives built-in tools the same shape.

Some agents do not need the full built-in tool set. A support agent backed by an R2 knowledge base may need to search and read files, but it may not need shell execution, file writes, file edits, or task spawning. A CI triage agent might make the opposite tradeoff.

Letting developers choose the built-in tools for an agent narrows the model's action space, can make tool selection more accurate, and avoids sending tool schemas the agent will not use. That can reduce token use, latency, and cost. It also gives application authors one guardrail among many against unwanted actions. Sandboxing is still the deeper isolation layer.

## Test plan

- `pnpm install --frozen-lockfile`
- `pnpm run check:types` in `packages/runtime`
- `pnpm run build` in `packages/runtime`
- `pnpm run build` in `packages/cli`
- `git diff --check`