### PR TITLE
feat: allow registerProvider to set input modalities 

### DIFF
--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -1,11 +1,11 @@
 /** Runtime provider registries consumed by `resolveModel` and Session. */
 
 import {
+	type Api,
 	getModel,
 	type KnownProvider,
-	registerApiProvider as piRegisterApiProvider,
-	type Api,
 	type Model,
+	registerApiProvider as piRegisterApiProvider,
 } from '@earendil-works/pi-ai';
 import type { CloudflareGatewayOptions } from '../cloudflare/gateway.ts';
 import {
@@ -48,6 +48,11 @@ export interface HttpProviderRegistration {
 	apiKey?: string;
 	/** Optional default headers for every outgoing request. */
 	headers?: Record<string, string>;
+	/**
+	 * Input modalities supported by every model resolved through this
+	 * registration. Defaults to text-only.
+	 */
+	input?: Model<Api>['input'];
 	/**
 	 * Override the pi-ai `provider` slug surfaced on AssistantMessage records
 	 * and `configureProvider()` overrides. Defaults to the registry name.
@@ -299,7 +304,7 @@ function buildModelFromRegistration(
 		provider: def.provider ?? name,
 		baseUrl: def.baseUrl,
 		reasoning: false,
-		input: ['text'],
+		input: def.input ?? ['text'],
 		cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 		contextWindow: def.models?.[modelId]?.contextWindow ?? def.contextWindow ?? 0,
 		maxTokens: def.models?.[modelId]?.maxTokens ?? def.maxTokens ?? 0,

--- a/packages/runtime/test/providers.test.ts
+++ b/packages/runtime/test/providers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+	registerProvider,
+	resolveRegisteredModel,
+} from '../src/runtime/providers.ts';
+
+describe('registered providers', () => {
+	it('defaults HTTP provider input to text', () => {
+		registerProvider('test-text-provider', {
+			api: 'openai-completions',
+			baseUrl: 'https://example.com/v1',
+		});
+
+		expect(resolveRegisteredModel('test-text-provider', 'model')?.input).toEqual([
+			'text',
+		]);
+	});
+
+	it('uses declared HTTP provider input modalities', () => {
+		registerProvider('test-vision-provider', {
+			api: 'openai-completions',
+			baseUrl: 'https://example.com/v1',
+			input: ['text', 'image'],
+		});
+
+		expect(resolveRegisteredModel('test-vision-provider', 'model')?.input).toEqual([
+			'text',
+			'image',
+		]);
+	});
+});


### PR DESCRIPTION
Allows manually registered providers via `registerProvider` to set supported input modalities, such as `["text", "image"]`, instead of always being treated as text-only