### PR TITLE
feat(runtime): Expand observability events to allow for capturing llm input/output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features
 
+- **LLM input/output observability events.** Added a public `turn_start` run event emitted immediately before each provider request. It includes the turn id, resolved model/provider/api, reasoning level, system prompt, LLM-visible messages, and tool definitions. The terminal `turn` event now includes the final assistant message as `output`, so observability tooling can capture exact assistant-turn inputs and outputs through `ctx.subscribeEvent()` / run event streams.
+
 - **Cloudflare shell sandbox.** Added `getShellSandbox({ workspace, loader })`, `getDefaultWorkspace()`, and `hydrateFromBucket()` from `@flue/runtime/cloudflare`. The new sandbox wires `@cloudflare/shell` Workspaces into Flue through a codemode `code` tool backed by a Worker Loader binding. Agents use `state.*` inside the `code` tool instead of bash/read/write/grep/glob. Use `@cloudflare/shell` directly for primitives like `Workspace`, `WorkspaceFileSystem`, and `createGit`.
 
 ### Breaking Changes
@@ -70,7 +72,6 @@
 ### Breaking Changes
 
 - **`sandbox` magic strings removed.** `init({ sandbox })` no longer accepts the literal strings `'empty'` or `'local'`. The TypeScript union excludes both, and the runtime throws with a migration message for JS callers / `any`-typed inputs.
-
   - For the default in-memory sandbox, omit the `sandbox` option entirely or pass `false`.
   - For host-bound agents on Node, use the `local()` factory from `@flue/runtime/node`. It also lets you opt host env vars into the sandbox via `local({ env: { ... } })`.
 
@@ -224,7 +225,7 @@
 
 ### Fixes & Other Changes
 
-- **`session.shell()` now redacts `env` values in transcript history.** When you pass per-call environment variables to `session.shell(cmd, { env })`, the keys still appear in the recorded tool-call arguments — so the model can reason about *which* variables were set on a later turn — but the values are replaced with `<redacted>`. The real values are still passed to `env.exec()`, so the command itself runs with the actual environment. This prevents API keys and other secrets from leaking into session storage.
+- **`session.shell()` now redacts `env` values in transcript history.** When you pass per-call environment variables to `session.shell(cmd, { env })`, the keys still appear in the recorded tool-call arguments — so the model can reason about _which_ variables were set on a later turn — but the values are replaced with `<redacted>`. The real values are still passed to `env.exec()`, so the command itself runs with the actual environment. This prevents API keys and other secrets from leaking into session storage.
 
 ## 0.4.0
 
@@ -233,28 +234,27 @@ Big release! We are working hard to stabilize our APIs and add any missing and e
 ### Breaking Changes
 
 - **New return type for `prompt()` / `skill()` / `task()` / `shell()`.** Two changes folded into one new shape:
-
   1. They now return a `CallHandle<T>` instead of a `Promise<T>`. `await` works exactly as before. The handle is a `PromiseLike` with `.signal: AbortSignal` and `.abort(reason?)` for synchronous cancellation, replacing the removed `PromptOptions.timeout` / `SkillOptions.timeout` / `ShellOptions.timeout` fields. Code that uses these as plain Promises without `await` (e.g. raw `.then()` / `.catch()` chains) may need adjustment.
 
   ```ts
   // Cancel via an AbortSignal on the options bag
-  const result = await session.prompt("…", { signal: AbortSignal.timeout(5000) });
+  const result = await session.prompt('…', { signal: AbortSignal.timeout(5000) });
 
   // Or abort the handle directly
-  const handle = session.prompt("…");
-  setTimeout(() => handle.abort("user cancelled"), 5000);
+  const handle = session.prompt('…');
+  setTimeout(() => handle.abort('user cancelled'), 5000);
   ```
 
   2. The awaited value is now `{ text | data, usage, model }` instead of a bare string or schema value. Schema-typed calls return `PromptResultResponse<T>`; non-schema calls return `PromptResponse` with the new `usage` and `model` fields. To migrate, read `response.text` or `response.data`:
 
   ```ts
   // Before
-  const text = await session.prompt("…");
-  const user = await session.prompt("…", { result: UserSchema });
+  const text = await session.prompt('…');
+  const user = await session.prompt('…', { result: UserSchema });
 
   // After
-  const { text } = await session.prompt("…");
-  const { data: user } = await session.prompt("…", { schema: UserSchema });
+  const { text } = await session.prompt('…');
+  const { data: user } = await session.prompt('…', { schema: UserSchema });
   ```
 
   The schema option was renamed from `result` to `schema`, and the response field from `result` to `data`. The old `result` spellings (both the option and the response field) still work at runtime for backwards compatibility, but are typed as `never` so TypeScript flags new usage. Both names will be removed in a future release.
@@ -265,10 +265,9 @@ Big release! We are working hard to stabilize our APIs and add any missing and e
 
 - **Default `thinkingLevel` changed from `'off'` to `'medium'`.** Reasoning-capable models (e.g. gpt-5, claude-opus-4-7) will now reason by default on every `prompt()` / `skill()` / `task()` call. Non-reasoning models are unaffected (clamped to `'off'` per the model's `thinkingLevelMap`). To restore the old behavior, set `thinkingLevel: 'off'` explicitly on `init()`, your role frontmatter, or the call options.
 
-- **`sandbox: 'local'` now runs locally.** Originally, `'local'` was a half-isolated layer — a `just-bash` subprocess with a `ReadWriteFs` / `MountableFs` overlay mounting `process.cwd()` at `/workspace`. That made sense when every Flue agent ran on a developer laptop, but increasingly people are deploying the agent itself *inside* a real sandbox (a container, a microVM, a Cloudflare Sandbox), where wrapping the host in a second virtual filesystem is pure overhead — and actively confusing, because paths get remapped twice. `sandbox: 'local'` now binds directly to the host: `exec` runs through the user's shell with full `process.env`, file methods hit the real filesystem, default `cwd` is `process.cwd()`, and there are no path remappings or command restrictions. Agents that hard-coded `/workspace` paths must migrate to real host paths. If you want isolation on a developer laptop, reach for a real sandbox connector (Daytona, E2B, Mirage, smolvm, etc.).
+- **`sandbox: 'local'` now runs locally.** Originally, `'local'` was a half-isolated layer — a `just-bash` subprocess with a `ReadWriteFs` / `MountableFs` overlay mounting `process.cwd()` at `/workspace`. That made sense when every Flue agent ran on a developer laptop, but increasingly people are deploying the agent itself _inside_ a real sandbox (a container, a microVM, a Cloudflare Sandbox), where wrapping the host in a second virtual filesystem is pure overhead — and actively confusing, because paths get remapped twice. `sandbox: 'local'` now binds directly to the host: `exec` runs through the user's shell with full `process.env`, file methods hit the real filesystem, default `cwd` is `process.cwd()`, and there are no path remappings or command restrictions. Agents that hard-coded `/workspace` paths must migrate to real host paths. If you want isolation on a developer laptop, reach for a real sandbox connector (Daytona, E2B, Mirage, smolvm, etc.).
 
 - **`commands` / `defineCommand` removed.** The `commands` API let you register user CLIs (`gh`, `npm`, etc.) into a sandbox-scoped `$PATH`, isolating secrets from the model. In practice it only ever worked when the sandbox was a `BashFactory` (the default in-memory sandbox or `getVirtualSandbox` on Cloudflare), and threw a runtime error on `'local'`, every remote connector (Daytona, E2B, Mirage, etc.), and Cloudflare Containers — so the documented "CI agent with `defineCommand('gh', { env: { GH_TOKEN } })`" pattern has been broken for most users since `'local'` was rebuilt. We're collapsing the API:
-
   - With the new `'local'` sandbox, the host shell is exposed directly. The agent's `bash` tool can run `gh issue view`, `npm test`, etc. with whatever's on `$PATH` and whatever env you launched flue with. The runner / container / VM is the isolation boundary.
   - For non-`'local'` sandboxes, install the binaries inside the sandbox image, or wrap the operation as a custom tool with `init({ tools: [...] })`. Tools have a structured parameter schema, are visible to the model directly, and recover the "secrets stay on the host" property — the tool reads `process.env`, the agent only sees the tool's params and result.
 
@@ -306,7 +305,6 @@ Big release! We are working hard to stabilize our APIs and add any missing and e
 - **`flue init` command** scaffolds a starter `flue.config.ts` in the target directory. Flags: `--target <node|cloudflare>` (required), `--root <path>`, `--force` (overwrite existing).
 
 - **`app.ts` runtime entry point.** A new optional `app.ts` (also `.mts` / `.js` / `.mjs`) at the source root lets you take over the request pipeline with custom Hono middleware, routes, auth, etc. Mount Flue's agent handler via `app.route('/', flue())`. New `@flue/sdk/app` subpath export ships:
-
   - `flue()` — Hono sub-app exposing `/agents/:name/:id`.
   - `Fetchable` — type for the user app's default export.
   - `registerProvider(name, def)` — register a new URL-prefix model provider at runtime, with platform `env` in scope. Supports HTTP and Cloudflare AI binding registrations (`HttpProviderRegistration`, `CloudflareAIBindingRegistration`, `CloudflareAIBinding`).

--- a/packages/cli/bin/flue.ts
+++ b/packages/cli/bin/flue.ts
@@ -661,6 +661,8 @@ function logEvent(event: any) {
 			break;
 		}
 
+		case 'turn_start':
+			break;
 		case 'turn':
 			flushBuffers();
 			break;

--- a/packages/runtime/src/runtime/ids.ts
+++ b/packages/runtime/src/runtime/ids.ts
@@ -7,3 +7,7 @@ export function generateRunId(): string {
 export function generateOperationId(): string {
 	return `op_${ulid()}`;
 }
+
+export function generateTurnId(): string {
+	return `turn_${ulid()}`;
+}

--- a/packages/runtime/src/runtime/run-store.ts
+++ b/packages/runtime/src/runtime/run-store.ts
@@ -48,7 +48,7 @@ export interface RunStoreOptions {
 export const DEFAULT_MAX_COMPLETED_RUNS = 50;
 export const DEFAULT_MAX_EVENT_BYTES = 256 * 1024;
 
-const TRUNCATABLE_FIELDS = ['result', 'args', 'text', 'content'] as const;
+const TRUNCATABLE_FIELDS = ['result', 'args', 'text', 'content', 'input', 'output'] as const;
 const PREVIEW_CHARS = 1024;
 const ENCODER = new TextEncoder();
 
@@ -116,6 +116,7 @@ function pickEventIdentity(event: Record<string, unknown>): Record<string, unkno
 		'taskId',
 		'toolCallId',
 		'operationId',
+		'turnId',
 	]) {
 		if (key in event) identity[key] = event[key];
 	}

--- a/packages/runtime/src/runtime/schemas.ts
+++ b/packages/runtime/src/runtime/schemas.ts
@@ -46,6 +46,7 @@ const EventBaseSchema = {
 	taskId: v.optional(v.string()),
 	harness: v.optional(v.string()),
 	operationId: v.optional(v.string()),
+	turnId: v.optional(v.string()),
 } satisfies v.ObjectEntries;
 
 const flueEvent = <const TEntries extends v.ObjectEntries>(entries: TEntries) =>
@@ -66,6 +67,11 @@ const PromptUsageSchema = v.object({
 	}),
 });
 
+type TurnStartEvent = Extract<FlueEvent, { type: 'turn_start' }>;
+type TurnInputMessage = TurnStartEvent['input']['messages'][number];
+type TurnInputTool = NonNullable<TurnStartEvent['input']['tools']>[number];
+type TurnOutput = NonNullable<Extract<FlueEvent, { type: 'turn' }>['output']>;
+
 const TruncatedEventSchema = flueEvent({
 	type: v.string(),
 	truncated: v.literal(true),
@@ -75,6 +81,7 @@ const TruncatedEventSchema = flueEvent({
 
 export const FLUE_EVENT_TYPES = [
 	'run_start',
+	'turn_start',
 	'text_delta',
 	'thinking_start',
 	'thinking_delta',
@@ -102,6 +109,19 @@ export const FlueEventSchema = v.union([
 		startedAt: v.string(),
 		payload: v.unknown(),
 	}),
+	flueEvent({
+		type: v.literal('turn_start'),
+		turnId: v.string(),
+		model: v.optional(v.string()),
+		provider: v.optional(v.string()),
+		api: v.optional(v.string()),
+		input: v.object({
+			systemPrompt: v.optional(v.string()),
+			messages: v.array(v.custom<TurnInputMessage>(() => true)),
+			tools: v.optional(v.array(v.custom<TurnInputTool>(() => true))),
+		}),
+		reasoning: v.optional(v.string()),
+	}),
 	flueEvent({ type: v.literal('text_delta'), text: v.string() }),
 	flueEvent({ type: v.literal('thinking_start') }),
 	flueEvent({ type: v.literal('thinking_delta'), delta: v.string() }),
@@ -124,6 +144,9 @@ export const FlueEventSchema = v.union([
 		type: v.literal('turn'),
 		durationMs: v.number(),
 		model: v.optional(v.string()),
+		provider: v.optional(v.string()),
+		api: v.optional(v.string()),
+		output: v.optional(v.custom<TurnOutput>(() => true)),
 		usage: v.optional(PromptUsageSchema),
 		stopReason: v.optional(v.string()),
 		isError: v.boolean(),

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -1,10 +1,12 @@
 /** Internal session implementation. Not exported publicly — wrapped by FlueSession. */
 
-import type { AgentMessage, AgentTool, AgentToolResult } from '@earendil-works/pi-agent-core';
+import type { AgentMessage, AgentTool, AgentToolResult, StreamFn } from '@earendil-works/pi-agent-core';
 import { Agent } from '@earendil-works/pi-agent-core';
+import { streamSimple } from '@earendil-works/pi-ai';
 import type {
 	AssistantMessage,
 	ImageContent,
+	Message,
 	Model,
 	ToolResultMessage,
 	UserMessage,
@@ -44,7 +46,7 @@ import {
 	resolveRoleModel,
 	resolveRoleThinkingLevel,
 } from './roles.ts';
-import { generateOperationId } from './runtime/ids.ts';
+import { generateOperationId, generateTurnId } from './runtime/ids.ts';
 import { getProviderConfiguration, getRegisteredApiKey } from './runtime/providers.ts';
 import { createFlueFs } from './sandbox.ts';
 
@@ -78,6 +80,86 @@ import type {
 import { addUsage, emptyUsage, fromProviderUsage } from './usage.ts';
 
 const MAX_TASK_DEPTH = 4;
+
+type TurnStartEvent = Extract<FlueEvent, { type: 'turn_start' }>;
+type TurnInputMessage = TurnStartEvent['input']['messages'][number];
+type TurnInputTool = NonNullable<TurnStartEvent['input']['tools']>[number];
+type TurnOutput = NonNullable<Extract<FlueEvent, { type: 'turn' }>['output']>;
+type ProviderTextOrImageContent = Exclude<UserMessage['content'], string>[number];
+type ProviderContentBlock =
+	| ProviderTextOrImageContent
+	| AssistantMessage['content'][number]
+	| ToolResultMessage['content'][number];
+type TurnUserContent = Exclude<
+	Extract<TurnInputMessage, { role: 'user' }>['content'],
+	string
+>[number];
+type TurnAssistantContent = Extract<TurnInputMessage, { role: 'assistant' }>['content'][number];
+type TurnToolResultContent = Extract<
+	TurnInputMessage,
+	{ role: 'toolResult' }
+>['content'][number];
+type TurnContent = TurnUserContent | TurnAssistantContent | TurnToolResultContent;
+
+function toTurnMessage(message: Message): TurnInputMessage {
+	if (message.role === 'user') {
+		const content =
+			typeof message.content === 'string'
+				? message.content
+				: (message.content.map(toTurnContent) as TurnUserContent[]);
+		return {
+			role: 'user',
+			content,
+		};
+	}
+
+	if (message.role === 'assistant') {
+		return {
+			role: 'assistant',
+			content: message.content.map(toTurnContent) as TurnAssistantContent[],
+		};
+	}
+
+	return {
+		role: 'toolResult',
+		toolCallId: message.toolCallId,
+		toolName: message.toolName,
+		content: message.content.map(toTurnContent) as TurnToolResultContent[],
+		isError: message.isError,
+	};
+}
+
+function toTurnContent(block: ProviderContentBlock): TurnContent {
+	if (block.type === 'text') {
+		return {
+			type: 'text',
+			text: block.text,
+			textSignature: block.textSignature,
+		};
+	}
+	if (block.type === 'image') {
+		return {
+			type: 'image',
+			data: block.data,
+			mimeType: block.mimeType,
+		};
+	}
+	if (block.type === 'thinking') {
+		return {
+			type: 'thinking',
+			thinking: block.thinking,
+			thinkingSignature: block.thinkingSignature,
+			redacted: block.redacted,
+		};
+	}
+	return {
+		type: 'toolCall',
+		id: block.id,
+		name: block.name,
+		arguments: block.arguments,
+		thoughtSignature: block.thoughtSignature,
+	};
+}
 
 export interface CreateTaskSessionOptions {
 	parentSession: string;
@@ -416,11 +498,38 @@ export class Session implements FlueSession {
 	private activeOperationId: string | undefined;
 	private toolStartTimes = new Map<string, number>();
 	private turnStartTime: number | undefined;
+	private activeTurnId: string | undefined;
 	private activeTasks = new Set<Session>();
 	private sessionRole: string | undefined;
 	private taskDepth: number;
 	private createTaskSession: CreateTaskSession | undefined;
 	private onDelete: (() => void) | undefined;
+
+	private emitTurnStartAndStream: StreamFn = (model, context, options) => {
+		const turnId = this.activeTurnId ?? (this.activeTurnId = generateTurnId());
+		const tools = context.tools?.map(
+			(tool): TurnInputTool => ({
+				name: tool.name,
+				description: tool.description,
+				parameters: tool.parameters,
+			}),
+		);
+		this.emit({
+			type: 'turn_start',
+			turnId,
+			model: model.id,
+			provider: model.provider,
+			api: model.api,
+			input: {
+				systemPrompt: context.systemPrompt,
+				messages: context.messages.map(toTurnMessage),
+				tools,
+			},
+			reasoning: options?.reasoning,
+		});
+
+		return streamSimple(model, context, options);
+	};
 
 	constructor(options: SessionInitOptions) {
 		this.name = options.name;
@@ -464,6 +573,7 @@ export class Session implements FlueSession {
 			},
 			getApiKey: (provider) => this.getProviderApiKey(provider),
 			onPayload: (payload, model) => this.applyProviderPayloadOverrides(payload, model),
+			streamFn: this.emitTurnStartAndStream,
 			toolExecution: 'parallel',
 			sessionId: options.affinityKey,
 		});
@@ -513,19 +623,27 @@ export class Session implements FlueSession {
 				case 'turn_end': {
 					const message = event.message;
 					const assistant = message.role === 'assistant' ? (message as AssistantMessage) : undefined;
+					const output = assistant ? (toTurnMessage(assistant) as TurnOutput) : undefined;
 					this.emit({
 						type: 'turn',
+						turnId: this.activeTurnId,
 						durationMs: durationSince(this.turnStartTime),
 						model: assistant?.model,
+						provider: assistant?.provider,
+						api: assistant?.api,
+						output,
 						usage: fromProviderUsage(assistant?.usage),
 						stopReason: assistant?.stopReason,
 						isError: assistant?.stopReason === 'error' || assistant?.stopReason === 'aborted',
 						error: assistant?.errorMessage,
 					});
 					this.turnStartTime = undefined;
+					this.activeTurnId = undefined;
 					break;
 				}
 				case 'agent_end':
+					this.turnStartTime = undefined;
+					this.activeTurnId = undefined;
 					break;
 			}
 		});
@@ -1243,6 +1361,8 @@ export class Session implements FlueSession {
 		};
 		const operationId = event.operationId ?? this.activeOperationId;
 		if (operationId !== undefined) decorated.operationId = operationId;
+		const turnId = event.turnId ?? this.activeTurnId;
+		if (turnId !== undefined) decorated.turnId = turnId;
 		this.eventCallback?.(decorated);
 	}
 

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -728,6 +728,59 @@ export interface BashLike {
 /** Factory that constructs the agent's Bash-like runtime. Called once at init. */
 export type BashFactory = () => BashLike | Promise<BashLike>;
 
+type LlmTextContent = {
+	type: 'text';
+	text: string;
+	textSignature?: string;
+};
+
+type LlmThinkingContent = {
+	type: 'thinking';
+	thinking: string;
+	thinkingSignature?: string;
+	redacted?: boolean;
+};
+
+type LlmImageContent = {
+	type: 'image';
+	data: string;
+	mimeType: string;
+};
+
+type LlmToolCall = {
+	type: 'toolCall';
+	id: string;
+	name: string;
+	arguments: Record<string, any>;
+	thoughtSignature?: string;
+};
+
+type LlmUserMessage = {
+	role: 'user';
+	content: string | (LlmTextContent | LlmImageContent)[];
+};
+
+type LlmAssistantMessage = {
+	role: 'assistant';
+	content: (LlmTextContent | LlmThinkingContent | LlmToolCall)[];
+};
+
+type LlmToolResultMessage = {
+	role: 'toolResult';
+	toolCallId: string;
+	toolName: string;
+	content: (LlmTextContent | LlmImageContent)[];
+	isError: boolean;
+};
+
+type LlmMessage = LlmUserMessage | LlmAssistantMessage | LlmToolResultMessage;
+
+type LlmTool = {
+	name: string;
+	description: string;
+	parameters: unknown;
+};
+
 export type FlueEvent = (
 	| {
 			type: 'run_start';
@@ -736,6 +789,19 @@ export type FlueEvent = (
 			agentName: string;
 			startedAt: string;
 			payload: unknown;
+		}
+	| {
+			type: 'turn_start';
+			turnId: string;
+			model?: string;
+			provider?: string;
+			api?: string;
+			input: {
+				systemPrompt?: string;
+				messages: LlmMessage[];
+				tools?: LlmTool[];
+			};
+			reasoning?: string;
 		}
 	| { type: 'text_delta'; text: string }
 	| { type: 'thinking_start' }
@@ -754,6 +820,9 @@ export type FlueEvent = (
 			type: 'turn';
 			durationMs: number;
 			model?: string;
+			provider?: string;
+			api?: string;
+			output?: LlmAssistantMessage;
 			usage?: PromptUsage;
 			stopReason?: string;
 			isError: boolean;
@@ -799,6 +868,7 @@ export type FlueEvent = (
 	taskId?: string;
 	harness?: string;
 	operationId?: string;
+	turnId?: string;
 };
 
 export type FlueEventCallback = (event: FlueEvent) => void | Promise<void>;

--- a/packages/runtime/test/turn-start-event.test.ts
+++ b/packages/runtime/test/turn-start-event.test.ts
@@ -1,0 +1,123 @@
+import { fauxAssistantMessage, registerFauxProvider, Type } from '@earendil-works/pi-ai';
+import { describe, expect, it } from 'vitest';
+import { createFlueContext, InMemorySessionStore } from '../src/internal.ts';
+import type { FlueEvent, SessionEnv } from '../src/types.ts';
+
+describe('turn_start events', () => {
+	it('emits the LLM-visible input before streaming a turn', async () => {
+		const provider = `faux-${crypto.randomUUID()}`;
+		const modelId = 'faux-observer';
+		const modelString = `${provider}/${modelId}`;
+		const registration = registerFauxProvider({
+			provider,
+			models: [{ id: modelId, reasoning: true }],
+			tokenSize: { min: 100, max: 100 },
+		});
+		registration.setResponses([
+			fauxAssistantMessage('captured', { responseId: 'resp_123', timestamp: 123 }),
+		]);
+
+		try {
+			const events: FlueEvent[] = [];
+			const resolvePath = (path: string) => (path.startsWith('/') ? path : `/${path}`);
+			const sessionEnv: SessionEnv = {
+				cwd: '/',
+				resolvePath,
+				exec: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+				readFile: async () => '',
+				readFileBuffer: async () => new Uint8Array(),
+				writeFile: async () => {},
+				stat: async () => ({
+					isFile: false,
+					isDirectory: false,
+					isSymbolicLink: false,
+					size: 0,
+					mtime: new Date(0),
+				}),
+				readdir: async () => [],
+				exists: async () => false,
+				mkdir: async () => {},
+				rm: async () => {},
+			};
+			const ctx = createFlueContext({
+				id: 'agent-1',
+				runId: 'run-1',
+				payload: {},
+				env: {},
+				agentConfig: {
+					systemPrompt: '',
+					skills: {},
+					roles: {},
+					model: undefined,
+					resolveModel: (model) => (model === modelString ? registration.getModel(modelId) : undefined),
+				},
+				createDefaultEnv: async () => sessionEnv,
+				defaultStore: new InMemorySessionStore(),
+			});
+			ctx.subscribeEvent((event) => {
+				events.push(event);
+			});
+
+			const harness = await ctx.init({
+				model: modelString,
+				thinkingLevel: 'high',
+				tools: [
+					{
+						name: 'lookup',
+						description: 'Lookup records by query.',
+						parameters: Type.Object({ query: Type.String() }),
+						execute: async () => 'not used',
+					},
+				],
+			});
+			const session = await harness.session();
+
+			await session.prompt('What input reaches the model?');
+
+			const turnStart = events.find(
+				(event): event is Extract<FlueEvent, { type: 'turn_start' }> =>
+					event.type === 'turn_start',
+			);
+			expect(turnStart).toBeDefined();
+			expect(turnStart?.runId).toBe('run-1');
+			expect(turnStart?.session).toBe('default');
+			expect(turnStart?.harness).toBe('default');
+			expect(turnStart?.operationId).toMatch(/^op_/);
+			expect(turnStart?.turnId).toMatch(/^turn_/);
+			expect(turnStart?.model).toBe(modelId);
+			expect(turnStart?.provider).toBe(provider);
+			expect(turnStart?.api).toBe(registration.api);
+			expect(turnStart?.reasoning).toBe('high');
+
+			const userMessage = turnStart?.input.messages[0];
+			expect(userMessage?.role).toBe('user');
+			expect(JSON.stringify(userMessage?.content)).toContain('What input reaches the model?');
+			expect('timestamp' in ((userMessage ?? {}) as Record<string, unknown>)).toBe(false);
+			const lookupTool = turnStart?.input.tools?.find((tool) => tool.name === 'lookup');
+			expect(lookupTool).toMatchObject({
+				name: 'lookup',
+				description: 'Lookup records by query.',
+			});
+			expect('execute' in ((lookupTool ?? {}) as Record<string, unknown>)).toBe(false);
+
+			const textDelta = events.find((event) => event.type === 'text_delta');
+			const turn = events.find((event) => event.type === 'turn');
+			expect(textDelta?.turnId).toBe(turnStart?.turnId);
+			expect(turn?.turnId).toBe(turnStart?.turnId);
+			if (turn?.type === 'turn') {
+				expect(turn.provider).toBe(provider);
+				expect(turn.api).toBe(registration.api);
+				expect(turn.output?.content).toEqual([{ type: 'text', text: 'captured' }]);
+				const output = (turn.output ?? {}) as Record<string, unknown>;
+				expect('responseId' in output).toBe(false);
+				expect('timestamp' in output).toBe(false);
+				expect('usage' in output).toBe(false);
+			}
+			expect(events.findIndex((event) => event.type === 'turn_start')).toBeLessThan(
+				events.findIndex((event) => event.type === 'text_delta'),
+			);
+		} finally {
+			registration.unregister();
+		}
+	});
+});


### PR DESCRIPTION
Adds an `turn_start` observability event emitting provider, model, inputs (system prompt, messages, tools) and reasoning level. Additionally expands the `turn` event to include used provider, LLM output

Having such an event is useful for AI observability, helping understand exactly what the LLM is thinking between turns.

---

Implementation wise, the typings for `toTurnMessage` and `toTurnContent` which are new mapping functions, turning Pi output into Flue event data, are a bit ugly.

The other thing I am not 100% about is the new private `activeTurnId` field on `Session`. It relies heavily on the fact that there con only be one active turn for a given session. I don't know if that might become a problem in the future.