### PR TITLE
feat(cloudflare): allow authored agent bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Agent and workflow WebSocket frames reject blank or whitespace-only `requestId` values, including optional agent ping IDs.
 - Published the Message-Driven Agents guide, Sandbox Connector API, and Daytona integration guide on the documentation site. Replace saved root-guide or raw GitHub links with [Message-Driven Agents](https://flueframework.com/docs/guide/message-driven-agents/), [Sandbox Connector API](https://flueframework.com/docs/api/sandbox-api/), and [Daytona](https://flueframework.com/docs/ecosystem/sandboxes/daytona/).
 - Refreshed homepage and documentation canonical URLs and social-preview metadata.
+- Cloudflare addressable agent modules may export a `CloudflareAgent extends Agent` base class to add native Agents SDK lifecycle hooks and methods while retaining Flue-owned routing and durability wrappers.
 
 ## 0.9.0 - 2026-06-02
 

--- a/apps/docs/src/content/docs/ecosystem/deploy/cloudflare.md
+++ b/apps/docs/src/content/docs/ecosystem/deploy/cloudflare.md
@@ -152,6 +152,31 @@ chat.close();
 
 An exported `websocket` middleware can authenticate its own agent or workflow socket endpoint. Custom `.flue/app.ts` applications provide centralized authentication and mounted prefixes: for example, apply `app.use('/api/agents/*', authenticate)` and `app.use('/api/workflows/*', authenticate)` before `app.route('/api', flue())` to cover both socket surfaces before Flue forwards accepted upgrades into their owning Durable Objects. SDK clients can connect through that mount with `baseUrl: 'https://example.com/api'` and attach query-token or signed handshake context with `websocketUrl: (url) => { url.searchParams.set('token', socketToken); return url; }`. HTTP `token` and `headers` options do not automatically apply to WebSocket upgrades; browsers should use cookies or application-designed URL authentication, while Node clients requiring implementation-specific headers can provide a custom `websocket` factory. Cloudflare socket authentication is established during the handshake: query parameters and original upgrade headers are not restored into operation-time request context after Durable Object forwarding. Avoid header-mutating middleware such as CORS wrapping WebSocket upgrade routes, because WebSocket upgrade responses may have immutable headers.
 
+### Extending an addressable Cloudflare agent
+
+Flue normally owns each generated agent Durable Object class. When an addressable agent needs native Cloudflare Agents SDK capabilities such as `onStart()`, `schedule()`, `scheduleEvery()`, or `queue()`, its module may additionally export a `CloudflareAgent` base class:
+
+```ts
+import { createAgent } from '@flue/runtime';
+import { Agent } from 'agents';
+
+export default createAgent(() => ({ model: 'anthropic/claude-sonnet-4-6' }));
+
+export class CloudflareAgent extends Agent {
+  async onStart() {
+    await this.scheduleEvery(60, 'heartbeat');
+  }
+
+  async heartbeat() {
+    this.setState({ ...this.state, lastHeartbeatAt: Date.now() });
+  }
+}
+```
+
+This is an advanced Cloudflare-only extension point. Flue generates the final Durable Object class as a subclass of the exported base, preserving the filename-derived binding and migration name. Use `onStart()` and additional named methods for native SDK behavior. Do not override `fetch()`, `onRequest()`, WebSocket hooks, `onFiberRecovered()`, or `alarm()`: Flue and the Agents SDK use those methods for routing, hibernating connections, interruption recovery, and alarm multiplexing.
+
+Native SDK callbacks run as agent-instance activity. They do not receive a Flue workflow context, do not create workflow runs, and do not automatically initialize a Flue harness or session.
+
 ## Subagents
 
 Subagents define named delegates for detached task sessions:

--- a/packages/cli/src/lib/build-plugin-cloudflare.ts
+++ b/packages/cli/src/lib/build-plugin-cloudflare.ts
@@ -69,7 +69,7 @@ export class CloudflarePlugin implements BuildPlugin {
 
 		const agentClasses = agents
 			.map(
-				(agent) => `export class ${agentClassName(agent.name)} extends Agent {
+				(agent) => `export class ${agentClassName(agent.name)} extends resolveCloudflareAgentBase(agentModules[${JSON.stringify(agent.name)}], ${JSON.stringify(agent.name)}) {
   async onRequest(request) {
     return dispatchAgent(request, this, ${JSON.stringify(agent.name)}, directHandlers[${JSON.stringify(agent.name)}]);
   }
@@ -266,6 +266,14 @@ ${agentClassMapEntries}
 const workflowClassNames = {
 ${workflowClassMapEntries}
 };
+
+function resolveCloudflareAgentBase(mod, name) {
+  const Base = mod.CloudflareAgent === undefined ? Agent : mod.CloudflareAgent;
+  if (typeof Base !== 'function' || (Base !== Agent && !(Base.prototype instanceof Agent))) {
+    throw new Error('[flue] Agent "' + name + '" CloudflareAgent export must extend Agent from "agents".');
+  }
+  return Base;
+}
 
 // ─── Sandbox Environments ───────────────────────────────────────────────────
 

--- a/packages/runtime/test/cloudflare-agent-extension.integration.test.ts
+++ b/packages/runtime/test/cloudflare-agent-extension.integration.test.ts
@@ -1,0 +1,92 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createServer } from 'vite';
+import { describe, it } from 'vitest';
+import {
+	build,
+	cloudflareViteConfigPath,
+	cloudflareViteInputDir,
+	createCloudflareViteConfig,
+} from '../../cli/src/lib/build.ts';
+
+describe('CloudflareAgent extension', () => {
+	it('runs inherited scheduled callbacks when an agent module exports a CloudflareAgent base', async () => {
+		const root = await createGeneratedFixture();
+		const entryPath = path.join(cloudflareViteInputDir(root), '_entry.ts');
+		const viteConfig = createCloudflareViteConfig(root, cloudflareViteConfigPath(root), [entryPath], {
+			persistState: false,
+		});
+		const server = await createServer({
+			...viteConfig,
+			logLevel: 'silent',
+			server: { host: '127.0.0.1', port: 0 },
+		});
+		try {
+			await server.listen();
+			const localUrl = server.resolvedUrls?.local[0];
+			if (!localUrl) throw new Error('Vite server URL unavailable');
+			await waitFor(async () => {
+				const response = await fetch(new URL('/heartbeat', localUrl));
+				if (!response.ok) return { done: false, detail: await response.text() };
+				const detail = (await response.json()) as { count: number };
+				return { done: detail.count > 0, detail };
+			});
+		} finally {
+			await server.close();
+			fs.rmSync(root, { recursive: true, force: true });
+		}
+	}, 90000);
+});
+
+async function createGeneratedFixture(): Promise<string> {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'flue-cloudflare-agent-extension-'));
+	const output = path.join(root, 'generated');
+	fs.mkdirSync(path.join(root, 'node_modules', '@earendil-works'), { recursive: true });
+	fs.mkdirSync(path.join(root, 'node_modules', '@flue'), { recursive: true });
+	fs.symlinkSync(
+		path.resolve(process.cwd(), 'node_modules', '@earendil-works', 'pi-ai'),
+		path.join(root, 'node_modules', '@earendil-works', 'pi-ai'),
+		'dir',
+	);
+	fs.symlinkSync(process.cwd(), path.join(root, 'node_modules', '@flue', 'runtime'), 'dir');
+	fs.symlinkSync(
+		path.resolve(process.cwd(), '../../examples/cloudflare-websocket/node_modules/agents'),
+		path.join(root, 'node_modules', 'agents'),
+		'dir',
+	);
+	fs.mkdirSync(path.join(root, 'src', 'agents'), { recursive: true });
+	fs.writeFileSync(
+		path.join(root, 'wrangler.jsonc'),
+		JSON.stringify({
+			name: 'cloudflare-agent-extension',
+			compatibility_date: '2026-04-01',
+			compatibility_flags: ['nodejs_compat'],
+			migrations: [{ tag: 'v1', new_sqlite_classes: ['Assistant', 'FlueRegistry'] }],
+		}),
+	);
+	fs.writeFileSync(
+		path.join(root, 'src', 'agents', 'assistant.ts'),
+		`import { createAgent } from '@flue/runtime';\nimport { Agent } from 'agents';\nexport default createAgent(() => ({ model: false }));\nexport class CloudflareAgent extends Agent {\n  async startHeartbeat() { return this.scheduleEvery(1, 'heartbeat'); }\n  async heartbeat() { this.setState({ count: (this.state?.count ?? 0) + 1 }); }\n  getHeartbeatCount() { return this.state?.count ?? 0; }\n}\n`,
+	);
+	fs.writeFileSync(
+		path.join(root, 'src', 'app.ts'),
+		`import { getAgentByName } from 'agents';\nlet started = false;\nexport default {\n  async fetch(_request, env) {\n    const agent = await getAgentByName(env.Assistant, 'scheduled');\n    if (!started) { await agent.startHeartbeat(); started = true; }\n    return Response.json({ count: await agent.getHeartbeatCount() });\n  },\n};\n`,
+	);
+	await build({ root, sourceRoot: path.join(root, 'src'), output, target: 'cloudflare', mode: 'development' });
+	return root;
+}
+
+async function waitFor(
+	predicate: () => Promise<{ done: boolean; detail: unknown }>,
+): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	let detail: unknown;
+	while (Date.now() < deadline) {
+		const result = await predicate();
+		detail = result.detail;
+		if (result.done) return;
+		await new Promise((resolve) => setTimeout(resolve, 100));
+	}
+	throw new Error(`Timed out waiting for scheduled Cloudflare agent callback: ${JSON.stringify(detail)}`);
+}

--- a/packages/runtime/vitest.integration.cloudflare.config.ts
+++ b/packages/runtime/vitest.integration.cloudflare.config.ts
@@ -2,6 +2,9 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
 	test: {
-		include: ['test-legacy/vite-cloudflare-build.test.ts'],
+		include: [
+			'test/cloudflare-agent-extension.integration.test.ts',
+			'test-legacy/vite-cloudflare-build.test.ts',
+		],
 	},
 });


### PR DESCRIPTION
## Summary
- allow addressable Cloudflare agent modules to export an advanced `CloudflareAgent extends Agent` base class
- keep Flue's filename-derived generated Durable Object class outermost so bindings, migrations, transport hooks, and recovery ownership remain stable
- document the native SDK boundary and add workerd integration coverage for inherited `scheduleEvery()` alarm execution

## Scope
This intentionally leaves workflow extension, top-level Worker event forwarding, and callback-to-Flue-session helpers for separate product decisions.

## Validation
- `pnpm run build && pnpm run check:types` in `packages/runtime`
- `pnpm run build && pnpm run check:types` in `packages/cli`
- `pnpm run test` in `packages/runtime`
- `pnpm run test` in `packages/cli`
- `pnpm run test:integration:cloudflare` in `packages/runtime`
- `pnpm run check:types && pnpm run build` in `apps/docs`
- `pnpm run check:types` at repository root
- `pnpm run check:lint` at repository root
- `git diff --check origin/main...HEAD`

Closes #187