### PR TITLE
fix(cli): skip Node version check when running under Bun

### DIFF
--- a/packages/cli/bin/flue.mjs
+++ b/packages/cli/bin/flue.mjs
@@ -25,6 +25,12 @@ const MIN_NODE_MINOR = 18;
 const ENGINES_LABEL = '>=22.18';
 
 function checkNodeVersion() {
+	// Bun runs this script with its own runtime and strips TypeScript natively,
+	// so the >=22.18 floor (which exists for Node's native TS config loading)
+	// does not apply. Bypass to avoid showing a misleading "upgrade Node.js"
+	// message to Bun users.
+	if (process.versions.bun) return;
+
 	const v = process.versions.node;
 	const m = /^(\d+)\.(\d+)/.exec(v);
 	if (!m) return; // unparseable; let it through and let the real CLI fail loudly


### PR DESCRIPTION
Hey! We updated `@flue/cli` from `0.3.10` to `0.6.2` in our Bun-first monorepo and our CD pipeline started failing — turns out the new bin shim hard-checks Node version, and we don't have Node in CI, just Bun.

Our setup: we use Bun for everything (scripts, package management, the runtime in our Cloudflare Workers Docker image). The flue build was the one piece that needed Node, purely to satisfy the shebang. We added `setup-node@v5` to unblock `0.6.2`, but it felt off — Bun can run the CLI fine.

Quick sanity check on our end:

```sh
bun --bun node_modules/@flue/cli/bin/flue.mjs build --target cloudflare
```

…produces a clean `dist/` (manifest.json, `_entry.ts`, wrangler.jsonc) for our internal Cloudflare-targeted agent. The only thing in the way is the version check in the bin shim, which assumes the user is on Node.

This PR adds a one-line bypass when running under Bun:

```diff
 function checkNodeVersion() {
+	// Bun runs this script with its own runtime and strips TypeScript natively,
+	// so the >=22.18 floor (which exists for Node's native TS config loading)
+	// does not apply. Bypass to avoid showing a misleading "upgrade Node.js"
+	// message to Bun users.
+	if (process.versions.bun) return;
+
 	const v = process.versions.node;
```

The Node path is unchanged — the early-return only fires when `process.versions.bun` is truthy. `engines.node` is left as-is (it's advisory and Bun ignores it).

## Test plan

- [x] `bun --bun packages/cli/bin/flue.mjs --help` exits 0
- [x] `bun --bun node_modules/@flue/cli/bin/flue.mjs build --target cloudflare` produces a clean dist for our agent
- [x] Node behavior unchanged on supported versions (early-return only fires under Bun)
- [x] Node error path unchanged on Node <22.18 (same exit code, same message)

Happy to restructure or add a unit test if you'd prefer.