### PR TITLE
feat: add OpenTelemetry tracing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Flue isn't another AI SDK. It's a proper runtime-agnostic framework — think As
 
 Message-driven agents receive direct HTTP or WebSocket messages at `/agents/:name/:id`; application-owned integrations may call `dispatch(...)` to deliver asynchronous input into agent sessions. See [Message-Driven Agents](docs/message-driven-agents.md) for these surfaces. Runnable WebSocket examples are available for [Node](examples/node-websocket) and [Cloudflare](examples/cloudflare-websocket).
 
-For external tracing, metrics, and error reporting, see [Observability](apps/docs/src/content/docs/guide/observability.md), the public `observe(...)`-based [Braintrust tracing example](examples/braintrust), and the [Sentry error-reporting example](examples/sentry).
+For external tracing, metrics, and error reporting, see [Observability](apps/docs/src/content/docs/guide/observability.md), the official [`@flue/opentelemetry`](packages/opentelemetry) adapter, the public `observe(...)`-based [Braintrust tracing example](examples/braintrust), and the [Sentry error-reporting example](examples/sentry).
 
 ### Quickstart
 

--- a/apps/docs/src/content/docs/guide/observability.md
+++ b/apps/docs/src/content/docs/guide/observability.md
@@ -107,13 +107,13 @@ dispatch(...) ─► { dispatchId, acceptedAt }
       └─► idle { instanceId, dispatchId }
 ```
 
-`run_start` and `run_end` are emitted only for workflows. `idle` means that current operation processing has settled and the session is ready for more input; it is not the end of an agent instance or session.
+`run_start`, `run_resume`, and `run_end` are emitted only for workflows. `run_resume` appears when durable recovery continues an already-started run in a new execution context. `idle` means that current operation processing has settled and the session is ready for more input; it is not the end of an agent instance or session.
 
 ### Root lifecycle by invocation kind
 
 | Invocation kind | Trace root | Opening and closing events | Persisted run history | Observation surface |
 | --- | --- | --- | --- | --- |
-| Workflow invocation | `runId` | `run_start` / `run_end` | Yes | `observe(...)`, run APIs, `flue logs`, workflow streams |
+| Workflow invocation | `runId` | `run_start` or recovery `run_resume` / `run_end` | Yes | `observe(...)`, run APIs, `flue logs`, workflow streams |
 | Direct agent prompt | `operationId`, with `instanceId` | `operation_start` / `operation`, then `idle` | No | `observe(...)` and attached HTTP/WebSocket streams |
 | Dispatched agent input | `operationId`, with `instanceId` and `dispatchId` | `operation_start` / `operation`, then `idle` | No | `observe(...)` |
 
@@ -132,7 +132,7 @@ dispatch(...) ─► { dispatchId, acceptedAt }
 | `turnId` | One normalized model request/output pair within agent or compaction work. |
 | `eventIndex` / `timestamp` | Ordering within one emitted context and event time. |
 
-Use `runId` as the root for a workflow trace. For direct or dispatched agent processing, use `operationId` as the finite trace root and retain `instanceId`, `session`, and `dispatchId` as attributes.
+Use `runId` as the root for a workflow trace. For direct or dispatched agent processing, use `operationId` as the finite trace root and retain `instanceId`, `session`, and `dispatchId` as attributes. When a durable workflow attempt replaces an interrupted attempt, `run_start.restartedFromRunId` carries the prior run identity for trace linking. When the same workflow run is recovered after an interrupted execution context, `run_resume` lets isolate-local exporters begin a resumed workflow segment for the existing `runId`.
 
 ## Event reference
 
@@ -140,7 +140,7 @@ Use `runId` as the root for a workflow trace. For direct or dispatched agent pro
 
 | Category | Events | Emitted when |
 | --- | --- | --- |
-| Workflow envelope | `run_start`, `run_end` | Workflow invocations only. |
+| Workflow envelope | `run_start`, `run_resume`, `run_end` | Workflow invocations only; `run_resume` signals durable recovery continuing in a new execution context. |
 | Operation lifecycle | `operation_start`, `operation`, `idle` | Session operations, including direct and dispatched prompts. |
 | Agent loop | `agent_start`, `agent_end` | Model-driven prompt, skill, or delegated task processing. |
 | Ordinary turn lifecycle | `turn_start`, `turn_end` | Agent-loop model turns only. |
@@ -148,7 +148,7 @@ Use `runId` as the root for a workflow trace. For direct or dispatched agent pro
 | Message streaming | `message_start`, `message_update`, `message_end` | Message activity inside the ordinary agent loop. |
 | Streamed content | `text_delta`, `thinking_start`, `thinking_delta`, `thinking_end` | Assistant text or reasoning projections when present. |
 | Tool execution | `tool_execution_start`, `tool_execution_update`, `tool_execution_end` | Tools invoked from an agent-loop turn. |
-| Normalized tool span | `tool_start`, `tool_call` | Agent-loop tools and `session.shell(...)`. |
+| Normalized tool span | `tool_start`, `tool_call` | Agent-loop tools, `session.shell(...)`, and `harness.shell(...)`. |
 | Delegated task span | `task_start`, `task` | Child-agent work performed through `session.task(...)` or the task tool. |
 | Compaction span | `compaction_start`, `compaction` | Context compaction when compaction work is performed. |
 | Diagnostics | `log` | Application-authored logs and runtime diagnostic logs. |
@@ -195,12 +195,12 @@ turn { purpose: 'agent', turnId, usage, durationMs, isError }
 
 Flue exposes raw agent-loop tool progress and normalized completed tool spans:
 
-| Event family | Use it for | Model-invoked tools | `session.shell(...)` |
-| --- | --- | ---: | ---: |
-| `tool_execution_start` / `tool_execution_update` / `tool_execution_end` | Incremental tool execution activity. | Yes | No |
-| `tool_start` / `tool_call` | Duration, result, and error span mapping. | Yes | Yes |
+| Event family | Use it for | Model-invoked tools | `session.shell(...)` | `harness.shell(...)` |
+| --- | --- | ---: | ---: | ---: |
+| `tool_execution_start` / `tool_execution_update` / `tool_execution_end` | Incremental tool execution activity. | Yes | No | No |
+| `tool_start` / `tool_call` | Duration, result, and error span mapping. | Yes | Yes | Yes |
 
-When an agent invokes several tools concurrently, execution-update and terminal events may interleave. Match tool activity by tool-call identity rather than assuming sequential ordering.
+`harness.shell(...)` emits a harness-correlated bash tool span without a session operation because it intentionally runs outside conversation state. When an agent invokes several tools concurrently, execution-update and terminal events may interleave. Match tool activity by tool-call identity rather than assuming sequential ordering.
 
 ### Delegated tasks
 
@@ -340,7 +340,7 @@ A useful span mapping is:
 
 | Flue lifecycle events | Trace concept |
 | --- | --- |
-| `run_start` / `run_end` | Workflow root span |
+| `run_start` / `run_resume` / `run_end` | Workflow root span or resumed workflow segment |
 | `operation_start` / `operation` | Operation span; root for direct/dispatched input processing |
 | `agent_start` / `agent_end` | Optional agent-loop span |
 | `turn_request` / `turn` | LLM generation span |
@@ -384,14 +384,30 @@ See the [`examples/sentry/`](https://github.com/withastro/flue/tree/main/example
 
 ## Export traces to an observability platform
 
-For full AI traces, translate correlated events into your provider's spans. The [`examples/braintrust/`](https://github.com/withastro/flue/tree/main/examples/braintrust) project demonstrates a public `observe(...)`-only bridge that creates:
+Use the OpenTelemetry adapter when your application already configures an OpenTelemetry SDK and exporter:
+
+```ts title=".flue/app.ts"
+import { createOpenTelemetryObserver } from '@flue/opentelemetry';
+import { flue, observe } from '@flue/runtime/app';
+import { Hono } from 'hono';
+
+observe(createOpenTelemetryObserver());
+
+const app = new Hono();
+app.route('/', flue());
+export default app;
+```
+
+The adapter maps workflow runs, recovered workflow segments, operations, model turns, tools, tasks, compaction, and logs into spans and span events. It exports correlation, latency, terminal error messages, model, and token/cost metadata by default. Set `captureContent: true` only if your exporter should receive payloads, results, prompts, outputs, task content, tool arguments/results, and log attributes.
+
+For a provider-specific integration, translate correlated events into your provider's spans. The [`examples/braintrust/`](https://github.com/withastro/flue/tree/main/examples/braintrust) project demonstrates a public `observe(...)`-only bridge that creates:
 
 - workflow root spans;
 - operation, task, and compaction spans;
 - model-generation spans with request/output and token/cost data;
 - nested tool spans.
 
-The same event model can be mapped to OpenTelemetry, Braintrust, Sentry tracing, or an internal trace store. `observe(...)` gives an adapter the Flue-level execution semantics. A vendor may separately use provider SDK instrumentation or Node-specific wrappers when it needs live async context for provider-native spans; application code does not need to depend on private Flue runtime internals to understand the Flue trace.
+`@flue/opentelemetry` and the Braintrust example both consume only the public `observe(...)` event model. `observe(...)` gives an adapter the Flue-level execution semantics. A vendor may separately use provider SDK instrumentation or Node-specific wrappers when it needs live async context for provider-native spans; application code does not need to depend on private Flue runtime internals to understand the Flue trace.
 
 ## Handle sensitive content carefully
 
@@ -423,6 +439,6 @@ A practical observability setup can grow in stages:
 1. **Local development:** log selected `observe(...)` events to the console and inspect workflows with `flue logs`.
 2. **Production diagnostics:** emit structured `ctx.log` events and forward terminal failures to an error reporter.
 3. **Operational monitoring:** derive latency, token, cost, and error metrics from terminal operation and model-turn events.
-4. **Full tracing:** map operations, turns, tools, tasks, and compactions to spans in Braintrust, OpenTelemetry, Sentry, or another tracing backend.
+4. **Full tracing:** configure an OpenTelemetry exporter with `@flue/opentelemetry`, or map operations, turns, tools, tasks, and compactions to spans in another tracing backend.
 
 Start with the questions your application needs answered, and add telemetry only where it helps you debug, monitor, or improve behavior.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,7 +23,7 @@ Flue isn't another AI SDK. It's a proper runtime-agnostic framework — think As
 
 Message-driven agents receive direct HTTP or WebSocket messages at `/agents/:name/:id`; application-owned integrations may call `dispatch(...)` to deliver asynchronous input into agent sessions. See [Message-Driven Agents](docs/message-driven-agents.md) for these surfaces. Runnable WebSocket examples are available for [Node](examples/node-websocket) and [Cloudflare](examples/cloudflare-websocket).
 
-For external tracing, metrics, and error reporting, see [Observability](apps/docs/src/content/docs/guide/observability.md), the public `observe(...)`-based [Braintrust tracing example](examples/braintrust), and the [Sentry error-reporting example](examples/sentry).
+For external tracing, metrics, and error reporting, see [Observability](apps/docs/src/content/docs/guide/observability.md), the official [`@flue/opentelemetry`](../opentelemetry) adapter, the public `observe(...)`-based [Braintrust tracing example](../../examples/braintrust), and the [Sentry error-reporting example](../../examples/sentry).
 
 ### Quickstart
 

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -1,0 +1,49 @@
+# OpenTelemetry for Flue
+
+`@flue/opentelemetry` converts Flue's public `observe(...)` event stream into OpenTelemetry spans. It does not instrument Flue internals or configure an exporter.
+
+## Usage
+
+Configure your OpenTelemetry SDK and exporter in your application, then register the observer in `.flue/app.ts`:
+
+```ts
+import { createOpenTelemetryObserver } from '@flue/opentelemetry';
+import { flue, observe } from '@flue/runtime/app';
+import { Hono } from 'hono';
+
+observe(createOpenTelemetryObserver());
+
+const app = new Hono();
+app.route('/', flue());
+export default app;
+```
+
+Pass a tracer when the application already owns a configured tracer instance:
+
+```ts
+observe(createOpenTelemetryObserver({ tracer }));
+```
+
+## Span mapping
+
+| Flue events | Span |
+| --- | --- |
+| `run_start` / `run_resume` / `run_end` | Workflow root span or resumed workflow segment |
+| `operation_start` / `operation` | Operation span; root for direct or dispatched processing |
+| `turn_request` / `turn` | Model-generation span |
+| `tool_start` / `tool_call` | Tool span, including `harness.shell(...)` |
+| `task_start` / `task` | Delegated-task span |
+| `compaction_start` / `compaction` | Compaction span |
+| `log` | Span event |
+
+## Sensitive content
+
+By default, spans contain identifiers, terminal error messages, durations, model/provider attributes, and token/cost metadata only. They do not contain workflow payloads/results, model input/output, tool arguments/results, task prompts/results, or log content.
+
+To explicitly send those values to the configured exporter:
+
+```ts
+observe(createOpenTelemetryObserver({ captureContent: true }));
+```
+
+Review exported data retention and redaction requirements before enabling content capture.

--- a/packages/opentelemetry/package.json
+++ b/packages/opentelemetry/package.json
@@ -1,0 +1,34 @@
+{
+	"name": "@flue/opentelemetry",
+	"version": "0.8.0",
+	"type": "module",
+	"license": "Apache-2.0",
+	"exports": {
+		".": {
+			"types": "./dist/index.d.mts",
+			"import": "./dist/index.mjs"
+		}
+	},
+	"main": "./dist/index.mjs",
+	"types": "./dist/index.d.mts",
+	"files": [
+		"dist"
+	],
+	"engines": {
+		"node": ">=22.18.0"
+	},
+	"scripts": {
+		"build": "tsdown",
+		"check:types": "tsc --noEmit",
+		"test": "vitest run"
+	},
+	"dependencies": {
+		"@flue/runtime": "workspace:*",
+		"@opentelemetry/api": "^1.9.0"
+	},
+	"devDependencies": {
+		"tsdown": "^0.22.0",
+		"typescript": "^6.0.3",
+		"vitest": "^4.1.6"
+	}
+}

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -1,0 +1,287 @@
+import type { FlueEvent } from '@flue/runtime';
+import type { FlueEventSubscriber } from '@flue/runtime/app';
+import { context, SpanKind, SpanStatusCode, trace, type Attributes, type Context, type Span, type Tracer } from '@opentelemetry/api';
+
+export interface OpenTelemetryObserverOptions {
+	tracer?: Tracer;
+	captureContent?: boolean;
+}
+
+export function createOpenTelemetryObserver(options: OpenTelemetryObserverOptions = {}): FlueEventSubscriber {
+	const tracer = options.tracer ?? trace.getTracer('@flue/opentelemetry');
+	const captureContent = options.captureContent === true;
+	const runs = new Map<string, Span>();
+	const resumedRuns = new Set<string>();
+	const operations = new Map<string, Span>();
+	const turns = new Map<string, Span>();
+	const tools = new Map<string, Span>();
+	const tasks = new Map<string, Span>();
+	const compactions = new Map<string, Span>();
+
+	return (event) => {
+		const time = timestamp(event);
+		if (event.type === 'run_start') {
+			runs.set(event.runId, tracer.startSpan(`flue.workflow ${event.workflowName}`, {
+				root: true,
+				kind: SpanKind.INTERNAL,
+				startTime: new Date(event.startedAt),
+				attributes: {
+					...identifiers(event),
+					'flue.workflow.name': event.workflowName,
+					...(event.restartedFromRunId ? { 'flue.workflow.restarted_from_run_id': event.restartedFromRunId } : {}),
+					...(captureContent ? contentAttribute('flue.workflow.payload', event.payload) : {}),
+				},
+			}));
+			return;
+		}
+		if (event.type === 'run_resume') {
+			const interrupted = runs.get(event.runId);
+			if (interrupted) {
+				interrupted.setStatus({ code: SpanStatusCode.ERROR, message: 'Workflow execution resumed after interruption.' });
+				interrupted.end(time);
+			}
+			resumedRuns.add(event.runId);
+			runs.set(event.runId, tracer.startSpan(`flue.workflow ${event.workflowName}`, {
+				root: true,
+				kind: SpanKind.INTERNAL,
+				startTime: time,
+				attributes: {
+					...identifiers(event),
+					'flue.workflow.name': event.workflowName,
+					'flue.workflow.resumed': true,
+					'flue.workflow.started_at': event.startedAt,
+				},
+			}));
+			return;
+		}
+		if (event.type === 'operation_start') {
+			const parent = event.taskId ? tasks.get(event.taskId) : workflowSpan(event, runs);
+			operations.set(event.operationId, startSpan(tracer, `flue.operation ${event.operationKind}`, parent, {
+				startTime: time,
+				attributes: { ...identifiers(event), 'flue.operation.kind': event.operationKind },
+			}));
+			return;
+		}
+		if (event.type === 'task_start') {
+			const parent = operationSpan(event, operations) ?? workflowSpan(event, runs);
+			tasks.set(event.taskId, startSpan(tracer, event.agent ? `flue.task ${event.agent}` : 'flue.task', parent, {
+				startTime: time,
+				attributes: {
+					...identifiers(event),
+					...(event.agent ? { 'flue.task.agent': event.agent } : {}),
+					...(captureContent && event.cwd ? { 'flue.task.cwd': event.cwd } : {}),
+					...(captureContent ? { 'flue.task.prompt': event.prompt } : {}),
+				},
+			}));
+			return;
+		}
+		if (event.type === 'compaction_start') {
+			const parent = operationSpan(event, operations) ?? workflowSpan(event, runs);
+			compactions.set(compactionKey(event), startSpan(tracer, 'flue.compaction', parent, {
+				startTime: time,
+				attributes: { ...identifiers(event), 'flue.compaction.reason': event.reason, 'flue.compaction.estimated_tokens': event.estimatedTokens },
+			}));
+			return;
+		}
+		if (event.type === 'turn_request') {
+			const parent = event.purpose === 'agent'
+				? operationSpan(event, operations) ?? workflowSpan(event, runs)
+				: compactions.get(compactionKey(event)) ?? operationSpan(event, operations) ?? workflowSpan(event, runs);
+			turns.set(event.turnId, startSpan(tracer, 'gen_ai.generate', parent, {
+				startTime: time,
+				attributes: {
+					...identifiers(event),
+					'flue.turn.purpose': event.purpose,
+					'gen_ai.operation.name': 'chat',
+					'gen_ai.provider.name': event.provider,
+					'gen_ai.request.model': event.model,
+					'flue.provider.api': event.api,
+					...(event.reasoning ? { 'flue.reasoning': event.reasoning } : {}),
+					...(captureContent ? contentAttribute('flue.turn.input', event.input) : {}),
+				},
+			}));
+			return;
+		}
+		if (event.type === 'tool_start') {
+			const parent = (event.turnId ? turns.get(event.turnId) : undefined) ?? operationSpan(event, operations) ?? workflowSpan(event, runs);
+			tools.set(toolKey(event), startSpan(tracer, `flue.tool ${event.toolName}`, parent, {
+				startTime: time,
+				attributes: {
+					...identifiers(event),
+					'flue.tool.name': event.toolName,
+					'flue.tool.call_id': event.toolCallId,
+					...(captureContent ? contentAttribute('flue.tool.arguments', event.args) : {}),
+				},
+			}));
+			return;
+		}
+		if (event.type === 'tool_call') {
+			const span = tools.get(toolKey(event));
+			if (!span) return;
+			span.setAttribute('flue.duration_ms', event.durationMs);
+			if (captureContent) setContentAttribute(span, 'flue.tool.result', event.result);
+			complete(span, event.isError, event.isError ? 'Tool call failed.' : undefined, time);
+			tools.delete(toolKey(event));
+			return;
+		}
+		if (event.type === 'turn') {
+			const span = turns.get(event.turnId);
+			if (!span) return;
+			span.setAttributes({
+				'flue.duration_ms': event.durationMs,
+				...(event.model ? { 'gen_ai.response.model': event.model } : {}),
+				...(event.provider ? { 'gen_ai.provider.name': event.provider } : {}),
+				...(event.api ? { 'flue.provider.api': event.api } : {}),
+				...(event.stopReason ? { 'gen_ai.response.finish_reasons': [event.stopReason] } : {}),
+				...usageAttributes(event.usage),
+			});
+			if (captureContent) setContentAttribute(span, 'flue.turn.output', event.output);
+			complete(span, event.isError, event.error, time);
+			turns.delete(event.turnId);
+			return;
+		}
+		if (event.type === 'compaction') {
+			const key = compactionKey(event);
+			const span = compactions.get(key);
+			if (!span) return;
+			span.setAttributes({
+				'flue.duration_ms': event.durationMs,
+				'flue.compaction.messages_before': event.messagesBefore,
+				'flue.compaction.messages_after': event.messagesAfter,
+			});
+			span.end(time);
+			compactions.delete(key);
+			return;
+		}
+		if (event.type === 'task') {
+			const span = tasks.get(event.taskId);
+			if (!span) return;
+			span.setAttribute('flue.duration_ms', event.durationMs);
+			if (captureContent) setContentAttribute(span, 'flue.task.result', event.result);
+			complete(span, event.isError, event.isError ? (captureContent ? event.result : 'Task failed.') : undefined, time);
+			tasks.delete(event.taskId);
+			return;
+		}
+		if (event.type === 'log') {
+			const span = (event.turnId ? turns.get(event.turnId) : undefined) ?? operationSpan(event, operations) ?? workflowSpan(event, runs);
+			if (!span) return;
+			span.addEvent('flue.log', {
+				'flue.log.level': event.level,
+				...(captureContent ? { 'flue.log.message': event.message, ...contentAttribute('flue.log.attributes', event.attributes) } : {}),
+			}, time);
+			return;
+		}
+		if (event.type === 'operation') {
+			const span = operations.get(event.operationId);
+			if (!span) return;
+			span.setAttributes({ 'flue.duration_ms': event.durationMs, ...usageAttributes(event.usage, 'flue.operation.usage') });
+			if (captureContent) setContentAttribute(span, 'flue.operation.result', event.result);
+			complete(span, event.isError, event.error, time);
+			operations.delete(event.operationId);
+			const key = compactionKey(event);
+			const compaction = compactions.get(key);
+			if (compaction) {
+				compaction.setStatus({ code: SpanStatusCode.ERROR, message: 'Operation ended without a terminal compaction event.' });
+				compaction.end(time);
+				compactions.delete(key);
+			}
+			return;
+		}
+		if (event.type === 'run_end') {
+			const span = runs.get(event.runId);
+			if (!span) return;
+			span.setAttribute(resumedRuns.has(event.runId) ? 'flue.workflow.total_duration_ms' : 'flue.duration_ms', event.durationMs);
+			if (captureContent) setContentAttribute(span, 'flue.workflow.result', event.result);
+			complete(span, event.isError, event.error, time);
+			runs.delete(event.runId);
+			resumedRuns.delete(event.runId);
+		}
+	};
+}
+
+function startSpan(tracer: Tracer, name: string, parent: Span | undefined, options: { startTime: Date; attributes: Attributes }): Span {
+	return tracer.startSpan(name, { ...options, root: parent === undefined }, parentContext(parent));
+}
+
+function parentContext(parent: Span | undefined): Context | undefined {
+	return parent ? trace.setSpan(context.active(), parent) : undefined;
+}
+
+function workflowSpan(event: FlueEvent, runs: Map<string, Span>): Span | undefined {
+	return event.runId ? runs.get(event.runId) : undefined;
+}
+
+function operationSpan(event: FlueEvent, operations: Map<string, Span>): Span | undefined {
+	return event.operationId ? operations.get(event.operationId) : undefined;
+}
+
+function compactionKey(event: FlueEvent): string {
+	return `${event.runId ?? event.instanceId ?? ''}:${event.session ?? ''}:${event.operationId ?? ''}`;
+}
+
+function toolKey(event: FlueEvent & { toolCallId: string }): string {
+	return `${event.turnId ?? event.operationId ?? event.taskId ?? event.runId ?? event.instanceId ?? ''}:${event.toolCallId}`;
+}
+
+function identifiers(event: FlueEvent): Attributes {
+	return Object.fromEntries(Object.entries({
+		'flue.run_id': event.runId,
+		'flue.instance_id': event.instanceId,
+		'flue.dispatch_id': event.dispatchId,
+		'flue.harness.name': event.harness,
+		'flue.session.name': event.session,
+		'flue.parent_session.name': event.parentSession,
+		'flue.operation.id': event.operationId,
+		'flue.task.id': event.taskId,
+		'flue.turn.id': event.turnId,
+	}).filter((entry): entry is [string, string] => entry[1] !== undefined));
+}
+
+function usageAttributes(usage: Extract<FlueEvent, { type: 'turn' }>['usage'], prefix = 'gen_ai.usage'): Attributes {
+	if (!usage) return {};
+	return {
+		[`${prefix}.input_tokens`]: usage.input,
+		[`${prefix}.output_tokens`]: usage.output,
+		[`${prefix}.cache_read_tokens`]: usage.cacheRead,
+		[`${prefix}.cache_write_tokens`]: usage.cacheWrite,
+		[`${prefix}.total_tokens`]: usage.totalTokens,
+		[`${prefix}.cost_total`]: usage.cost.total,
+	};
+}
+
+function contentAttribute(name: string, value: unknown): Attributes {
+	if (value === undefined) return {};
+	return { [name]: typeof value === 'string' ? value : safeJson(value) };
+}
+
+function setContentAttribute(span: Span, name: string, value: unknown): void {
+	const attributes = contentAttribute(name, value);
+	if (Object.keys(attributes).length > 0) span.setAttributes(attributes);
+}
+
+function complete(span: Span, isError: boolean, error: unknown, time: Date): void {
+	if (isError) {
+		const message = errorMessage(error);
+		span.setStatus({ code: SpanStatusCode.ERROR, message });
+		if (message) span.recordException(message);
+	}
+	span.end(time);
+}
+
+function errorMessage(error: unknown): string | undefined {
+	if (typeof error === 'string') return error;
+	if (error && typeof error === 'object' && 'message' in error && typeof error.message === 'string') return error.message;
+	return error === undefined ? undefined : safeJson(error);
+}
+
+function safeJson(value: unknown): string {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function timestamp(event: FlueEvent): Date {
+	return event.timestamp ? new Date(event.timestamp) : new Date();
+}

--- a/packages/opentelemetry/test/index.test.ts
+++ b/packages/opentelemetry/test/index.test.ts
@@ -1,0 +1,125 @@
+import { trace, type AttributeValue, type Context, type Exception, type Link, type Span, type SpanContext, type SpanOptions, type SpanStatus, type TimeInput } from '@opentelemetry/api';
+import { describe, expect, it } from 'vitest';
+import { createOpenTelemetryObserver } from '../src/index.ts';
+
+class RecordingSpan implements Span {
+	readonly attributes: Record<string, AttributeValue> = {};
+	readonly events: Array<{ name: string; attributes?: Record<string, AttributeValue> }> = [];
+	readonly exceptions: unknown[] = [];
+	status?: SpanStatus;
+	ended = false;
+
+	constructor(readonly name: string, readonly options: SpanOptions | undefined, readonly parent: Span | undefined) {
+		Object.assign(this.attributes, options?.attributes);
+	}
+
+	spanContext(): SpanContext {
+		return { traceId: '00000000000000000000000000000001', spanId: '0000000000000001', traceFlags: 1 };
+	}
+
+	setAttribute(key: string, value: AttributeValue) {
+		this.attributes[key] = value;
+		return this;
+	}
+
+	setAttributes(attributes: Record<string, AttributeValue>) {
+		Object.assign(this.attributes, attributes);
+		return this;
+	}
+
+	addEvent(name: string, attributesOrStartTime?: Record<string, AttributeValue> | TimeInput) {
+		const attributes = attributesOrStartTime && typeof attributesOrStartTime === 'object' && !Array.isArray(attributesOrStartTime) && !(attributesOrStartTime instanceof Date)
+			? attributesOrStartTime
+			: undefined;
+		this.events.push({ name, attributes });
+		return this;
+	}
+
+	addLink(_link: Link) { return this; }
+	addLinks(_links: Link[]) { return this; }
+
+	setStatus(status: SpanStatus) {
+		this.status = status;
+		return this;
+	}
+
+	updateName() { return this; }
+
+	end(_endTime?: TimeInput) {
+		this.ended = true;
+	}
+
+	isRecording() { return true; }
+
+	recordException(exception: Exception, _time?: TimeInput) {
+		this.exceptions.push(exception);
+	}
+}
+
+class RecordingTracer {
+	readonly spans: RecordingSpan[] = [];
+
+	startSpan(name: string, options?: SpanOptions, parentContext?: Context): Span {
+		const parent = parentContext ? trace.getSpan(parentContext) : undefined;
+		const span = new RecordingSpan(name, options, parent);
+		this.spans.push(span);
+		return span;
+	}
+}
+
+describe('createOpenTelemetryObserver', () => {
+	it('creates workflow and nested semantic spans without capturing content by default', () => {
+		const tracer = new RecordingTracer();
+		const observe = createOpenTelemetryObserver({ tracer: tracer as never });
+		observe({ type: 'run_start', runId: 'run-1', owner: { kind: 'workflow', workflowName: 'report', instanceId: 'run-1' }, instanceId: 'run-1', workflowName: 'report', startedAt: '2026-05-27T00:00:00.000Z', restartedFromRunId: 'run-0', payload: { secret: true }, timestamp: '2026-05-27T00:00:00.000Z' }, {} as never);
+		observe({ type: 'operation_start', runId: 'run-1', operationId: 'op-1', operationKind: 'prompt', timestamp: '2026-05-27T00:00:00.010Z' }, {} as never);
+		observe({ type: 'turn_request', runId: 'run-1', operationId: 'op-1', turnId: 'turn-1', purpose: 'agent', model: 'sonnet', provider: 'anthropic', api: 'messages', input: { messages: [] }, timestamp: '2026-05-27T00:00:00.020Z' }, {} as never);
+		observe({ type: 'turn', runId: 'run-1', operationId: 'op-1', turnId: 'turn-1', purpose: 'agent', durationMs: 10, isError: false, usage: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0, totalTokens: 5, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0.01 } }, timestamp: '2026-05-27T00:00:00.030Z' }, {} as never);
+		observe({ type: 'operation', runId: 'run-1', operationId: 'op-1', operationKind: 'prompt', durationMs: 30, isError: false, timestamp: '2026-05-27T00:00:00.040Z' }, {} as never);
+		observe({ type: 'run_end', runId: 'run-1', durationMs: 40, isError: false, timestamp: '2026-05-27T00:00:00.050Z' }, {} as never);
+
+		expect(tracer.spans.map((span) => span.name)).toEqual(['flue.workflow report', 'flue.operation prompt', 'gen_ai.generate']);
+		expect(tracer.spans[0]?.attributes).toMatchObject({ 'flue.workflow.name': 'report', 'flue.workflow.restarted_from_run_id': 'run-0' });
+		expect(tracer.spans[0]?.attributes).not.toHaveProperty('flue.workflow.payload');
+		expect(tracer.spans[2]?.attributes).toMatchObject({ 'gen_ai.request.model': 'sonnet', 'gen_ai.usage.input_tokens': 2, 'gen_ai.usage.output_tokens': 3 });
+		expect(tracer.spans.every((span) => span.ended)).toBe(true);
+	});
+
+	it('starts a resumed workflow segment when an isolate observes recovered work', () => {
+		const tracer = new RecordingTracer();
+		const observe = createOpenTelemetryObserver({ tracer: tracer as never });
+		observe({ type: 'run_resume', runId: 'run-1', owner: { kind: 'workflow', workflowName: 'report', instanceId: 'run-1' }, instanceId: 'run-1', workflowName: 'report', startedAt: '2026-05-27T00:00:00.000Z', timestamp: '2026-05-27T00:01:00.000Z' }, {} as never);
+		observe({ type: 'operation_start', runId: 'run-1', operationId: 'op-1', operationKind: 'prompt', timestamp: '2026-05-27T00:01:00.010Z' }, {} as never);
+		observe({ type: 'operation', runId: 'run-1', operationId: 'op-1', operationKind: 'prompt', durationMs: 5, isError: false, timestamp: '2026-05-27T00:01:00.020Z' }, {} as never);
+		observe({ type: 'run_end', runId: 'run-1', durationMs: 60_020, isError: false, timestamp: '2026-05-27T00:01:00.020Z' }, {} as never);
+
+		expect(tracer.spans.map((span) => span.name)).toEqual(['flue.workflow report', 'flue.operation prompt']);
+		expect(tracer.spans[0]?.attributes).toMatchObject({ 'flue.workflow.resumed': true, 'flue.workflow.started_at': '2026-05-27T00:00:00.000Z' });
+		expect(tracer.spans[1]?.parent).toBe(tracer.spans[0]);
+		expect(tracer.spans.every((span) => span.ended)).toBe(true);
+	});
+
+	it('does not export failed task result content unless capture is enabled', () => {
+		const tracer = new RecordingTracer();
+		const observe = createOpenTelemetryObserver({ tracer: tracer as never });
+		observe({ type: 'task_start', instanceId: 'agent-1', operationId: 'op-1', taskId: 'task-1', prompt: 'secret prompt', cwd: '/secret/workspace', timestamp: '2026-05-27T00:00:00.000Z' }, {} as never);
+		observe({ type: 'task', instanceId: 'agent-1', operationId: 'op-1', taskId: 'task-1', durationMs: 5, isError: true, result: 'secret failure detail', timestamp: '2026-05-27T00:00:00.010Z' }, {} as never);
+
+		expect(tracer.spans[0]?.attributes).not.toHaveProperty('flue.task.result');
+		expect(tracer.spans[0]?.attributes).not.toHaveProperty('flue.task.cwd');
+		expect(tracer.spans[0]?.status?.message).toBe('Task failed.');
+		expect(tracer.spans[0]?.exceptions).toEqual(['Task failed.']);
+	});
+
+	it('traces standalone harness tools and only captures content when enabled', () => {
+		const tracer = new RecordingTracer();
+		const observe = createOpenTelemetryObserver({ tracer: tracer as never, captureContent: true });
+		observe({ type: 'tool_start', instanceId: 'agent-1', harness: 'default', toolName: 'bash', toolCallId: 'call-1', args: { command: 'pwd' }, timestamp: '2026-05-27T00:00:00.000Z' }, {} as never);
+		observe({ type: 'tool_call', instanceId: 'agent-1', harness: 'default', toolName: 'bash', toolCallId: 'call-1', durationMs: 5, isError: false, result: 'ok', timestamp: '2026-05-27T00:00:00.010Z' }, {} as never);
+
+		expect(tracer.spans).toHaveLength(1);
+		expect(tracer.spans[0]?.options?.root).toBe(true);
+		expect(tracer.spans[0]?.attributes).toMatchObject({ 'flue.instance_id': 'agent-1', 'flue.tool.name': 'bash', 'flue.tool.arguments': '{"command":"pwd"}', 'flue.tool.result': 'ok' });
+		expect(tracer.spans[0]?.ended).toBe(true);
+	});
+});

--- a/packages/opentelemetry/tsconfig.json
+++ b/packages/opentelemetry/tsconfig.json
@@ -1,0 +1,6 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"lib": ["ESNext", "DOM"]
+	}
+}

--- a/packages/opentelemetry/tsdown.config.ts
+++ b/packages/opentelemetry/tsdown.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+	entry: ['src/index.ts'],
+	format: ['esm'],
+	dts: true,
+	clean: true,
+	deps: { neverBundle: ['@flue/runtime', '@opentelemetry/api'] },
+});

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -23,7 +23,7 @@ Flue isn't another AI SDK. It's a proper runtime-agnostic framework — think As
 
 Message-driven agents receive direct HTTP or WebSocket messages at `/agents/:name/:id`; application-owned integrations may call `dispatch(...)` to deliver asynchronous input into agent sessions. See [Message-Driven Agents](docs/message-driven-agents.md) for these surfaces. Runnable WebSocket examples are available for [Node](examples/node-websocket) and [Cloudflare](examples/cloudflare-websocket).
 
-For external tracing, metrics, and error reporting, see [Observability](apps/docs/src/content/docs/guide/observability.md), the public `observe(...)`-based [Braintrust tracing example](examples/braintrust), and the [Sentry error-reporting example](examples/sentry).
+For external tracing, metrics, and error reporting, see [Observability](apps/docs/src/content/docs/guide/observability.md), the official [`@flue/opentelemetry`](../opentelemetry) adapter, the public `observe(...)`-based [Braintrust tracing example](../../examples/braintrust), and the [Sentry error-reporting example](../../examples/sentry).
 
 ### Quickstart
 

--- a/packages/runtime/src/harness.ts
+++ b/packages/runtime/src/harness.ts
@@ -1,4 +1,6 @@
+import type { AgentToolResult } from '@earendil-works/pi-agent-core';
 import { createCallHandle } from './abort.ts';
+import { formatBashResult } from './agent.ts';
 import { discoverSessionContext } from './context.ts';
 import { createCwdSessionEnv, createFlueFs } from './sandbox.ts';
 import { type CreateTaskSessionOptions, deleteSessionTree, Session } from './session.ts';
@@ -6,6 +8,7 @@ import type {
 	AgentConfig,
 	AgentProfile,
 	CallHandle,
+	FlueEvent,
 	FlueEventCallback,
 	FlueFs,
 	FlueHarness,
@@ -54,12 +57,43 @@ export class Harness implements FlueHarness {
 
 	shell(command: string, options?: ShellOptions): CallHandle<ShellResult> {
 		return createCallHandle(options?.signal, async (signal) => {
-			const result = await this.env.exec(command, {
-				env: options?.env,
-				cwd: options?.cwd,
-				signal,
-			});
-			return { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+			const toolCallId = crypto.randomUUID();
+			const startedAt = Date.now();
+			const args: Record<string, unknown> = { command };
+			if (options?.cwd !== undefined) args.cwd = options.cwd;
+			if (options?.env !== undefined) args.env = redactEnvValues(options.env);
+			this.emit({ type: 'tool_start', toolName: 'bash', toolCallId, args });
+			try {
+				const result = await this.env.exec(command, {
+					env: options?.env,
+					cwd: options?.cwd,
+					signal,
+				});
+				const shellResult = { stdout: result.stdout, stderr: result.stderr, exitCode: result.exitCode };
+				this.emit({
+					type: 'tool_call',
+					toolName: 'bash',
+					toolCallId,
+					isError: false,
+					result: formatBashResult(shellResult, command),
+					durationMs: Date.now() - startedAt,
+				});
+				return shellResult;
+			} catch (error) {
+				const result: AgentToolResult<any> = {
+					content: [{ type: 'text', text: getErrorMessage(error) }],
+					details: { command, exitCode: -1 },
+				};
+				this.emit({
+					type: 'tool_call',
+					toolName: 'bash',
+					toolCallId,
+					isError: true,
+					result,
+					durationMs: Date.now() - startedAt,
+				});
+				throw error;
+			}
 		});
 	}
 
@@ -188,6 +222,10 @@ export class Harness implements FlueHarness {
 		});
 	}
 
+	private emit(event: FlueEvent): void {
+		this.eventCallback?.({ ...event, harness: event.harness ?? this.name });
+	}
+
 	private decorateEventCallback(callback: FlueEventCallback | undefined): FlueEventCallback | undefined {
 		return callback
 			? (event) => {
@@ -195,6 +233,14 @@ export class Harness implements FlueHarness {
 				}
 			: undefined;
 	}
+}
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function redactEnvValues(env: Record<string, string>): Record<string, string> {
+	return Object.fromEntries(Object.keys(env).map((key) => [key, '<redacted>']));
 }
 
 function normalizeSessionName(name: string | undefined): string {

--- a/packages/runtime/src/runtime/handle-agent.ts
+++ b/packages/runtime/src/runtime/handle-agent.ts
@@ -501,6 +501,11 @@ export async function failRecoveredRun(opts: FailRecoveredRunOptions): Promise<v
 		startedAt,
 		startedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : Date.now(),
 	};
+	if (events.some((event) => event.type === 'run_start')) {
+		const flushFanout = subscribeRunFanout(lifecycle);
+		emitRunResume(lifecycle);
+		await flushFanout();
+	}
 	await emitRunEnd(lifecycle, { isError: true, error: opts.error });
 }
 
@@ -526,7 +531,8 @@ export async function recoverWorkflowRun(opts: RecoverRunOptions): Promise<Recov
 			startedAt,
 			startedAtMs: Number.isFinite(startedAtMs) ? startedAtMs : Date.now(),
 		};
-		const result = await invokeWorkflowRunLifecycle(lifecycle, () => opts.handler(lifecycle.ctx), !events.some((event) => event.type === 'run_start'));
+		const hasStarted = events.some((event) => event.type === 'run_start');
+		const result = await invokeWorkflowRunLifecycle(lifecycle, () => opts.handler(lifecycle.ctx), !hasStarted, hasStarted);
 		return { result, isError: false };
 	} catch (error) {
 		try {
@@ -875,9 +881,11 @@ async function invokeWorkflowRunLifecycle<T>(
 	lifecycle: WorkflowRunLifecycle,
 	body: () => T | Promise<T>,
 	emitStart: boolean,
+	emitResume = false,
 ): Promise<T> {
 	const flushFanout = subscribeRunFanout(lifecycle);
 	if (emitStart) emitRunStart(lifecycle);
+	if (emitResume) emitRunResume(lifecycle);
 	let didFlushFanout = false;
 	let result: T;
 	try {
@@ -905,7 +913,19 @@ function emitRunStart(lifecycle: WorkflowRunLifecycle): void {
 		instanceId: lifecycle.owner.instanceId,
 		workflowName: lifecycle.owner.workflowName,
 		startedAt: lifecycle.startedAt,
+		restartedFromRunId: lifecycle.restartedFromRunId,
 		payload: lifecycle.payload,
+	});
+}
+
+function emitRunResume(lifecycle: WorkflowRunLifecycle): void {
+	lifecycle.ctx.emitEvent({
+		type: 'run_resume',
+		runId: lifecycle.runId,
+		owner: lifecycle.owner,
+		instanceId: lifecycle.owner.instanceId,
+		workflowName: lifecycle.owner.workflowName,
+		startedAt: lifecycle.startedAt,
 	});
 }
 

--- a/packages/runtime/src/runtime/schemas.ts
+++ b/packages/runtime/src/runtime/schemas.ts
@@ -127,6 +127,7 @@ const LlmToolSchema = v.object({
 
 const FLUE_EVENT_TYPES = [
 	'run_start',
+	'run_resume',
 	'agent_start',
 	'agent_end',
 	'turn_start',
@@ -164,7 +165,16 @@ const FlueEventSchema = v.union([
 		instanceId: v.string(),
 		workflowName: v.string(),
 		startedAt: v.string(),
+		restartedFromRunId: v.optional(v.string()),
 		payload: v.unknown(),
+	}),
+	flueEvent({
+		type: v.literal('run_resume'),
+		runId: v.string(),
+		owner: v.object({ kind: v.literal('workflow'), workflowName: v.string(), instanceId: v.string() }),
+		instanceId: v.string(),
+		workflowName: v.string(),
+		startedAt: v.string(),
 	}),
 	flueEvent({ type: v.literal('agent_start') }),
 	flueEvent({ type: v.literal('agent_end'), messages: v.array(v.any()) }),

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -911,7 +911,16 @@ export type FlueEvent = (
 			instanceId: string;
 			workflowName: string;
 			startedAt: string;
+			restartedFromRunId?: string;
 			payload: unknown;
+		}
+	| {
+			type: 'run_resume';
+			runId: string;
+			owner: { kind: 'workflow'; workflowName: string; instanceId: string };
+			instanceId: string;
+			workflowName: string;
+			startedAt: string;
 		}
 	| { type: 'agent_start' }
 	| { type: 'agent_end'; messages: AgentMessage[] }
@@ -1009,7 +1018,7 @@ export type FlueEvent = (
 	turnId?: string;
 };
 
-export type AttachedAgentEvent = Exclude<FlueEvent, { type: 'run_start' } | { type: 'run_end' }> & {
+export type AttachedAgentEvent = Exclude<FlueEvent, { type: 'run_start' } | { type: 'run_resume' } | { type: 'run_end' }> & {
 	runId?: never;
 	instanceId: string;
 };

--- a/packages/runtime/test/observe-turn-events.test.ts
+++ b/packages/runtime/test/observe-turn-events.test.ts
@@ -136,6 +136,38 @@ describe('observe model-turn telemetry', () => {
 		}
 	});
 
+	it('emits normalized tool telemetry for harness shell without session operations', async () => {
+		const events: FlueEvent[] = [];
+		const ctx = createFlueContext({
+			id: 'harness-shell-instance',
+			runId: undefined,
+			payload: {},
+			env: {},
+			agentConfig: { systemPrompt: '', skills: {}, model: undefined, resolveModel: () => undefined },
+			createDefaultEnv: async () => ({
+				...createEnv(),
+				exec: async () => ({ stdout: 'prepared', stderr: '', exitCode: 0 }),
+			}),
+			defaultStore: new InMemorySessionStore(),
+		});
+		ctx.subscribeEvent((event) => { events.push(event); });
+		const harness = await ctx.init(createAgent(() => ({ model: false })));
+
+		await harness.shell('prepare workspace', { env: { TOKEN: 'secret' }, cwd: '/work' });
+
+		expect(events.map((event) => event.type)).toEqual(['tool_start', 'tool_call']);
+		expect(events[0]).toMatchObject({
+			type: 'tool_start',
+			instanceId: 'harness-shell-instance',
+			harness: 'default',
+			toolName: 'bash',
+			args: { command: 'prepare workspace', cwd: '/work', env: { TOKEN: '<redacted>' } },
+		});
+		expect(events[0]?.session).toBeUndefined();
+		expect(events[0]?.operationId).toBeUndefined();
+		expect(events[1]).toMatchObject({ type: 'tool_call', toolName: 'bash', isError: false });
+	});
+
 	it('exposes compaction summarization calls as purpose-specific model turns', async () => {
 		const provider = `faux-${crypto.randomUUID()}`;
 		const modelId = 'compact';

--- a/packages/runtime/test/runtime-schemas.test.ts
+++ b/packages/runtime/test/runtime-schemas.test.ts
@@ -3,6 +3,38 @@ import { describe, expect, it } from 'vitest';
 import { RunEventListResponseSchema } from '../src/runtime/schemas.ts';
 
 describe('rich model-turn event schemas', () => {
+	it('accepts workflow restart linkage on run starts', () => {
+		const result = v.safeParse(RunEventListResponseSchema, {
+			events: [{
+				type: 'run_start',
+				runId: 'workflow:report:replacement',
+				owner: { kind: 'workflow', workflowName: 'report', instanceId: 'workflow:report:replacement' },
+				instanceId: 'workflow:report:replacement',
+				workflowName: 'report',
+				startedAt: '2026-05-27T00:00:00.000Z',
+				restartedFromRunId: 'workflow:report:interrupted',
+				payload: {},
+			}],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
+	it('accepts workflow resume signals', () => {
+		const result = v.safeParse(RunEventListResponseSchema, {
+			events: [{
+				type: 'run_resume',
+				runId: 'workflow:report:run',
+				owner: { kind: 'workflow', workflowName: 'report', instanceId: 'workflow:report:run' },
+				instanceId: 'workflow:report:run',
+				workflowName: 'report',
+				startedAt: '2026-05-27T00:00:00.000Z',
+			}],
+		});
+
+		expect(result.success).toBe(true);
+	});
+
 	it('accepts normalized model-turn request and output content', () => {
 		const result = v.safeParse(RunEventListResponseSchema, {
 			events: [

--- a/packages/runtime/test/websocket-foundation.test.ts
+++ b/packages/runtime/test/websocket-foundation.test.ts
@@ -8,6 +8,7 @@ import {
 	InMemoryRunStore,
 	failRecoveredRun,
 	InMemorySessionStore,
+	recoverWorkflowRun,
 	invokeWorkflowAttached,
 	invokeDirectAttached,
 	registeredAgentsForTransport,
@@ -443,6 +444,65 @@ describe('WebSocket transport foundation', () => {
 		expect(await runStore.getRun(runId)).toMatchObject({ status: 'completed', result: { echoed: { day: 'today' } } });
 	});
 
+	it('emits a resume signal when durable terminalization continues an admitted workflow run', async () => {
+		const events: FlueEvent[] = [];
+		const runStore = new InMemoryRunStore();
+		const runId = 'workflow:daily-report:terminal-recover';
+		const owner = { kind: 'workflow' as const, workflowName: 'daily-report', instanceId: runId };
+		await runStore.createRun({ runId, owner, startedAt: '2026-05-27T00:00:00.000Z', payload: { day: 'today' } });
+		await runStore.appendEvent(runId, { type: 'run_start', runId, owner, instanceId: runId, workflowName: 'daily-report', startedAt: '2026-05-27T00:00:00.000Z', payload: { day: 'today' } });
+
+		await failRecoveredRun({
+			label: 'daily-report',
+			owner,
+			id: runId,
+			runId,
+			payload: { day: 'today' },
+			request: new Request('http://localhost/workflows/daily-report'),
+			createContext: (id, currentRunId, payload, request, initialEventIndex) => {
+				const ctx = createContext(id, currentRunId, payload, request, initialEventIndex);
+				ctx.subscribeEvent((event) => { events.push(event); });
+				return ctx;
+			},
+			error: new Error('interrupted'),
+			runStore,
+		});
+
+		expect(events.map((event) => event.type)).toEqual(['run_resume', 'run_end']);
+		expect(events[0]).toMatchObject({ type: 'run_resume', runId, workflowName: 'daily-report' });
+	});
+
+	it('emits a resume signal when durable recovery continues an admitted workflow run', async () => {
+		const events: FlueEvent[] = [];
+		const runStore = new InMemoryRunStore();
+		const runRegistry = new InMemoryRunRegistry();
+		const runId = 'workflow:daily-report:recover';
+		const owner = { kind: 'workflow' as const, workflowName: 'daily-report', instanceId: runId };
+		await runStore.createRun({ runId, owner, startedAt: '2026-05-27T00:00:00.000Z', payload: { day: 'today' } });
+		await runStore.appendEvent(runId, { type: 'run_start', runId, owner, instanceId: runId, workflowName: 'daily-report', startedAt: '2026-05-27T00:00:00.000Z', payload: { day: 'today' } });
+
+		const result = await recoverWorkflowRun({
+			label: 'daily-report',
+			owner,
+			id: runId,
+			runId,
+			payload: { day: 'today' },
+			request: new Request('http://localhost/workflows/daily-report'),
+			createContext: (id, currentRunId, payload, request, initialEventIndex) => {
+				const ctx = createContext(id, currentRunId, payload, request, initialEventIndex);
+				ctx.subscribeEvent((event) => { events.push(event); });
+				return ctx;
+			},
+			handler: async () => ({ ok: true }),
+			runStore,
+			runRegistry,
+		});
+
+		expect(result).toEqual({ result: { ok: true }, isError: false });
+		expect(events.map((event) => event.type)).toEqual(['run_resume', 'run_end']);
+		expect(events[0]).toMatchObject({ type: 'run_resume', runId, workflowName: 'daily-report', startedAt: '2026-05-27T00:00:00.000Z' });
+	});
+
 	it('preserves replacement linkage when a recovered workflow socket attempt is replaced', async () => {
 		const runStore = new InMemoryRunStore();
 		const runRegistry = new InMemoryRunRegistry();
@@ -515,6 +575,7 @@ describe('WebSocket transport foundation', () => {
 		expect(invocation).toEqual({ runId, result: { echoed: { day: 'today' } } });
 		expect(events.map((event) => event.type)).toEqual(['run_start', 'log', 'idle', 'run_end']);
 		expect(events.every((event) => event.runId === runId)).toBe(true);
+		expect(events[0]).toMatchObject({ type: 'run_start', restartedFromRunId: 'workflow:daily-report:previous' });
 		expect(await runStore.getRun(runId)).toMatchObject({ status: 'completed', restartedFromRunId: 'workflow:daily-report:previous', result: { echoed: { day: 'today' } } });
 		expect(await runRegistry.lookupRun(runId)).toMatchObject({ status: 'completed' });
 	});

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -23,7 +23,7 @@ Flue isn't another AI SDK. It's a proper runtime-agnostic framework — think As
 
 Message-driven agents receive direct HTTP or WebSocket messages at `/agents/:name/:id`; application-owned integrations may call `dispatch(...)` to deliver asynchronous input into agent sessions. See [Message-Driven Agents](docs/message-driven-agents.md) for these surfaces. Runnable WebSocket examples are available for [Node](examples/node-websocket) and [Cloudflare](examples/cloudflare-websocket).
 
-For external tracing, metrics, and error reporting, see [Observability](apps/docs/src/content/docs/guide/observability.md), the public `observe(...)`-based [Braintrust tracing example](examples/braintrust), and the [Sentry error-reporting example](examples/sentry).
+For external tracing, metrics, and error reporting, see [Observability](apps/docs/src/content/docs/guide/observability.md), the official [`@flue/opentelemetry`](../opentelemetry) adapter, the public `observe(...)`-based [Braintrust tracing example](../../examples/braintrust), and the [Sentry error-reporting example](../../examples/sentry).
 
 ### Quickstart
 

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -7,6 +7,8 @@ export interface RunRecord {
 	owner: RunOwner;
 	status: RunStatus;
 	startedAt: string;
+	restartedFromRunId?: string;
+	restartedAsRunId?: string;
 	endedAt?: string;
 	isError?: boolean;
 	durationMs?: number;
@@ -226,7 +228,16 @@ export type FlueEvent = (
 			instanceId: string;
 			workflowName: string;
 			startedAt: string;
+			restartedFromRunId?: string;
 			payload: unknown;
+		}
+	| {
+			type: 'run_resume';
+			runId: string;
+			owner: RunOwner;
+			instanceId: string;
+			workflowName: string;
+			startedAt: string;
 		}
 	| { type: 'agent_start' }
 	| { type: 'agent_end'; messages: unknown[] }
@@ -269,7 +280,7 @@ export type FlueEvent = (
 	turnId?: string;
 };
 
-export type AttachedAgentEvent = Exclude<FlueEvent, { type: 'run_start' } | { type: 'run_end' }> & {
+export type AttachedAgentEvent = Exclude<FlueEvent, { type: 'run_start' } | { type: 'run_resume' } | { type: 'run_end' }> & {
 	runId?: never;
 	instanceId: string;
 };

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -116,6 +116,27 @@ describe('createFlueClient', () => {
 		expect(parsed.searchParams.get('limit')).toBe('10');
 	});
 
+	it('exposes workflow restart linkage in run records', async () => {
+		const record = {
+			runId: 'run-next',
+			owner: { kind: 'workflow' as const, workflowName: 'report', instanceId: 'run-next' },
+			status: 'completed' as const,
+			startedAt: '2026-05-27T00:00:00.000Z',
+			restartedFromRunId: 'run-before',
+			restartedAsRunId: 'run-after',
+		};
+		const client = createFlueClient({
+			baseUrl: 'https://flue.test',
+			fetch: async () => Response.json(record),
+		});
+
+		const run = await client.runs.get('run-next');
+		const adminRun = await client.admin.runs.get('run-next');
+
+		expect(run.restartedFromRunId).toBe('run-before');
+		expect(adminRun.restartedAsRunId).toBe('run-after');
+	});
+
 	it('supports admin mounted below a custom path', async () => {
 		let url = '';
 		const client = createFlueClient({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -324,6 +324,25 @@ importers:
 
   packages/connectors: {}
 
+  packages/opentelemetry:
+    dependencies:
+      '@flue/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.1
+    devDependencies:
+      tsdown:
+        specifier: ^0.22.0
+        version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.22.3)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.6
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/runtime:
     dependencies:
       '@earendil-works/pi-agent-core':


### PR DESCRIPTION
## Summary
- add an official `@flue/opentelemetry` adapter built entirely on the public `observe(...)` event model
- expose `harness.shell(...)` as normalized tool telemetry and add workflow recovery/restart correlation events
- document OpenTelemetry usage and extend runtime/SDK coverage for the new event surfaces
