### PR TITLE
feat(runtime): add harness-scoped tool hooks for policy and auditing

### DIFF
--- a/packages/runtime/src/client.ts
+++ b/packages/runtime/src/client.ts
@@ -170,6 +170,7 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 					},
 					options.tools,
 					toolFactory,
+					options.hooks,
 				);
 			} catch (error) {
 				initializedHarnessNames.delete(name);

--- a/packages/runtime/src/harness.ts
+++ b/packages/runtime/src/harness.ts
@@ -5,6 +5,7 @@ import { createCwdSessionEnv, createFlueFs } from './sandbox.ts';
 import { type CreateTaskSessionOptions, deleteSessionTree, Session } from './session.ts';
 import type {
 	AgentConfig,
+	AgentHooks,
 	CallHandle,
 	FlueEventCallback,
 	FlueFs,
@@ -45,6 +46,7 @@ export class Harness implements FlueHarness {
 		private eventCallback?: FlueEventCallback,
 		private agentTools: ToolDef[] = [],
 		private toolFactory?: SessionToolFactory,
+		private hooks?: AgentHooks,
 	) {
 		this.fs = createFlueFs(env);
 	}
@@ -112,6 +114,7 @@ export class Harness implements FlueHarness {
 			onAgentEvent: this.decorateEventCallback(this.eventCallback),
 			agentTools: this.agentTools,
 			toolFactory: this.toolFactory,
+			hooks: this.hooks,
 			sessionRole: options?.role,
 			taskDepth: 0,
 			createTaskSession: (taskOptions) => this.createTaskSession(taskOptions),
@@ -178,6 +181,7 @@ export class Harness implements FlueHarness {
 			onAgentEvent: eventCallback,
 			agentTools: this.agentTools,
 			toolFactory: this.toolFactory,
+			hooks: this.hooks,
 			sessionRole: options.role,
 			taskDepth: options.depth,
 			createTaskSession: (childOptions) => this.createTaskSession(childOptions),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	FlueSessions,
 	FlueSession,
 	AgentInit,
+	AgentHooks,
 	FlueEvent,
 	FlueEventCallback,
 	SessionData,
@@ -35,6 +36,9 @@ export type {
 	ToolParameters,
 	ThinkingLevel,
 	ProviderSettings,
+	ToolHookCall,
+	ToolHookResult,
+	ToolExecutionHooks,
 } from './types.ts';
 
 export { Type } from '@earendil-works/pi-ai';

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -50,6 +50,7 @@ import { createFlueFs } from './sandbox.ts';
 
 import type {
 	AgentConfig,
+	AgentHooks,
 	BranchSummaryEntry,
 	CallHandle,
 	CompactionEntry,
@@ -76,6 +77,11 @@ import type {
 	ToolDef,
 } from './types.ts';
 import { addUsage, emptyUsage, fromProviderUsage } from './usage.ts';
+import {
+	runAfterToolHooks,
+	runBeforeToolHooks,
+	wrapAgentToolsWithHooks,
+} from './tool-hooks.ts';
 
 const MAX_TASK_DEPTH = 4;
 
@@ -107,6 +113,7 @@ interface SessionInitOptions {
 	taskDepth?: number;
 	createTaskSession?: CreateTaskSession;
 	onDelete?: () => void;
+	hooks?: AgentHooks;
 }
 
 // TODO: rename `RuntimeScopeOptions` → `CallOverrides` and `withScopedRuntime`
@@ -421,6 +428,7 @@ export class Session implements FlueSession {
 	private taskDepth: number;
 	private createTaskSession: CreateTaskSession | undefined;
 	private onDelete: (() => void) | undefined;
+	private hooks: AgentHooks | undefined;
 
 	constructor(options: SessionInitOptions) {
 		this.name = options.name;
@@ -435,6 +443,7 @@ export class Session implements FlueSession {
 		this.taskDepth = options.taskDepth ?? 0;
 		this.createTaskSession = options.createTaskSession;
 		this.onDelete = options.onDelete;
+		this.hooks = options.hooks;
 
 		this.metadata = options.existingData?.metadata ?? {};
 		this.createdAt = options.existingData?.createdAt;
@@ -447,10 +456,10 @@ export class Session implements FlueSession {
 		assertRoleExists(this.config.roles, this.sessionRole);
 
 		const builtinTools = this.createBuiltinTools(this.env, []);
-		const tools = [
-			...builtinTools,
-			...this.createCustomTools(this.agentTools, builtinTools),
-		];
+		const tools = wrapAgentToolsWithHooks(
+			[...builtinTools, ...this.createCustomTools(this.agentTools, builtinTools)],
+			this.hooks,
+		);
 
 		const previousMessages = this.history.buildContext();
 
@@ -685,6 +694,32 @@ export class Session implements FlueSession {
 
 				this.emit({ type: 'tool_start', toolName: 'bash', toolCallId, args });
 
+				const hookCall = { toolName: 'bash' as const, toolCallId, args };
+
+				try {
+					await runBeforeToolHooks(hookCall, this.hooks);
+				} catch (beforeError) {
+					await runAfterToolHooks(
+						hookCall,
+						{ isError: true, error: beforeError },
+						this.hooks,
+					);
+					const errResult: AgentToolResult<any> = {
+						content: [{ type: 'text', text: getErrorMessage(beforeError) }],
+						details: { command, exitCode: -1 },
+					};
+					await this.appendShellTriple(toolCallId, args, errResult, true);
+					this.emit({
+						type: 'tool_call',
+						toolName: 'bash',
+						toolCallId,
+						isError: true,
+						result: errResult,
+						durationMs: durationSince(toolStartMs),
+					});
+					throw beforeError;
+				}
+
 				try {
 					const result = await this.env.exec(command, {
 						env: options?.env,
@@ -697,6 +732,11 @@ export class Session implements FlueSession {
 						exitCode: result.exitCode,
 					};
 					const toolResult = formatBashResult(shellResult, command);
+					await runAfterToolHooks(
+						hookCall,
+						{ isError: false, result: toolResult },
+						this.hooks,
+					);
 					await this.appendShellTriple(toolCallId, args, toolResult, false);
 					this.emit({
 						type: 'tool_call',
@@ -713,6 +753,7 @@ export class Session implements FlueSession {
 					// number on both branches. -1 is the conventional sentinel for
 					// "no exit recorded" (the same one env.exec uses internally for
 					// sandbox-level failures — see sandbox.ts).
+					await runAfterToolHooks(hookCall, { isError: true, error }, this.hooks);
 					const errResult: AgentToolResult<any> = {
 						content: [{ type: 'text', text: getErrorMessage(error) }],
 						details: { command, exitCode: -1 },
@@ -964,11 +1005,10 @@ export class Session implements FlueSession {
 			[...this.agentTools, ...options.tools],
 			builtinTools,
 		);
-		this.harness.state.tools = [
-			...builtinTools,
-			...customTools,
-			...(options.extraTools ?? []),
-		];
+		this.harness.state.tools = wrapAgentToolsWithHooks(
+			[...builtinTools, ...customTools, ...(options.extraTools ?? [])],
+			this.hooks,
+		);
 		try {
 			return await fn({ resolvedModel });
 		} finally {

--- a/packages/runtime/src/tool-hooks.ts
+++ b/packages/runtime/src/tool-hooks.ts
@@ -1,0 +1,70 @@
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import type { AgentHooks, ToolHookCall, ToolHookResult } from './types.ts';
+
+function hookArgsFromParams(params: unknown): Record<string, unknown> {
+	if (params && typeof params === 'object' && !Array.isArray(params)) {
+		return params as Record<string, unknown>;
+	}
+	return { value: params as unknown };
+}
+
+/** Run `hooks.tool.before` when present. */
+export async function runBeforeToolHooks(
+	call: ToolHookCall,
+	hooks: AgentHooks | undefined,
+): Promise<void> {
+	const before = hooks?.tool?.before;
+	if (!before) return;
+	await before(call);
+}
+
+/**
+ * Run `hooks.tool.after` when present. Errors are logged and swallowed so audit hooks
+ * cannot change model-visible outcomes.
+ */
+export async function runAfterToolHooks(
+	call: ToolHookCall,
+	outcome: ToolHookResult,
+	hooks: AgentHooks | undefined,
+): Promise<void> {
+	const after = hooks?.tool?.after;
+	if (!after) return;
+	try {
+		await after(call, outcome);
+	} catch (error) {
+		console.error('[flue:hooks] tool.after hook threw:', error);
+	}
+}
+
+/**
+ * Wrap each pi-agent tool's execute with harness before/after hooks.
+ */
+export function wrapAgentToolsWithHooks(
+	tools: AgentTool<any>[],
+	hooks: AgentHooks | undefined,
+): AgentTool<any>[] {
+	if (!hooks?.tool?.before && !hooks?.tool?.after) return tools;
+
+	return tools.map((tool) => {
+		const originalExecute = tool.execute.bind(tool);
+		return {
+			...tool,
+			async execute(toolCallId: string, params: unknown, signal?: AbortSignal) {
+				const call: ToolHookCall = {
+					toolName: tool.name,
+					toolCallId,
+					args: hookArgsFromParams(params),
+				};
+				await runBeforeToolHooks(call, hooks);
+				try {
+					const result = await originalExecute(toolCallId, params, signal);
+					await runAfterToolHooks(call, { isError: false, result }, hooks);
+					return result;
+				} catch (error) {
+					await runAfterToolHooks(call, { isError: true, error }, hooks);
+					throw error;
+				}
+			},
+		} as AgentTool<any>;
+	});
+}

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,4 +1,9 @@
-import type { AgentMessage, AgentTool, ThinkingLevel } from '@earendil-works/pi-agent-core';
+import type {
+	AgentMessage,
+	AgentTool,
+	AgentToolResult,
+	ThinkingLevel,
+} from '@earendil-works/pi-agent-core';
 import type { ImageContent, Model, TSchema } from '@earendil-works/pi-ai';
 import type * as v from 'valibot';
 
@@ -316,6 +321,45 @@ export interface FlueLogger {
 	error(message: string, attributes?: Record<string, unknown>): void;
 }
 
+/**
+ * One model-requested tool invocation, passed to harness `hooks`.
+ * `args` is the parsed parameter object for that tool (e.g. bash `{ command, timeout? }`).
+ */
+export interface ToolHookCall {
+	toolName: string;
+	toolCallId: string;
+	args: Record<string, unknown>;
+}
+
+/**
+ * Outcome after a tool execute attempt. On success, `result` is the pi-agent tool result
+ * object. On failure, `error` is the thrown value (often an `Error`).
+ */
+export interface ToolHookResult {
+	isError: boolean;
+	result?: AgentToolResult<any>;
+	error?: unknown;
+}
+
+/** Per-stage callbacks for tool execution on a harness. */
+export interface ToolExecutionHooks {
+	/**
+	 * Runs before the tool body executes. Throw to block execution; the error is returned
+	 * to the model as the tool error result.
+	 */
+	before?: (call: ToolHookCall) => void | Promise<void>;
+	/**
+	 * Runs after execution or after a thrown error from the tool body. Throwing from `after`
+	 * is logged and does not change the outcome seen by the model.
+	 */
+	after?: (call: ToolHookCall, outcome: ToolHookResult) => void | Promise<void>;
+}
+
+/** Harness-scoped extension hooks. */
+export interface AgentHooks {
+	tool?: ToolExecutionHooks;
+}
+
 /** Harness options. A default model is required unless explicitly disabled with `model: false`. */
 export interface AgentInit {
 	/** Harness name. Defaults to `"default"`. */
@@ -369,6 +413,13 @@ export interface AgentInit {
 	 * Per-call tools are added on top and must not reuse the same names.
 	 */
 	tools?: ToolDef[];
+
+	/**
+	 * Optional hooks for this harness (e.g. inspect or block tool calls before they run).
+	 * Task child sessions inherit the same hooks. Thrown errors from `before` become the
+	 * tool error result seen by the model.
+	 */
+	hooks?: AgentHooks;
 
 	/**
 	 * Compaction tuning. When context approaches the model's window limit,

--- a/packages/runtime/test/tool-hooks.test.ts
+++ b/packages/runtime/test/tool-hooks.test.ts
@@ -1,0 +1,169 @@
+import { Type } from '@earendil-works/pi-ai';
+import { describe, expect, it, vi } from 'vitest';
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import { Harness } from '../src/harness.ts';
+import { InMemorySessionStore } from '../src/session.ts';
+import {
+	runAfterToolHooks,
+	runBeforeToolHooks,
+	wrapAgentToolsWithHooks,
+} from '../src/tool-hooks.ts';
+import type { AgentConfig, AgentHooks, SessionEnv } from '../src/types.ts';
+
+function minimalAgentConfig(): AgentConfig {
+	return {
+		systemPrompt: '',
+		skills: {},
+		roles: {},
+		model: undefined,
+		resolveModel: () => undefined,
+	};
+}
+
+function mockSessionEnv(): SessionEnv {
+	const notImpl = async () => {
+		throw new Error('not implemented');
+	};
+	return {
+		exec: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+		readFile: notImpl,
+		readFileBuffer: async () => new Uint8Array(),
+		writeFile: notImpl,
+		stat: notImpl,
+		readdir: notImpl,
+		exists: async () => false,
+		mkdir: notImpl,
+		rm: notImpl,
+		cwd: '/',
+		resolvePath: (p: string) => (p.startsWith('/') ? p : `/${p}`),
+	};
+}
+
+describe('wrapAgentToolsWithHooks', () => {
+	it('runs before hook and blocks execution when before throws', async () => {
+		const exec = vi.fn(async () => ({
+			content: [{ type: 'text' as const, text: 'ran' }],
+			details: {},
+		}));
+		const tool: AgentTool<any> = {
+			name: 'bash',
+			label: 'bash',
+			description: 'test',
+			parameters: Type.Object({ command: Type.String() }),
+			execute: exec,
+		};
+		const wrapped = wrapAgentToolsWithHooks([tool], {
+			tool: {
+				before: async (call) => {
+					if (call.args.command === 'rm -rf /') throw new Error('blocked');
+				},
+			},
+		});
+
+		await expect(wrapped[0]!.execute('tc1', { command: 'rm -rf /' }, undefined)).rejects.toThrow(
+			'blocked',
+		);
+		expect(exec).not.toHaveBeenCalled();
+
+		await wrapped[0]!.execute('tc2', { command: 'echo hi' }, undefined);
+		expect(exec).toHaveBeenCalledTimes(1);
+	});
+
+	it('invokes after with isError false on success', async () => {
+		const after = vi.fn();
+		const tool: AgentTool<any> = {
+			name: 'read',
+			label: 'read',
+			description: 'test',
+			parameters: Type.Object({ path: Type.String() }),
+			async execute() {
+				return { content: [{ type: 'text' as const, text: 'ok' }], details: { path: '/' } };
+			},
+		};
+		const wrapped = wrapAgentToolsWithHooks([tool], {
+			tool: { after },
+		});
+		await wrapped[0]!.execute('id', { path: '/x' }, undefined);
+		expect(after).toHaveBeenCalledTimes(1);
+		const [, outcome] = after.mock.calls[0]!;
+		expect(outcome.isError).toBe(false);
+		expect(outcome.result?.content[0]).toEqual({ type: 'text', text: 'ok' });
+	});
+
+	it('invokes after with isError true when execute throws', async () => {
+		const after = vi.fn();
+		const tool: AgentTool<any> = {
+			name: 'bash',
+			label: 'bash',
+			description: 'test',
+			parameters: Type.Object({ command: Type.String() }),
+			async execute() {
+				throw new Error('exec failed');
+			},
+		};
+		const wrapped = wrapAgentToolsWithHooks([tool], { tool: { after } });
+		await expect(wrapped[0]!.execute('id', { command: 'x' }, undefined)).rejects.toThrow('exec failed');
+		expect(after).toHaveBeenCalledTimes(1);
+		expect(after.mock.calls[0]![1].isError).toBe(true);
+		expect(after.mock.calls[0]![1].error).toMatchObject({ message: 'exec failed' });
+	});
+
+	it('logs and preserves outcome when after hook throws', async () => {
+		const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const tool: AgentTool<any> = {
+			name: 'bash',
+			label: 'bash',
+			description: 'test',
+			parameters: Type.Object({ command: Type.String() }),
+			async execute() {
+				return { content: [{ type: 'text' as const, text: 'done' }], details: {} };
+			},
+		};
+		const wrapped = wrapAgentToolsWithHooks([tool], {
+			tool: {
+				after: async () => {
+					throw new Error('after oops');
+				},
+			},
+		});
+		const result = await wrapped[0]!.execute('id', { command: 'x' }, undefined);
+		expect(result.content[0]).toEqual({ type: 'text', text: 'done' });
+		expect(errSpy).toHaveBeenCalled();
+		errSpy.mockRestore();
+	});
+});
+
+describe('runBeforeToolHooks / runAfterToolHooks', () => {
+	it('no-ops when hooks are undefined', async () => {
+		const call = { toolName: 'x', toolCallId: '1', args: {} };
+		await expect(runBeforeToolHooks(call, undefined)).resolves.toBeUndefined();
+		await expect(runAfterToolHooks(call, { isError: false }, undefined)).resolves.toBeUndefined();
+	});
+});
+
+describe('Harness hooks on task child sessions', () => {
+	it('passes the same AgentHooks instance to task Session', async () => {
+		const hooks: AgentHooks = { tool: { before: async () => {} } };
+		const harness = new Harness(
+			'inst-1',
+			'default',
+			minimalAgentConfig(),
+			mockSessionEnv(),
+			new InMemorySessionStore(),
+			undefined,
+			[],
+			undefined,
+			hooks,
+		);
+
+		const parent = await harness.session();
+		const child = await (harness as any).createTaskSession({
+			parentSession: parent.name,
+			taskId: 't1',
+			parentEnv: mockSessionEnv(),
+			depth: 1,
+		});
+
+		expect((child as unknown as { hooks?: AgentHooks }).hooks).toBe(hooks);
+	});
+});


### PR DESCRIPTION
Allow init({ hooks }) to run before/after each model tool execution, with before throws surfaced as tool errors to the LLM; task sessions inherit hooks; session.shell synthetic bash runs the same hook path.

```ts
const harness = await ctx.init({
  hooks: {
    tool: {
      before: async (call) => {
        if (call.toolName === 'bash' && String(call.args.command).includes('rm -rf')) {
          throw new Error('Blocked: destructive command');
        }
      },
      after: async (call, outcome) => {
        /* audit */
      },
    },
  },
});
```