### PR TITLE
[fix] Allow task tool during prompts

### DIFF
--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -989,7 +989,7 @@ export class Session implements FlueSession {
 		inheritedThinkingLevel: ThinkingLevel | undefined,
 		signal?: AbortSignal,
 	): Promise<AgentToolResult<TaskToolResultDetails>> {
-		const result = await this.runTask(
+		const result = await this.runTaskExclusive(
 			params.prompt,
 			{
 				role: params.role ?? inheritedRole,

--- a/packages/runtime/test/session-task-tool.test.ts
+++ b/packages/runtime/test/session-task-tool.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import { InMemorySessionStore, Session } from '../src/session.ts';
+import type { AgentConfig, FileStat, FlueEvent, SessionEnv } from '../src/types.ts';
+
+describe('Session task tool', () => {
+	it('can run while the parent prompt operation is active', async () => {
+		const events: FlueEvent[] = [];
+		let childPrompt = '';
+		const session = new Session({
+			name: 'default',
+			storageKey: 'session',
+			affinityKey: 'affinity',
+			config: createConfig(),
+			env: createEnv(),
+			store: new InMemorySessionStore(),
+			existingData: null,
+			onAgentEvent: (event) => {
+				events.push(event);
+			},
+			createTaskSession: async (options) =>
+				({
+					name: `task:${options.taskId}`,
+					storageKey: `task-storage:${options.taskId}`,
+					prompt: async (text: string) => {
+						childPrompt = text;
+						return { text: `child saw ${text}` };
+					},
+					getAssistantText: () => 'child fallback',
+					getLatestAssistantMessageId: () => 'message-1',
+					close: () => {},
+					abort: () => {},
+				}) as unknown as Session,
+		});
+
+		(session as unknown as { activeOperation: string }).activeOperation = 'prompt';
+
+		const result = await (
+			session as unknown as {
+				runTaskForTool: (
+					params: { prompt: string },
+					tools: [],
+					role: undefined,
+					model: undefined,
+					thinkingLevel: undefined,
+				) => Promise<{ content: Array<{ text: string }> }>;
+			}
+		).runTaskForTool({ prompt: 'inspect the diff' }, [], undefined, undefined, undefined);
+
+		expect(childPrompt).toBe('inspect the diff');
+		expect(result.content[0]?.text).toBe('child saw inspect the diff');
+		expect(events.map((event) => event.type)).toContain('task_start');
+		expect(events.map((event) => event.type)).toContain('task');
+	});
+});
+
+function createConfig(): AgentConfig {
+	return {
+		systemPrompt: '',
+		skills: {},
+		roles: {},
+		model: undefined,
+		resolveModel: () => undefined,
+	};
+}
+
+function createEnv(): SessionEnv {
+	const stat: FileStat = {
+		isFile: true,
+		isDirectory: false,
+		isSymbolicLink: false,
+		size: 0,
+		mtime: new Date(0),
+	};
+	return {
+		cwd: '/workspace',
+		resolvePath: (path) => (path.startsWith('/') ? path : `/workspace/${path}`),
+		exec: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+		readFile: async () => '',
+		readFileBuffer: async () => new Uint8Array(),
+		writeFile: async () => {},
+		stat: async () => stat,
+		readdir: async () => [],
+		exists: async () => true,
+		mkdir: async () => {},
+		rm: async () => {},
+	};
+}


### PR DESCRIPTION
I was building a code review agent using flue and ran into the problem where

```
[flue] tool:start  read  .github/workflows/goodreview.yml
[flue] tool:done   read  (478 chars)
[flue] thinking:start
  **Considering finalization options**
  I’m in the process of finalizing things, but before jumping to a decision, I think it might be useful to involve a child reviewer. Their perspective could bring fresh insights, which might help me make a better choice. I wonder how their views would influence the overall outcome. Let’s take that step before wrapping things up! It could really make a difference.
[flue] tool:start  task
[flue] tool:error   task  [flue] Session "default" is already running prompt. Start another session for parallel conversation branches.
[flue] thinking:start
[flue] tool:start  glob  AGENTS.md
[flue] tool:done   glob
[flue] thinking:start
[flue] tool:start  finish
[flue] tool:done   finish
{
[flue] Done.
  "reviewPosted": true,
  "mode": "full",
  "findings": 0,
  "overallCorrectness": "patch is correct"
}
```

This PR fixes the model-facing `task` tool so it can create a child task while the parent session is already inside a `prompt()` call.

Previously the task tool called the public `session.task()` path, which is guarded by `runExclusive('task')`. During tool execution the parent session is already in `runExclusive('prompt')`, so the tool failed with:

`[flue] Session "default" is already running prompt. Start another session for parallel conversation branches.`

The public `session.task()` API keeps the exclusivity guard. Only the model-facing task tool now routes directly to the child task runner, which is the path it needs when invoked from inside a prompt.

Reproduction:

```ts
const session = new Session({
	name: 'default',
	storageKey: 'session',
	affinityKey: 'affinity',
	config,
	env,
	store: new InMemorySessionStore(),
	existingData: null,
	createTaskSession: async () =>
		({
			prompt: async (text: string) => ({ text }),
			getAssistantText: () => '',
			getLatestAssistantMessageId: () => undefined,
			close: () => {},
			abort: () => {},
		}) as Session,
});

(session as unknown as { activeOperation: string }).activeOperation = 'prompt';

await (
	session as unknown as {
		runTaskForTool: (
			params: { prompt: string },
			tools: [],
			role: undefined,
			model: undefined,
			thinkingLevel: undefined,
		) => Promise<unknown>;
	}
).runTaskForTool({ prompt: 'inspect the diff' }, [], undefined, undefined, undefined);
```