### PR TITLE
feat(runtime): expose compaction controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 ### New Features
 
+- **Compaction tuning on `init({ compaction })` and on-demand `session.compact()`.** Compaction (the mechanism that summarizes older messages when context approaches the window limit) is now configurable from agent code. `init({ compaction: { reserveTokens, keepRecentTokens, model } })` lets agents shape the headroom buffer, the verbatim tail size, and the summarization model. `init({ compaction: false })` disables threshold compaction entirely (overflow recovery still runs). `session.compact()` triggers compaction on demand for Claude-Code-style `/compact` UX — surfaces in the event stream as `compaction_start` with `reason: 'manual'` and as `operation_start` with `operationKind: 'compact'`. Throws if another operation (`prompt`/`skill`/`task`/`shell`) is in flight on the session. Fixes #135, #136.
+
+  ```ts
+  // Smaller models with tighter windows
+  init({
+    model: 'cloudflare/@cf/google/gemma-7b-it',
+    compaction: { reserveTokens: 1024, keepRecentTokens: 2048 },
+  });
+
+  // Cheap summarizer on an expensive session model
+  init({
+    model: 'anthropic/claude-opus-4-5',
+    compaction: { model: 'anthropic/claude-haiku-4-5' },
+  });
+
+  // Manual compact (e.g. wired to a slash command)
+  await session.compact();
+  ```
+
 - **`local()` sandbox factory for host-bound agents on Node.** A new factory exported from `@flue/runtime/node`. `init({ sandbox: local() })` builds a `SessionEnv` that binds directly to the host: `exec` runs through the user's shell, file methods hit the real filesystem, and `cwd` defaults to `process.cwd()`. Env exposure is opt-in by design — only a small allowlist of shell essentials (`PATH`, `HOME`, `USER`, `LOGNAME`, `HOSTNAME`, `SHELL`, `LANG`, `LC_ALL`, `LC_CTYPE`, `TZ`, `TERM`, `TMPDIR`, `TMP`, `TEMP`) is inherited from `process.env`. Anything else, including API keys and tokens, must be passed explicitly via the `env` option, which keeps host secrets out of the agent's `bash` tool by default. Set a key to `undefined` to drop a default; pass `env: { ...process.env }` to opt into the full host env.
 
   ```ts
@@ -79,6 +98,8 @@
 - **The `@flue/sdk` package is now a migration placeholder.** It keeps publishing with the old export map (`.`, `./app`, `./client`, `./sandbox`, `./internal`, `./cloudflare`, `./node`, `./config`) but has no runtime dependencies and every import throws with migration guidance. This prevents old installs from silently staying on an obsolete package while reserving the name for a future client-side SDK for talking to deployed Flue agents (create runs, stream events, etc.).
 
 ### Fixes & Other Changes
+
+- **Compaction defaults are now model-aware.** Previously every session used flat `reserveTokens: 16384` and `keepRecentTokens: 20000`, which were calibrated for Sonnet-class 200k windows but broke on small-window models (Gemma, Llama-3.1-8B at 8–16k windows): the reserve exceeded the window, so threshold compaction misfired on every turn, and `keepRecentTokens` exceeded the window entirely so `prepareCompaction` could never find a valid cut point. Defaults are now derived from the model's metadata: `reserveTokens = min(20_000, model.maxTokens)` capped further when it would exceed half the contextWindow, and `keepRecentTokens = 8000` (matching the convention used by OpenCode and similar agents — recent-context fidelity doesn't scale with window size). Effect on existing Sonnet/Kimi-class sessions: marginally different trigger points and a smaller verbatim tail (8k vs 20k). Effect on small-window sessions: compaction actually works.
 
 - **`cloudflare/<model>` resolutions now carry real `contextWindow`, `maxTokens`, `cost`, `reasoning`, and `input` metadata.** Previously the binding branch of `buildModelFromRegistration` synthesized a model from scratch with `contextWindow: 0`, which made `shouldCompact` evaluate `contextTokens > 0 - reserveTokens` as true on every turn after the first — spamming `[flue:compaction] Threshold reached — window 0` and running no-op compaction prep on every turn. Resolution now hydrates from pi-ai's `cloudflare-workers-ai` catalog when the model id is known. Uncatalogued ids (embeddings, image-gen, anything outside pi-ai's chat-completion subset of Workers AI) fall back to zero metadata, and `shouldCompact` now treats `contextWindow <= 0` as unknown and skips the threshold check — overflow recovery still runs. Fixes #132.
 

--- a/packages/runtime/src/client.ts
+++ b/packages/runtime/src/client.ts
@@ -145,6 +145,7 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 					model: agentModel,
 					role: options.role ?? config.agentConfig.role,
 					thinkingLevel: options.thinkingLevel ?? config.agentConfig.thinkingLevel,
+					compaction: options.compaction ?? config.agentConfig.compaction,
 				};
 
 				return new Harness(

--- a/packages/runtime/src/compaction.ts
+++ b/packages/runtime/src/compaction.ts
@@ -29,11 +29,46 @@ export interface CompactionSettings {
 	keepRecentTokens: number;
 }
 
+/**
+ * Defaults applied when no user config and no model metadata are available.
+ * Real sessions construct settings via {@link deriveCompactionDefaults} so
+ * headroom tracks the active model instead of a fixed Sonnet-sized window.
+ */
 export const DEFAULT_COMPACTION_SETTINGS: CompactionSettings = {
 	enabled: true,
-	reserveTokens: 16384,
-	keepRecentTokens: 20000,
+	reserveTokens: 20000,
+	keepRecentTokens: 8000,
 };
+
+/**
+ * Compute model-aware defaults. Reserve is capped at the model's max output
+ * because reserving more than the model can emit in one turn wastes context;
+ * the preserved tail stays flat because recent-context fidelity depends on
+ * the active work, not on the model's total window size.
+ *
+ * Caller may override either field after calling this.
+ */
+export function deriveCompactionDefaults(input: {
+	contextWindow: number;
+	maxTokens: number;
+}): CompactionSettings {
+	// When `maxTokens` is unknown (e.g. HTTP providers without declared
+	// metadata), fall back to a flat 20k.
+	const reserveCap = input.maxTokens > 0 ? input.maxTokens : 20000;
+	let reserveTokens = Math.min(20000, reserveCap);
+	// Safety floor for tiny-window models: reserve must leave room for at
+	// least some meaningful context. If reserve would consume half or more
+	// of the window, clamp to a third of the window so threshold compaction
+	// can actually fire usefully instead of triggering on every turn.
+	if (input.contextWindow > 0 && reserveTokens * 2 >= input.contextWindow) {
+		reserveTokens = Math.max(1024, Math.floor(input.contextWindow / 3));
+	}
+	return {
+		enabled: true,
+		reserveTokens,
+		keepRecentTokens: 8000,
+	};
+}
 
 // ─── Token Estimation ───────────────────────────────────────────────────────
 

--- a/packages/runtime/src/compaction.ts
+++ b/packages/runtime/src/compaction.ts
@@ -53,9 +53,9 @@ export function deriveCompactionDefaults(input: {
 	maxTokens: number;
 }): CompactionSettings {
 	// When `maxTokens` is unknown (e.g. HTTP providers without declared
-	// metadata), fall back to a flat 20k.
-	const reserveCap = input.maxTokens > 0 ? input.maxTokens : 20000;
-	let reserveTokens = Math.min(20000, reserveCap);
+	// metadata), fall back to the static reserve.
+	const reserveCap = input.maxTokens > 0 ? input.maxTokens : DEFAULT_COMPACTION_SETTINGS.reserveTokens;
+	let reserveTokens = Math.min(DEFAULT_COMPACTION_SETTINGS.reserveTokens, reserveCap);
 	// Safety floor for tiny-window models: reserve must leave room for at
 	// least some meaningful context. If reserve would consume half or more
 	// of the window, clamp to a third of the window so threshold compaction
@@ -66,7 +66,7 @@ export function deriveCompactionDefaults(input: {
 	return {
 		enabled: true,
 		reserveTokens,
-		keepRecentTokens: 8000,
+		keepRecentTokens: DEFAULT_COMPACTION_SETTINGS.keepRecentTokens,
 	};
 }
 

--- a/packages/runtime/src/runtime/schemas.ts
+++ b/packages/runtime/src/runtime/schemas.ts
@@ -145,7 +145,7 @@ export const FlueEventSchema = v.union([
 	}),
 	flueEvent({
 		type: v.literal('compaction_start'),
-		reason: v.picklist(['threshold', 'overflow']),
+		reason: v.picklist(['threshold', 'overflow', 'manual']),
 		estimatedTokens: v.number(),
 	}),
 	flueEvent({
@@ -158,12 +158,12 @@ export const FlueEventSchema = v.union([
 	flueEvent({
 		type: v.literal('operation_start'),
 		operationId: v.string(),
-		operationKind: v.picklist(['prompt', 'skill', 'task', 'shell']),
+		operationKind: v.picklist(['prompt', 'skill', 'task', 'shell', 'compact']),
 	}),
 	flueEvent({
 		type: v.literal('operation'),
 		operationId: v.string(),
-		operationKind: v.picklist(['prompt', 'skill', 'task', 'shell']),
+		operationKind: v.picklist(['prompt', 'skill', 'task', 'shell', 'compact']),
 		durationMs: v.number(),
 		isError: v.boolean(),
 		error: v.optional(v.unknown()),

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -23,6 +23,7 @@ import {
 	calculateContextTokens,
 	compact,
 	DEFAULT_COMPACTION_SETTINGS,
+	deriveCompactionDefaults,
 	isContextOverflow,
 	prepareCompaction,
 	shouldCompact,
@@ -88,7 +89,7 @@ export interface CreateTaskSessionOptions {
 
 export type CreateTaskSession = (options: CreateTaskSessionOptions) => Promise<Session>;
 
-type OperationKind = 'prompt' | 'skill' | 'task' | 'shell';
+type OperationKind = 'prompt' | 'skill' | 'task' | 'shell' | 'compact';
 
 interface SessionInitOptions {
 	name: string;
@@ -406,7 +407,6 @@ export class Session implements FlueSession {
 	private store: SessionStore;
 	private history: SessionHistory;
 	private createdAt: string | undefined;
-	private compactionSettings: CompactionSettings;
 	private overflowRecoveryAttempted = false;
 	private compactionAbortController: AbortController | undefined;
 	private eventCallback: FlueEventCallback | undefined;
@@ -439,13 +439,6 @@ export class Session implements FlueSession {
 		this.createdAt = options.existingData?.createdAt;
 
 		this.history = SessionHistory.fromData(options.existingData);
-
-		const cc = this.config.compaction;
-		this.compactionSettings = {
-			enabled: cc?.enabled ?? DEFAULT_COMPACTION_SETTINGS.enabled,
-			reserveTokens: cc?.reserveTokens ?? DEFAULT_COMPACTION_SETTINGS.reserveTokens,
-			keepRecentTokens: cc?.keepRecentTokens ?? DEFAULT_COMPACTION_SETTINGS.keepRecentTokens,
-		};
 
 		const systemPrompt = this.config.systemPrompt;
 
@@ -534,6 +527,27 @@ export class Session implements FlueSession {
 					break;
 			}
 		});
+	}
+
+	private resolveCompactionSettings(model: Model<any> | undefined): CompactionSettings {
+		const cc = this.config.compaction;
+		const defaults = model
+			? deriveCompactionDefaults({
+					contextWindow: model.contextWindow ?? 0,
+					maxTokens: model.maxTokens ?? 0,
+				})
+			: DEFAULT_COMPACTION_SETTINGS;
+		if (cc === false) {
+			return { ...defaults, enabled: false };
+		}
+		if (!cc) {
+			return defaults;
+		}
+		return {
+			enabled: true,
+			reserveTokens: cc.reserveTokens ?? defaults.reserveTokens,
+			keepRecentTokens: cc.keepRecentTokens ?? defaults.keepRecentTokens,
+		};
 	}
 
 	prompt<S extends v.GenericSchema>(
@@ -702,6 +716,12 @@ export class Session implements FlueSession {
 				}
 			}),
 		);
+	}
+
+	async compact(): Promise<void> {
+		await this.runOperation('compact', undefined, async () => {
+			await this.runCompaction('manual', false);
+		});
 	}
 
 	abort(): void {
@@ -1273,10 +1293,10 @@ export class Session implements FlueSession {
 	}
 
 	private async checkCompaction(assistantMessage: AssistantMessage): Promise<void> {
-		if (!this.compactionSettings.enabled) return;
 		if (assistantMessage.stopReason === 'aborted') return;
 
 		const model = this.harness.state.model;
+		const settings = this.resolveCompactionSettings(model);
 		const contextWindow = model.contextWindow ?? 0;
 		const overflow = isContextOverflow(assistantMessage, contextWindow);
 
@@ -1301,15 +1321,16 @@ export class Session implements FlueSession {
 			}
 			return;
 		}
+		if (!settings.enabled) return;
 		if (assistantMessage.stopReason === 'error') return;
 
 		const contextTokens = calculateContextTokens(assistantMessage.usage);
 
-		if (shouldCompact(contextTokens, contextWindow, this.compactionSettings)) {
+		if (shouldCompact(contextTokens, contextWindow, settings)) {
 			this.internalLog(
 				'info',
 				`[flue:compaction] Threshold reached — ${contextTokens} tokens used, ` +
-					`window ${contextWindow}, reserve ${this.compactionSettings.reserveTokens}, ` +
+					`window ${contextWindow}, reserve ${settings.reserveTokens}, ` +
 					`triggering compaction`,
 			);
 			await this.runCompaction('threshold', false);
@@ -1323,20 +1344,32 @@ export class Session implements FlueSession {
 	 * `response.usage` — so users see the true cost of the call that
 	 * triggered compaction.
 	 */
-	private async runCompaction(reason: 'threshold' | 'overflow', willRetry: boolean): Promise<void> {
+	private async runCompaction(
+		reason: 'threshold' | 'overflow' | 'manual',
+		willRetry: boolean,
+	): Promise<void> {
 		this.compactionAbortController = new AbortController();
 		const messagesBefore = this.harness.state.messages.length;
 		const compactionStartMs = Date.now();
 
 		try {
-			const model = this.harness.state.model;
+			const sessionModel = this.harness.state.model;
+			const settings = this.resolveCompactionSettings(sessionModel);
+			// Summarization may use a cheaper or stronger model than the active
+			// session model, but the cut point still uses the active model's window.
+			const compactionConfig =
+				this.config.compaction === false ? undefined : this.config.compaction;
+			const summarizationModel = compactionConfig?.model
+				? (this.config.resolveModel(compactionConfig.model) ?? sessionModel)
+				: sessionModel;
+
 			const contextEntries = this.history.buildContextEntries();
 			const messages = contextEntries.map((entry) => entry.message);
 			const latestCompaction = this.history.getLatestCompaction();
 
 			const preparation = prepareCompaction(
 				messages,
-				this.compactionSettings,
+				settings,
 				latestCompaction
 					? {
 							summary: latestCompaction.summary,
@@ -1369,8 +1402,8 @@ export class Session implements FlueSession {
 
 			const result = await compact(
 				preparation,
-				model,
-				this.getProviderApiKey(model.provider),
+				summarizationModel,
+				this.getProviderApiKey(summarizationModel.provider),
 				this.compactionAbortController.signal,
 			);
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -186,11 +186,33 @@ export interface FlueFs {
 // ─── Compaction ─────────────────────────────────────────────────────────────
 
 export interface CompactionConfig {
-	enabled?: boolean;
-	/** Token buffer to keep free in the context window. Default: 16384 */
+	/**
+	 * Token headroom to reserve in the context window. Compaction triggers
+	 * when used tokens exceed `contextWindow - reserveTokens`.
+	 *
+	 * Defaults to `min(20000, model.maxTokens || 20000)` — a flat 20k cap,
+	 * shrunk on models that emit fewer output tokens than that. On a 200k
+	 * Sonnet window this triggers compaction near 96% full, matching the
+	 * defaults used by OpenCode, Claude Code, and similar agents.
+	 */
 	reserveTokens?: number;
-	/** Recent tokens to preserve (not summarized). Default: 20000 */
+	/**
+	 * Recent tokens to preserve unsummarized after compaction. Older messages
+	 * are folded into a summary; this many tokens of recent history remain
+	 * verbatim so the model keeps immediate context (file paths, tool
+	 * results, current focus). Defaults to 8000.
+	 *
+	 * Lower values compact more aggressively at the cost of recent-context
+	 * fidelity. Setting above ~10% of the contextWindow is rarely useful.
+	 */
 	keepRecentTokens?: number;
+	/**
+	 * Override the model used for summarization. Defaults to the session's
+	 * model. Useful for cost optimization (cheap summarizer on an expensive
+	 * session model) or quality routing (long-context summarizer on a
+	 * short-context session). Format: `'provider/modelId'`.
+	 */
+	model?: string;
 }
 
 // ─── Provider Runtime Settings ──────────────────────────────────────────────
@@ -234,7 +256,13 @@ export interface AgentConfig {
 	 * `AgentInit.thinkingLevel` for the full precedence rules.
 	 */
 	thinkingLevel?: ThinkingLevel;
-	compaction?: CompactionConfig;
+	/**
+	 * Compaction tuning. `false` disables threshold compaction (overflow
+	 * recovery and explicit `session.compact()` still run). An object
+	 * overrides individual fields against model-aware defaults. Undefined
+	 * uses defaults.
+	 */
+	compaction?: false | CompactionConfig;
 }
 
 export type ModelConfig = string | false;
@@ -341,6 +369,19 @@ export interface AgentInit {
 	 * Per-call tools are added on top and must not reuse the same names.
 	 */
 	tools?: ToolDef[];
+
+	/**
+	 * Compaction tuning. When context approaches the model's window limit,
+	 * older messages are summarized and replaced with a structured summary
+	 * so the session can continue without overflow.
+	 *
+	 * - Omitted: model-aware defaults (~96% trigger, 8k preserved tail).
+	 * - `false`: disable automatic threshold compaction. Overflow recovery
+	 *   and explicit `session.compact()` still run.
+	 * - `CompactionConfig`: override individual fields. See
+	 *   {@link CompactionConfig}.
+	 */
+	compaction?: false | CompactionConfig;
 }
 
 // ─── Flue Harness (returned by init()) ──────────────────────────────────────
@@ -422,6 +463,23 @@ export interface FlueSession {
 		options: TaskOptions<S> & { schema: S },
 	): CallHandle<PromptResultResponse<v.InferOutput<S>>>;
 	task(text: string, options?: TaskOptions): CallHandle<PromptResponse>;
+
+	/**
+	 * Trigger compaction immediately. Equivalent to what automatic
+	 * compaction would run when crossing the configured threshold, but
+	 * on-demand — useful for surfacing a `/compact`-style action in agent
+	 * UIs without waiting for the window to fill.
+	 *
+	 * Resolves successfully (no-op) when there is nothing to compact.
+	 * Throws if another operation (`prompt` / `skill` / `task` / `shell`)
+	 * is in flight on this session — start a separate session for parallel
+	 * branches.
+	 *
+	 * Emits a {@link FlueEvent} `compaction_start` (with `reason: "manual"`)
+	 * followed by `compaction`. The summarization LLM cost is recorded the
+	 * same as automatic compaction.
+	 */
+	compact(): Promise<void>;
 
 	delete(): Promise<void>;
 }
@@ -687,13 +745,21 @@ export type FlueEvent = (
 		}
 	| { type: 'task_start'; taskId: string; prompt: string; role?: string; cwd?: string }
 	| { type: 'task'; taskId: string; isError: boolean; result?: any; durationMs: number }
-	| { type: 'compaction_start'; reason: 'threshold' | 'overflow'; estimatedTokens: number }
+	| {
+			type: 'compaction_start';
+			reason: 'threshold' | 'overflow' | 'manual';
+			estimatedTokens: number;
+		}
 	| { type: 'compaction'; messagesBefore: number; messagesAfter: number; durationMs: number; usage?: PromptUsage }
-	| { type: 'operation_start'; operationId: string; operationKind: 'prompt' | 'skill' | 'task' | 'shell' }
+	| {
+			type: 'operation_start';
+			operationId: string;
+			operationKind: 'prompt' | 'skill' | 'task' | 'shell' | 'compact';
+		}
 	| {
 			type: 'operation';
 			operationId: string;
-			operationKind: 'prompt' | 'skill' | 'task' | 'shell';
+			operationKind: 'prompt' | 'skill' | 'task' | 'shell' | 'compact';
 			durationMs: number;
 			isError: boolean;
 			error?: unknown;


### PR DESCRIPTION
## Summary
- Adds `init({ compaction })` for runtime compaction tuning, including `reserveTokens`, `keepRecentTokens`, `model`, and `compaction: false` for disabling automatic threshold compaction.
- Adds `session.compact()` for manual `/compact`-style UX, surfaced as `operationKind: 'compact'` and `compaction_start.reason: 'manual'` events.
- Updates compaction defaults to derive headroom from the active model and use a smaller flat preserved tail, so small-window models compact usefully without over-preserving context on large-window models.

Fixes #135.
Fixes #136.

## Verification
- `pnpm -r run check:types`
- `git diff --check`
- Integration test via fake OpenAI-compatible server: 17/17 assertions across defaults, overrides, disabled automatic compaction, manual compaction, in-flight mutex rejection, and `compaction.model` routing.