### PR TITLE
Add AI agent monitoring, structured logs, and span streaming to Sentry example

### DIFF
--- a/examples/sentry/.flue/agents/chat.ts
+++ b/examples/sentry/.flue/agents/chat.ts
@@ -1,0 +1,39 @@
+/**
+ * Chat agent — exercises the full gen_ai tracing pipeline.
+ *
+ * Calls the LLM via `session.prompt()`, producing `turn` events that
+ * the bridge in `app.ts` translates into gen_ai.chat spans. Requires
+ * ANTHROPIC_API_KEY (or whichever provider matches the model).
+ *
+ * Invoke:
+ *
+ *   curl -X POST http://localhost:3583/agents/chat/test1 \
+ *     -H 'content-type: application/json' \
+ *     -d '{ "message": "What is the capital of France?" }'
+ *
+ * Expected:
+ *   - HTTP 200 with `{ reply, usage, _meta: { runId } }`.
+ *   - In Sentry: an invoke_agent span containing one or more chat spans.
+ *   - In Sentry Logs: structured log entries for the run lifecycle.
+ */
+import type { FlueContext } from '@flue/runtime';
+
+export const triggers = { webhook: true };
+
+export default async function chat(ctx: FlueContext) {
+	const message = ctx.payload?.message ?? 'Say hello in one sentence.';
+
+	ctx.log.info('chat agent invoked', { message });
+
+	const harness = await ctx.init({ model: 'anthropic/claude-sonnet-4-6' });
+	const session = await harness.session();
+	const { text, usage } = await session.prompt(message);
+
+	ctx.log.info('chat agent completed', {
+		inputTokens: usage.input,
+		outputTokens: usage.output,
+		totalCost: usage.cost.total,
+	});
+
+	return { reply: text, usage };
+}

--- a/examples/sentry/.flue/app.ts
+++ b/examples/sentry/.flue/app.ts
@@ -1,46 +1,24 @@
 /**
- * Sentry error reporting for Flue.
+ * Sentry observability for Flue.
  *
- * This file is the entire integration. It does two things:
+ * This file is the entire integration. It does three things:
  *
  *   1. Initializes the Sentry Node SDK at module scope so every isolate
  *      that imports `app.ts` has a configured Sentry client.
  *
  *   2. Calls `observe(...)` to register a global Flue event subscriber
- *      that translates run-fatal errors and explicit error logs into
- *      `Sentry.captureException(...)` calls with Flue correlation tags.
+ *      that translates Flue events into:
+ *        - **gen_ai spans** for runs, LLM turns, and tool calls, using
+ *          Sentry's AI Agent Monitoring semantic conventions.
+ *        - **Sentry.logger** calls so handler logs appear in Sentry Logs.
+ *        - **Sentry.captureException** for run-fatal errors and explicit
+ *          `ctx.log.error(...)` calls.
+ *
+ *   3. Mounts the Flue agent routes via Hono.
  *
  * Read top-to-bottom — there are no other Sentry-related files in the
  * project. Every agent in `.flue/agents/` is a plain Flue handler;
  * none of them know that Sentry exists.
- *
- *
- * Scope of this example
- * ─────────────────────
- *
- * This is intentionally focused on **error reporting**:
- *
- *   - run-fatal errors (the handler throws / rejects) → captured as
- *     Sentry exceptions at `error` level.
- *   - `ctx.log.error(...)` calls from handlers → captured as Sentry
- *     exceptions when an `error` attribute is present, otherwise as
- *     messages at `error` level.
- *
- * What this example does NOT do (deliberate, for now):
- *
- *   - It does not emit Sentry spans / traces for runs, operations, or
- *     tool calls. The Flue event stream already carries the data a
- *     future span-based integration would need (`durationMs`, `usage`,
- *     `operationKind`, etc.), so layering spans on top is a follow-up
- *     rather than a redesign.
- *   - It does not forward `ctx.log.info` / `.warn` to Sentry breadcrumbs
- *     or logs. Add `Sentry.addBreadcrumb({ ... })` inside the `observe`
- *     callback if you want that — it's a five-line change.
- *   - It does not capture per-operation or per-tool failures. Those are
- *     usually recoverable (the model handles tool errors and keeps
- *     going), so capturing them tends to be noise. If you want them,
- *     uncomment the `operation` / `tool_call` branches inside the
- *     `observe(...)` callback below.
  *
  *
  * Isolate scoping (read this once, then forget about it)
@@ -61,142 +39,257 @@
  * Environment variables
  * ─────────────────────
  *
- *   SENTRY_DSN          required to send anything. If unset, the SDK
- *                       is initialized in "disabled" mode and your app
- *                       runs unchanged.
- *   SENTRY_ENVIRONMENT  e.g. "production", "staging". Defaults to
- *                       NODE_ENV.
- *   SENTRY_RELEASE      e.g. a git SHA. Optional.
+ *   SENTRY_DSN              required to send anything. If unset, the SDK
+ *                           is initialized in "disabled" mode and your app
+ *                           runs unchanged.
+ *   SENTRY_ENVIRONMENT      e.g. "production", "staging". Defaults to
+ *                           NODE_ENV.
+ *   SENTRY_RELEASE          e.g. a git SHA. Optional.
+ *   SENTRY_AI_RECORD_INPUTS   set to "true" to capture prompt messages
+ *                              as `gen_ai.input.messages` on chat spans.
+ *   SENTRY_AI_RECORD_OUTPUTS  set to "true" to capture model responses
+ *                              as `gen_ai.output.messages` on chat spans.
  */
 
 import { flue, observe } from '@flue/runtime/app';
-import type { FlueContext, FlueEvent } from '@flue/runtime';
+import type { FlueContext, FlueEvent, PromptUsage } from '@flue/runtime';
 import * as Sentry from '@sentry/node';
 import { Hono } from 'hono';
 
 // ─── 1. Sentry init ─────────────────────────────────────────────────────────
 
-// `Sentry.init` is module-scoped: it runs once per isolate, before any
-// HTTP request is served. When SENTRY_DSN is unset (e.g. in local
-// development without a DSN handy), `enabled: false` makes every
-// capture call a no-op. The rest of this file behaves the same either
-// way, so you don't have to gate it.
-//
-// `tracesSampleRate: 0` is explicit: this example does not produce
-// spans, so we disable Sentry's tracing engine entirely. Set this to
-// a positive number only if you add span-emitting code yourself.
 Sentry.init({
 	dsn: process.env.SENTRY_DSN,
 	environment: process.env.SENTRY_ENVIRONMENT ?? process.env.NODE_ENV,
 	release: process.env.SENTRY_RELEASE,
-	tracesSampleRate: 0,
+	tracesSampleRate: 1.0,
+	// Send gen_ai spans as standalone envelopes instead of bundling in
+	// the transaction payload. Prevents large AI spans from being dropped.
+	streamGenAiSpans: true,
+	// Forward Sentry.logger calls to Sentry Logs.
+	enableLogs: true,
 	enabled: Boolean(process.env.SENTRY_DSN),
 });
 
 // ─── 2. The Flue → Sentry event bridge ──────────────────────────────────────
 
-// `observe` is the only Flue API this file uses besides `flue()`
-// itself. It is module-scoped on purpose: register once, fire for
-// every run handled by this isolate, for the lifetime of the
-// isolate. There is no per-agent wiring and no per-request
-// registration.
-//
-// The callback runs synchronously inside the Flue event emit path,
-// so it must be cheap and must not throw. (Sentry's `withScope` and
-// `captureException` are both synchronous JS calls that queue work
-// internally; they will not block the run.)
+const recordInputs = process.env.SENTRY_AI_RECORD_INPUTS === 'true';
+const recordOutputs = process.env.SENTRY_AI_RECORD_OUTPUTS === 'true';
+
+// Per-run state: track the agent-level span so child spans (turns,
+// tool calls) can nest under it. Keyed by runId. Cleaned up on run_end.
+const activeAgentSpans = new Map<string, ReturnType<typeof Sentry.startInactiveSpan>>();
+
+// Track per-run agent name and accumulated usage for the invoke_agent span.
+const runAgentNames = new Map<string, string>();
+const runUsage = new Map<string, { input: number; output: number; cacheRead: number; cacheWrite: number; total: number; model?: string }>();
+
 observe((event, ctx) => {
-	// Common Flue correlation tags — attached to every Sentry
-	// capture made from this bridge so an investigator can pivot
-	// from a Sentry issue to a Flue run via:
-	//
-	//   GET /runs/<flue.run_id>
-	//
-	// or replay the run via the CLI:
-	//
-	//   flue logs <flue.run_id>
-	//
-	// `flue.agent` and `flue.instance_id` are still attached as tags
-	// for filtering / grouping in Sentry, but they are no longer
-	// part of the URL — the run id is globally unique and resolves
-	// to its owner via the run registry server-side.
 	const tags = flueCorrelationTags(event, ctx);
+	const runId = event.runId;
 
-	// ─── Run-fatal: the handler threw or rejected ─────────────────────
+	// ─── Agent span: run_start → run_end ──────────────────────────────
 	//
-	// `run_end` fires exactly once per run. When `isError` is true,
-	// the handler did not return successfully — this is the
-	// canonical "something broke" signal.
-	if (event.type === 'run_end' && event.isError) {
-		Sentry.withScope((scope) => {
-			scope.setTags(tags);
-			scope.setLevel('error');
-			scope.setContext('flue.run', {
-				durationMs: event.durationMs,
-				agentName: tags['flue.agent'],
-				instanceId: ctx.id,
+	// Maps the full agent run to a `gen_ai.invoke_agent` span, which
+	// is the top-level container in Sentry's AI monitoring view.
+	if (event.type === 'run_start' && runId) {
+		runAgentNames.set(runId, event.agentName);
+		runUsage.set(runId, { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 });
+
+		// Link multi-turn sessions via conversation ID (ctx.id is the
+		// agent instance id from the URL, stable across calls).
+		Sentry.setConversationId(ctx.id);
+
+		const attrs: Record<string, string> = {
+			'gen_ai.operation.name': 'invoke_agent',
+			'gen_ai.agent.name': event.agentName,
+			'flue.run_id': runId,
+			'flue.instance_id': event.instanceId,
+		};
+		if (recordInputs && event.payload != null) {
+			attrs['gen_ai.input.messages'] = safeStringify(event.payload);
+		}
+		const span = Sentry.startInactiveSpan({
+			op: 'gen_ai.invoke_agent',
+			name: `invoke_agent ${event.agentName}`,
+			attributes: attrs,
+		});
+		activeAgentSpans.set(runId, span);
+		Sentry.logger.info('Agent run started', {
+			'flue.run_id': runId,
+			'flue.instance_id': event.instanceId,
+			'flue.agent': event.agentName,
+		});
+		return;
+	}
+
+	if (event.type === 'run_end' && runId) {
+		const span = activeAgentSpans.get(runId);
+		const accumulated = runUsage.get(runId);
+		if (span) {
+			// Set aggregated usage on the agent span so it shows totals
+			// in the AI monitoring view.
+			if (accumulated) {
+				span.setAttributes({
+					'gen_ai.usage.input_tokens': accumulated.input,
+					'gen_ai.usage.output_tokens': accumulated.output,
+					'gen_ai.usage.total_tokens': accumulated.total,
+				});
+				if (accumulated.model) {
+					span.setAttribute('gen_ai.request.model', accumulated.model);
+				}
+			}
+			if (recordOutputs && event.result != null) {
+				span.setAttribute('gen_ai.output.messages', safeStringify(event.result));
+			}
+			if (event.isError) {
+				span.setStatus({ code: 2 });
+			}
+			span.end();
+			activeAgentSpans.delete(runId);
+		}
+		runAgentNames.delete(runId);
+		runUsage.delete(runId);
+		Sentry.setConversationId(null);
+
+		if (event.isError) {
+			Sentry.withScope((scope) => {
+				scope.setTags(tags);
+				scope.setLevel('error');
+				scope.setContext('flue.run', {
+					durationMs: event.durationMs,
+					agentName: tags['flue.agent'],
+					instanceId: ctx.id,
+				});
+				Sentry.captureException(reconstructError(event.error));
 			});
-			Sentry.captureException(reconstructError(event.error));
-		});
+			Sentry.logger.error('Agent run failed', {
+				'flue.run_id': runId,
+				'durationMs': event.durationMs,
+			});
+		} else {
+			Sentry.logger.info('Agent run completed', {
+				'flue.run_id': runId,
+				'durationMs': event.durationMs,
+			});
+		}
 		return;
 	}
 
-	// ─── Explicit handler-side error logs ─────────────────────────────
+	// ─── LLM turn → gen_ai.chat span ─────────────────────────────────
 	//
-	// `ctx.log.error(message, { error })` is how handler code says
-	// "I want this in my error reporter without crashing the run."
-	// We mirror Junior's convention: if the log carries an `error`
-	// attribute, capture it as an exception; otherwise capture the
-	// message itself at `error` level.
-	if (event.type === 'log' && event.level === 'error') {
-		Sentry.withScope((scope) => {
-			scope.setTags(tags);
-			scope.setLevel('error');
-			if (event.attributes) {
-				scope.setContext('flue.log_attributes', event.attributes);
-			}
-			const errorAttr = event.attributes?.error;
-			if (errorAttr) {
-				Sentry.captureException(reconstructError(errorAttr));
-			} else {
-				Sentry.captureMessage(event.message, 'error');
-			}
+	// Each `turn` event represents one completed LLM call. It carries
+	// the model name, token usage, and duration. We use
+	// `startInactiveSpan` + manual `end()` so the span's wall-clock
+	// duration matches the actual LLM call time from `durationMs`.
+	if (event.type === 'turn' && runId) {
+		const agentSpan = activeAgentSpans.get(runId);
+		const modelName = event.model ?? 'unknown';
+
+		// Accumulate usage on the parent invoke_agent span.
+		const accumulated = runUsage.get(runId);
+		if (accumulated && event.usage) {
+			accumulated.input += event.usage.input;
+			accumulated.output += event.usage.output;
+			accumulated.cacheRead += event.usage.cacheRead;
+			accumulated.cacheWrite += event.usage.cacheWrite;
+			accumulated.total += event.usage.totalTokens;
+			accumulated.model ??= modelName;
+		}
+
+		const endTimeMs = event.timestamp ? new Date(event.timestamp).getTime() : Date.now();
+		const startTimeMs = endTimeMs - event.durationMs;
+
+		const span = Sentry.withActiveSpan(agentSpan ?? null, () => {
+			return Sentry.startInactiveSpan({
+				op: 'gen_ai.chat',
+				name: `chat ${modelName}`,
+				startTime: startTimeMs / 1000,
+				attributes: {
+					'gen_ai.operation.name': 'chat',
+					'gen_ai.request.model': modelName,
+					'gen_ai.response.model': modelName,
+					...usageAttributes(event.usage),
+				},
+			});
 		});
+		if (event.isError) span.setStatus({ code: 2 });
+		span.end(endTimeMs / 1000);
+
+		if (event.usage) {
+			Sentry.logger.debug('LLM turn completed', {
+				'flue.run_id': runId,
+				'flue.operation_id': event.operationId ?? '',
+				'model': modelName,
+				'input_tokens': event.usage.input,
+				'output_tokens': event.usage.output,
+				'durationMs': event.durationMs,
+			});
+		}
 		return;
 	}
 
-	// ─── Not captured (and why) ───────────────────────────────────────
+	// ─── Tool call → gen_ai.execute_tool span ────────────────────────
+	if (event.type === 'tool_call' && runId) {
+		const agentSpan = activeAgentSpans.get(runId);
+
+		const endTimeMs = event.timestamp ? new Date(event.timestamp).getTime() : Date.now();
+		const startTimeMs = endTimeMs - event.durationMs;
+
+		const span = Sentry.withActiveSpan(agentSpan ?? null, () => {
+			return Sentry.startInactiveSpan({
+				op: 'gen_ai.execute_tool',
+				name: `execute_tool ${event.toolName}`,
+				startTime: startTimeMs / 1000,
+				attributes: {
+					'gen_ai.operation.name': 'execute_tool',
+					'gen_ai.tool.name': event.toolName,
+				},
+			});
+		});
+		if (event.isError) span.setStatus({ code: 2 });
+		span.end(endTimeMs / 1000);
+		return;
+	}
+
+	// ─── Structured logs → Sentry.logger ─────────────────────────────
 	//
-	// `operation` events with `isError: true` represent a single
-	// `prompt()` / `skill()` / `task()` / `shell()` call that
-	// threw. If the agent handler caught and recovered, the run is
-	// still healthy — capturing here would be noise. If the
-	// handler did NOT catch, the same error propagates up to
-	// `run_end` above and is captured there.
-	//
-	// `tool_call` events with `isError: true` represent a tool body
-	// that threw or returned an error. The model usually keeps
-	// going with the error result and recovers. Capturing every
-	// tool error would drown out real incidents. Add a branch here
-	// if your agents do something where tool failures are
-	// catastrophic.
-	//
-	// Uncomment to enable:
-	//
-	//   if (event.type === 'operation' && event.isError) { ... }
-	//   if (event.type === 'tool_call' && event.isError) { ... }
+	// Every ctx.log.info/warn/error is forwarded to Sentry.logger so
+	// they appear in the Sentry Logs view with flue correlation attrs.
+	if (event.type === 'log') {
+		const logAttrs: Record<string, string | number | boolean> = {};
+		if (runId) logAttrs['flue.run_id'] = runId;
+		if (event.operationId) logAttrs['flue.operation_id'] = event.operationId;
+		const agentName = runId ? runAgentNames.get(runId) : undefined;
+		if (agentName) logAttrs['flue.agent'] = agentName;
+
+		if (event.level === 'info') {
+			Sentry.logger.info(event.message, logAttrs);
+		} else if (event.level === 'warn') {
+			Sentry.logger.warn(event.message, logAttrs);
+		} else if (event.level === 'error') {
+			Sentry.logger.error(event.message, logAttrs);
+
+			Sentry.withScope((scope) => {
+				scope.setTags(tags);
+				scope.setLevel('error');
+				if (event.attributes) {
+					scope.setContext('flue.log_attributes', event.attributes);
+				}
+				const errorAttr = event.attributes?.error;
+				if (errorAttr) {
+					Sentry.captureException(reconstructError(errorAttr));
+				} else {
+					Sentry.captureMessage(event.message, 'error');
+				}
+			});
+		}
+		return;
+	}
 });
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-/**
- * Build the Sentry tags attached to every capture from this bridge.
- *
- * Tag keys use the `flue.*` prefix to namespace them away from
- * Sentry's built-in tags and from any application tags the user
- * adds. Pivoting on `flue.run_id` in Sentry's search box is the
- * fastest way to find every issue raised by a single Flue run.
- */
 function flueCorrelationTags(
 	event: FlueEvent,
 	ctx: FlueContext,
@@ -210,24 +303,24 @@ function flueCorrelationTags(
 	if (event.parentSession) tags['flue.parent_session'] = event.parentSession;
 	if (event.operationId) tags['flue.operation_id'] = event.operationId;
 	if (event.taskId) tags['flue.task_id'] = event.taskId;
-	// `run_start` carries the agent name; cache it via the most
-	// common shape so other events can pick it up too. (Currently
-	// only `run_start` includes `agentName`, but we don't depend on
-	// that — we read it defensively.)
 	if (event.type === 'run_start') tags['flue.agent'] = event.agentName;
 	return tags;
 }
 
-/**
- * Reconstruct an `Error` instance from a value that may already be an
- * `Error`, may be the JSON-serialized envelope Flue's run-store uses
- * (`{ name, message }`), or may be something arbitrary a handler
- * threw (a string, a number, a plain object).
- *
- * Sentry's `captureException` does its best with non-Error values,
- * but it produces much better issue grouping when given a real
- * `Error` with a stable `name` and `message`.
- */
+function usageAttributes(usage: PromptUsage | undefined): Record<string, number> {
+	if (!usage) return {};
+	return {
+		'gen_ai.usage.input_tokens': usage.input,
+		'gen_ai.usage.output_tokens': usage.output,
+		'gen_ai.usage.input_tokens.cached': usage.cacheRead,
+		'gen_ai.usage.input_tokens.cache_write': usage.cacheWrite,
+		'gen_ai.usage.total_tokens': usage.totalTokens,
+		'gen_ai.cost.input_tokens': usage.cost.input,
+		'gen_ai.cost.output_tokens': usage.cost.output,
+		'gen_ai.cost.total_tokens': usage.cost.total,
+	};
+}
+
 function reconstructError(raw: unknown): Error {
 	if (raw instanceof Error) return raw;
 	if (raw && typeof raw === 'object') {

--- a/examples/sentry/README.md
+++ b/examples/sentry/README.md
@@ -1,55 +1,39 @@
-# Sentry error reporting for Flue
+# Sentry observability for Flue
 
 A working example of wiring Flue agents up to [Sentry](https://sentry.io)
-for error reporting.
+for error reporting, AI agent monitoring (gen_ai traces/spans), and
+structured logging.
 
 This example is intended to be read top-to-bottom as documentation. The
 entire integration lives in [`.flue/app.ts`](.flue/app.ts) — every agent
 in `.flue/agents/` is a plain Flue handler that doesn't import Sentry,
-doesn't import the bridge, and doesn't know that error reporting is
+doesn't import the bridge, and doesn't know that observability is
 happening.
 
 ## What you get
 
 After running this example with a Sentry DSN configured:
 
-- Every run that ends with an unhandled exception (the handler throws
-  or rejects) becomes a Sentry issue tagged with the Flue `runId`,
-  `instanceId`, harness name, and session name.
-- Every `ctx.log.error(...)` call from a handler becomes a Sentry
-  capture — an exception if the log carries an `error` attribute, a
-  message otherwise.
+- **AI Agent Monitoring.** Every agent run becomes a `gen_ai.invoke_agent`
+  span. Each LLM turn within the run becomes a `gen_ai.chat` child span
+  with model name, token usage (input, output, cached), and cost
+  attributes. Each tool call becomes a `gen_ai.execute_tool` child span.
+  All spans follow Sentry's [AI Agent Monitoring](https://docs.sentry.io/platforms/javascript/guides/node/ai-agent-monitoring/)
+  semantic conventions and appear in the AI monitoring view.
+- **Structured Logs.** Every `ctx.log.info/warn/error(...)` call from a
+  handler is forwarded to `Sentry.logger` with `flue.run_id` and
+  `flue.agent` correlation attributes. Logs appear in the Sentry Logs
+  view alongside traces.
+- **Error Reporting.** Every run that ends with an unhandled exception
+  becomes a Sentry issue. Every `ctx.log.error(...)` call becomes a
+  Sentry capture. All tagged with the Flue `runId`, `instanceId`,
+  harness name, and session name.
+- **Span Streaming.** `streamGenAiSpans: true` sends gen_ai spans as
+  standalone envelopes, so large AI spans are not dropped due to payload
+  size limits.
 - Sentry tags use a stable `flue.*` prefix, so pivoting on
   `flue.run_id` in Sentry's search box finds every capture from a
   single Flue run.
-- A failing run in Sentry can be replayed in full by feeding the
-  `flue.run_id` tag back into the Flue CLI:
-
-  ```
-  flue logs <flue.run_id>
-  ```
-
-## What this example does NOT do
-
-Deliberate scope cuts, listed up front so you can decide whether this
-example fits your needs:
-
-- **No spans, no traces.** Flue's event stream carries `durationMs`,
-  `usage`, `operationKind`, and other span-shaped fields, but this
-  integration does not emit Sentry spans. Adding spans is a layered
-  follow-up rather than a redesign — the same `observe(...)` hook can
-  call `Sentry.startInactiveSpan` for wide lifecycle events when
-  you're ready.
-- **No log forwarding for `info` / `warn`.** Only `log.error` reaches
-  Sentry. If you want `log.info` as Sentry breadcrumbs, add a one-line
-  `Sentry.addBreadcrumb(...)` call to the bridge in `app.ts`.
-- **No tool-error capture.** Tool failures are usually recoverable
-  (the model handles them and keeps going), so capturing them would
-  drown out real incidents. The bridge in `app.ts` documents how to
-  opt in.
-- **No AI metrics.** Token counts, costs, and model identities live on
-  Flue's `turn` and `operation` events, but this example does not
-  forward them to Sentry as measurements or attributes.
 
 ## Files
 
@@ -63,19 +47,19 @@ examples/sentry/
 └── .flue/
     ├── app.ts                ← Sentry.init + observe(...) bridge
     └── agents/
-        ├── hello.ts          ← success case — no Sentry traffic
+        ├── chat.ts           ← LLM call — produces gen_ai spans + logs
+        ├── hello.ts          ← success case — no Sentry error traffic
         ├── boom.ts           ← run-fatal throw — captures via run_end
         └── explicit.ts       ← non-fatal log.error — captures while run continues
 ```
 
-Open `.flue/app.ts` first. Every line is commented to explain why it's
-there. The rest of this README explains how to run, what to look for,
-and how the pieces fit together.
+Open `.flue/app.ts` first. The rest of this README explains how to run
+and what to look for.
 
 ## How the integration works
 
 Flue emits a structured event for every meaningful boundary in a run —
-`run_start`, `operation`, `tool_call`, `log`, `run_end`, and others.
+`run_start`, `turn`, `tool_call`, `log`, `run_end`, and others.
 Every event carries the Flue correlation tree (`runId`, `harness`,
 `session`, `operationId`, `taskId`) so any consumer can reconstruct
 what happened.
@@ -92,45 +76,17 @@ observe((event, ctx) => {
 });
 ```
 
-`observe` is called once at module scope. The subscriber receives every
-event from every run handled by the current isolate.
+The bridge in `app.ts` is a single `observe(...)` call that maps Flue
+events to Sentry:
 
-The bridge in `app.ts` is a single `observe(...)` call that filters for
-two event shapes:
-
-| Flue event | Sentry call | Severity |
+| Flue event | Sentry output | Details |
 |---|---|---|
-| `run_end` with `isError: true` | `captureException` (reconstructed Error) | `error` |
-| `log` with `level: 'error'` and `attributes.error` | `captureException` (reconstructed Error) | `error` |
-| `log` with `level: 'error'` and no `error` attribute | `captureMessage` | `error` |
-
-Every capture is enclosed in `Sentry.withScope(...)` so the Flue tags
-do not leak into unrelated events captured by Sentry's auto-instrumentation
-elsewhere in the process.
-
-## Isolate scoping (Node vs. Cloudflare)
-
-`observe` is described as "global," but the precise meaning differs by
-target:
-
-- **Node target.** One V8 isolate per server process. `observe` is
-  truly global — register once in `app.ts`, captures fire for every
-  run the server handles.
-
-- **Cloudflare target.** Each agent runs in its own [Durable
-  Object](https://developers.cloudflare.com/durable-objects/), which
-  is a separate V8 isolate from the outer Worker and from every other
-  DO. `app.ts` is evaluated once per isolate. That means
-  `Sentry.init` and `observe(...)` execute independently inside each
-  DO. Every isolate has its own Sentry client and captures its own
-  events. This is the only thing that *can* work on Cloudflare — there
-  is no shared module state across isolates — and it is the right
-  shape: no cross-isolate RPC for every event, each agent
-  independently reports its own errors.
-
-You do not have to think about this when writing handlers. Put
-`Sentry.init` and `observe(...)` at the top of `app.ts` and the rest is
-automatic.
+| `run_start` | `Sentry.startInactiveSpan` | Opens a `gen_ai.invoke_agent` span |
+| `run_end` | `span.end()` | Closes the agent span; captures exception if error |
+| `turn` | `Sentry.startInactiveSpan` | `gen_ai.chat` span with model, token usage, cost |
+| `tool_call` | `Sentry.startInactiveSpan` | `gen_ai.execute_tool` span with tool name |
+| `log` (any level) | `Sentry.logger.info/warn/error` | Structured log with correlation attrs |
+| `log` (error) | `Sentry.captureException/Message` | Error reporting (unchanged from before) |
 
 ## Running it
 
@@ -141,10 +97,6 @@ From the repo root:
 ```bash
 pnpm install
 ```
-
-This example declares `@flue/runtime` as a workspace dependency and
-`@sentry/node` as a regular npm dependency. The workspace install picks
-up both.
 
 ### 2. Set up Sentry
 
@@ -157,8 +109,7 @@ export SENTRY_ENVIRONMENT='development'
 ```
 
 If you skip this step, the integration still works — `Sentry.init` is
-called with `enabled: false` and every capture is a no-op. The example
-runs identically, you just won't see any traffic in Sentry's UI.
+called with `enabled: false` and every capture is a no-op.
 
 ### 3. Run the dev server
 
@@ -171,12 +122,18 @@ The server starts on port `3583`.
 ### 4. Trigger each scenario
 
 ```bash
-# Success case — no Sentry traffic
+# LLM call — produces gen_ai spans in Sentry AI monitoring
+# Requires ANTHROPIC_API_KEY (or your provider's key)
+curl -X POST http://localhost:3583/agents/chat/test1 \
+  -H 'content-type: application/json' \
+  -d '{ "message": "What is the capital of France?" }'
+
+# Success case — no Sentry error traffic (still produces agent span + logs)
 curl -X POST http://localhost:3583/agents/hello/test1 \
   -H 'content-type: application/json' \
   -d '{}'
 
-# Run-fatal throw — one Sentry issue
+# Run-fatal throw — one Sentry issue + error span
 curl -X POST http://localhost:3583/agents/boom/test1 \
   -H 'content-type: application/json' \
   -d '{}'
@@ -187,10 +144,17 @@ curl -X POST http://localhost:3583/agents/explicit/test1 \
   -d '{}'
 ```
 
-Each response includes a `_meta.runId` field. That's the same id you'll
-see as the `flue.run_id` tag in Sentry.
+### 5. What to look for in Sentry
 
-### 5. Replay a captured run
+- **Traces → AI monitoring:** The `chat` agent produces an
+  `invoke_agent` span with nested `chat` spans showing model, token
+  counts, and cost.
+- **Logs:** All `ctx.log.*` calls appear in the Logs view with
+  `flue.run_id` and `flue.agent` attributes for filtering.
+- **Issues:** The `boom` and `explicit` agents produce issues tagged
+  with `flue.run_id` for cross-referencing.
+
+### 6. Replay a captured run
 
 Take a `flue.run_id` from Sentry and feed it back to the CLI:
 
@@ -198,40 +162,14 @@ Take a `flue.run_id` from Sentry and feed it back to the CLI:
 flue logs run_01HX...
 ```
 
-The CLI streams the full event log of that run — including the
-`run_end` event that triggered the Sentry capture.
-
 ## Adapting this to your project
-
-To use this pattern in your own Flue project:
 
 1. Add `@sentry/node` (or `@sentry/cloudflare` for the CF target) to
    your dependencies.
-2. Copy `installSentryEventBridge` from `app.ts` into your own
-   `app.ts`, alongside your own `Sentry.init` call.
-3. Decide which event types you care about. The defaults in this
-   example (run-fatal + `log.error`) are a reasonable starting point;
-   the bridge code documents what each branch does and how to enable
-   the others.
+2. Copy the `Sentry.init` and `observe(...)` bridge from `app.ts` into
+   your own `app.ts`.
+3. Decide which event types you care about. The defaults in this example
+   (agent spans + turns + tool calls + logs + errors) are a reasonable
+   starting point; remove what you don't need.
 
-That's the whole migration. There is nothing to do on a per-agent
-basis.
-
-## Going further
-
-When you outgrow error-only reporting, the same `observe(...)` hook can
-carry more:
-
-- **Breadcrumbs.** Forward `log.info` / `log.warn` to
-  `Sentry.addBreadcrumb(...)` so each captured exception has the
-  in-run log trail attached.
-- **Spans.** The wide `operation`, `tool_call`, `turn`, and `run_end`
-  events all carry `durationMs`. Synthesize Sentry spans from
-  `(timestamp - durationMs, timestamp)` to build a flame graph for
-  every run. The `gen_ai.*` OpenTelemetry semantic conventions are a
-  good attribute schema to target — see Sentry's GenAI docs.
-- **Metrics.** `turn.usage` carries input/output/cache tokens and cost.
-  Forward as Sentry measurements or to a separate metrics sink.
-
-None of those require changes to your agents. They all live inside the
-same `observe(...)` callback you already have.
+That's the whole migration. There is nothing to do on a per-agent basis.

--- a/examples/sentry/package.json
+++ b/examples/sentry/package.json
@@ -4,7 +4,7 @@
 	"type": "module",
 	"dependencies": {
 		"@flue/runtime": "workspace:*",
-		"@sentry/node": "^10.0.0",
+		"@sentry/node": "^10.53.0",
 		"hono": "^4.7.0"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -143,8 +143,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/runtime
       '@sentry/node':
-        specifier: ^10.0.0
-        version: 10.52.0(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1))
+        specifier: ^10.53.0
+        version: 10.53.1(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1))
       hono:
         specifier: ^4.7.0
         version: 4.12.16
@@ -2292,12 +2292,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sentry/core@10.52.0':
-    resolution: {integrity: sha512-VA/kAqLhkMnRWY2RXdBLyTemR9D4m7MVRy/gyapoq9yvllVPx9WXbvKgnMP2LQp7mFgT/oLFvw58aQKaYTGn3A==}
+  '@sentry/core@10.53.1':
+    resolution: {integrity: sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==}
     engines: {node: '>=18'}
 
-  '@sentry/node-core@10.52.0':
-    resolution: {integrity: sha512-IG7MBtLRPQ2LuU+kbD14AFZroZgAeUmJQTP1FI/F8n56O31+p+9R703LuBTpvZr6sm+eRYDMWcGYYkfLHRVjwg==}
+  '@sentry/node-core@10.53.1':
+    resolution: {integrity: sha512-iH7SMcM/7jPbN+t7+7ussQOiIqI4BMOGt4VYWlV71/z7k0pY+YPaSvlfVkNXfISiDzFAKv0ecCY3BmsLMu1xDQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -2320,12 +2320,12 @@ packages:
       '@opentelemetry/semantic-conventions':
         optional: true
 
-  '@sentry/node@10.52.0':
-    resolution: {integrity: sha512-9+p3KJUk3rHO1HOEZuSknP2RgKCJZONDm4HWgkVDtVBtocb66KLtVlMjc59d2/bWP7tM3wc877tpG30quFfU9g==}
+  '@sentry/node@10.53.1':
+    resolution: {integrity: sha512-rxHVil0tJAmz+keFcZCj1LaUdgdkK66E/l0gqh2p1209PNCGoD3lnClFr6vusy1aF3zF8O9JPtuMEJzXOKhs+w==}
     engines: {node: '>=18'}
 
-  '@sentry/opentelemetry@10.52.0':
-    resolution: {integrity: sha512-Sc7StsvC0bwhMcgDfTRWUIexO5cNzzKUurvUwtpgQUnxO7AzexU3lkY3yHYDsCbWYAEQMXAgQYQtbcqoh+Ie7g==}
+  '@sentry/opentelemetry@10.53.1':
+    resolution: {integrity: sha512-Zok6UXla0mFOjd1YnVb1TZtQNOry9v93fXUqx8jmDaygwWM2BwvP8rBQabLz0/OZXo8+35oge+Vmw+QY5aesnA==}
     engines: {node: '>=18'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
@@ -7718,12 +7718,12 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
-  '@sentry/core@10.52.0': {}
+  '@sentry/core@10.53.1': {}
 
-  '@sentry/node-core@10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/node-core@10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
-      '@sentry/core': 10.52.0
-      '@sentry/opentelemetry': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/core': 10.53.1
+      '@sentry/opentelemetry': 10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -7733,7 +7733,7 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@sentry/node@10.52.0(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1))':
+  '@sentry/node@10.53.1(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1))':
     dependencies:
       '@fastify/otel': 0.18.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
@@ -7760,21 +7760,21 @@ snapshots:
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
       '@prisma/instrumentation': 7.6.0(@opentelemetry/api@1.9.1)
-      '@sentry/core': 10.52.0
-      '@sentry/node-core': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
-      '@sentry/opentelemetry': 10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/core': 10.53.1
+      '@sentry/node-core': 10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.1))(@opentelemetry/instrumentation@0.214.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
+      '@sentry/opentelemetry': 10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)
       import-in-the-middle: 3.0.1
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
       - supports-color
 
-  '@sentry/opentelemetry@10.52.0(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
+  '@sentry/opentelemetry@10.53.1(@opentelemetry/api@1.9.1)(@opentelemetry/core@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(@opentelemetry/semantic-conventions@1.40.0)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
-      '@sentry/core': 10.52.0
+      '@sentry/core': 10.53.1
 
   '@shikijs/core@3.23.0':
     dependencies:


### PR DESCRIPTION
## Summary

- Extends the `examples/sentry/` example from error-only reporting to full Sentry observability using [AI Agent Monitoring](https://docs.sentry.io/platforms/javascript/guides/node/ai-agent-monitoring/) conventions
- Adds `gen_ai.invoke_agent` → `gen_ai.chat` → `gen_ai.execute_tool` span hierarchy with proper parent-child nesting, real wall-clock durations, aggregated token usage, cost attributes, and conversation ID tracking
- Forwards all `ctx.log.*` calls to `Sentry.logger` with `flue.run_id` / `flue.agent` correlation attributes
- Enables `streamGenAiSpans: true` so gen_ai spans are sent as standalone envelopes
- Adds optional `SENTRY_AI_RECORD_INPUTS` / `SENTRY_AI_RECORD_OUTPUTS` env vars for privacy-controlled prompt/response capture
- Adds a new `chat.ts` agent that makes a real LLM call to exercise the full pipeline
- Bumps `@sentry/node` to `^10.53.0` for `streamGenAiSpans`, `enableLogs`, and `setConversationId` support

## Verified in Sentry

Tested against the `flue-sentry-example` project in `sentry-developer-experience` org. Confirmed:
- `invoke_agent` spans with `gen_ai.agent.name`, `gen_ai.request.model`, `gen_ai.usage.*`, `gen_ai.conversation.id`
- `chat` child spans with per-turn model, token usage, cost, and real duration (~1s, not 0ms)
- Proper parent-child span nesting (http.server → invoke_agent → chat)
- Structured logs in Sentry Logs view with correlation attributes
- Error capture unchanged for `boom` and `explicit` agents

## Test plan

- [x] `npx tsc --noEmit` passes (strict mode)
- [x] `pnpm exec flue dev --target node` builds and serves all 4 agents
- [x] `curl /agents/chat/test1` returns LLM response with usage
- [x] `curl /agents/hello/test1` returns success (agent span + logs, no errors)
- [x] `curl /agents/boom/test1` returns error (captureException + error span)
- [x] `curl /agents/explicit/test1` returns 200 with error logs captured
- [x] Spans verified in Sentry via MCP: correct hierarchy, attributes, durations
- [x] Logs verified in Sentry: messages, severity levels, correlation attrs

🤖 Generated with [Claude Code](https://claude.com/claude-code)