### PR TITLE
feat: orchestration primitives and tool approval middleware

### DIFF
--- a/packages/runtime/src/approval.ts
+++ b/packages/runtime/src/approval.ts
@@ -1,0 +1,261 @@
+/**
+ * Human-in-the-loop tool approval middleware for Flue.
+ *
+ * Wraps defineTool with an approval gate: when the model tries to invoke a
+ * protected tool, execution pauses until an external system (frontend UI,
+ * webhook, Slack bot) approves or rejects the action.
+ *
+ * Design principles:
+ * - Non-invasive: works as a wrapper around existing ToolDefinition
+ * - Transport-agnostic: approval resolution via callback you provide
+ * - Timeout-safe: auto-reject if approval doesn't arrive within deadline
+ * - Auditable: every approval decision is logged with context
+ *
+ * @example
+ * ```ts
+ * import { withApproval, createApprovalGate } from './approval';
+ *
+ * const gate = createApprovalGate({
+ *   timeout: 300_000,
+ *   onRequest: async (req) => ws.send(JSON.stringify(req)),
+ * });
+ *
+ * const protectedRefund = withApproval(refundTool, {
+ *   gate,
+ *   when: (args) => args.amount > 100,
+ *   reason: (args) => `Refund $${args.amount} for order #${args.orderId}`,
+ * });
+ *
+ * // Use in agent — it's still a regular ToolDefinition
+ * const agent = createAgent(() => ({
+ *   tools: [protectedRefund, queryOrder],
+ * }));
+ *
+ * // When approval arrives:
+ * gate.resolve(approvalId, { action: 'approve' });
+ * ```
+ *
+ * @module
+ */
+
+import type { ToolDefinition, ToolParameters } from './types.ts';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** The decision returned by an external approver. */
+export type ApprovalDecision =
+	| { action: 'approve' }
+	| { action: 'reject'; reason?: string }
+	| { action: 'modify'; args: Record<string, any> };
+
+/** An approval request sent to the external system. */
+export interface ApprovalRequest {
+	/** Unique ID for this approval request. */
+	id: string;
+	/** Name of the tool requesting approval. */
+	tool: string;
+	/** Arguments the model wants to pass to the tool. */
+	args: Record<string, any>;
+	/** Human-readable explanation of why this needs approval. */
+	reason: string;
+	/** When this request was created (ISO 8601). */
+	timestamp: string;
+	/** When this request will auto-reject if not resolved (ISO 8601). */
+	deadline: string;
+}
+
+/** Configuration for an approval gate instance. */
+export interface ApprovalGateOptions {
+	/**
+	 * Milliseconds to wait for a decision before auto-rejecting.
+	 * Default: 300_000 (5 minutes).
+	 */
+	timeout?: number;
+	/**
+	 * Called when a tool needs approval. Your job: deliver this request
+	 * to whoever can approve it (WebSocket push, Slack message, etc.).
+	 */
+	onRequest: (request: ApprovalRequest) => Promise<void> | void;
+	/**
+	 * Called when a decision is made (approve/reject/timeout).
+	 * Use for audit logging.
+	 */
+	onDecision?: (request: ApprovalRequest, decision: ApprovalDecision) => void;
+}
+
+/** Options for wrapping a specific tool with approval. */
+export interface WithApprovalOptions {
+	/** The approval gate to use. */
+	gate: ApprovalGate;
+	/**
+	 * Predicate: only require approval when this returns true.
+	 * If omitted, ALL invocations require approval.
+	 */
+	when?: (args: Record<string, any>) => boolean;
+	/**
+	 * Generate a human-readable reason for the approval request.
+	 * If omitted, uses a generic message with tool name and args.
+	 */
+	reason?: (args: Record<string, any>) => string;
+}
+
+// ─── ApprovalGate ───────────────────────────────────────────────────────────
+
+/**
+ * An ApprovalGate manages pending approval requests and resolves them
+ * when external systems respond. One gate can serve multiple tools.
+ *
+ * @example
+ * ```ts
+ * const gate = createApprovalGate({
+ *   timeout: 60_000,
+ *   onRequest: async (req) => ws.send(JSON.stringify(req)),
+ *   onDecision: (req, decision) => auditLog.write({ ...req, decision }),
+ * });
+ *
+ * ws.on('message', (msg) => {
+ *   const { type, approvalId, decision } = JSON.parse(msg);
+ *   if (type === 'approval_response') gate.resolve(approvalId, decision);
+ * });
+ * ```
+ */
+export interface ApprovalGate {
+	/** Submit an approval request. Returns a promise that resolves with the decision. */
+	request(tool: string, args: Record<string, any>, reason: string): Promise<ApprovalDecision>;
+	/** Resolve a pending approval request by ID. */
+	resolve(id: string, decision: ApprovalDecision): void;
+	/** Number of currently pending approvals. */
+	readonly pending: number;
+}
+
+export function createApprovalGate(options: ApprovalGateOptions): ApprovalGate {
+	const { timeout = 300_000, onRequest, onDecision } = options;
+
+	const pendingMap = new Map<
+		string,
+		{
+			request: ApprovalRequest;
+			resolve: (decision: ApprovalDecision) => void;
+			timer: ReturnType<typeof setTimeout>;
+		}
+	>();
+
+	return {
+		get pending() {
+			return pendingMap.size;
+		},
+
+		async request(tool, args, reason): Promise<ApprovalDecision> {
+			const id = crypto.randomUUID();
+			const now = new Date();
+			const deadlineDate = new Date(now.getTime() + timeout);
+
+			const approvalRequest: ApprovalRequest = {
+				id,
+				tool,
+				args,
+				reason,
+				timestamp: now.toISOString(),
+				deadline: deadlineDate.toISOString(),
+			};
+
+			return new Promise<ApprovalDecision>((resolvePromise) => {
+				const timer = setTimeout(() => {
+					const entry = pendingMap.get(id);
+					if (entry) {
+						pendingMap.delete(id);
+						const decision: ApprovalDecision = {
+							action: 'reject',
+							reason: `Approval timed out after ${timeout / 1000}s`,
+						};
+						onDecision?.(approvalRequest, decision);
+						resolvePromise(decision);
+					}
+				}, timeout);
+
+				pendingMap.set(id, {
+					request: approvalRequest,
+					resolve: (decision) => {
+						clearTimeout(timer);
+						pendingMap.delete(id);
+						onDecision?.(approvalRequest, decision);
+						resolvePromise(decision);
+					},
+					timer,
+				});
+
+				// Notify external system (fire and forget)
+				Promise.resolve(onRequest(approvalRequest)).catch((err) => {
+					console.error(`[approval] Failed to deliver request: ${err}`);
+				});
+			});
+		},
+
+		resolve(id, decision) {
+			const entry = pendingMap.get(id);
+			if (!entry) {
+				console.warn(`[approval] No pending approval for id=${id}`);
+				return;
+			}
+			entry.resolve(decision);
+		},
+	};
+}
+
+// ─── withApproval ───────────────────────────────────────────────────────────
+
+/**
+ * Wrap a ToolDefinition with an approval gate. Returns a new ToolDefinition
+ * that pauses execution until human approval is received.
+ *
+ * The wrapped tool is a drop-in replacement — same name, same parameters,
+ * same return type. The only difference: execution may pause waiting for
+ * approval.
+ *
+ * @example
+ * ```ts
+ * const protectedRefund = withApproval(refundTool, {
+ *   gate,
+ *   when: ({ amount }) => amount > 100,
+ *   reason: ({ amount, orderId }) => `Refund $${amount} for #${orderId}`,
+ * });
+ * ```
+ */
+export function withApproval<TParams extends ToolParameters>(
+	tool: ToolDefinition<TParams>,
+	options: WithApprovalOptions,
+): ToolDefinition<TParams> {
+	const { gate, when, reason } = options;
+
+	return {
+		name: tool.name,
+		description: tool.description,
+		parameters: tool.parameters,
+
+		async execute(args: Record<string, any>, signal?: AbortSignal): Promise<string> {
+			const needsApproval = when ? when(args) : true;
+
+			if (needsApproval) {
+				const reasonText = reason
+					? reason(args)
+					: `Tool "${tool.name}" requires approval. Args: ${JSON.stringify(args)}`;
+
+				const decision = await gate.request(tool.name, args, reasonText);
+
+				switch (decision.action) {
+					case 'reject':
+						return `[REJECTED] Tool "${tool.name}" was not approved. ${decision.reason || ''}`.trim();
+
+					case 'modify':
+						return tool.execute(decision.args, signal);
+
+					case 'approve':
+						// Fall through to execute below
+						break;
+				}
+			}
+
+			return tool.execute(args, signal);
+		},
+	};
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -17,6 +17,40 @@ export {
 } from './runtime/providers.ts';
 export { createSandboxSessionEnv, type SandboxApi } from './sandbox.ts';
 export { defineTool } from './tool.ts';
+
+// ─── Orchestration primitives ─────────────────────────────────────────────
+
+export {
+	parallel,
+	pipeline,
+	phase,
+	log,
+	registerWorkflow,
+	resolveWorkflow,
+	listWorkflows,
+} from './orchestrate.ts';
+
+export type {
+	TaskDescriptor,
+	ParallelOptions,
+	PipelineOptions,
+	PipelineStage,
+	OrchestrationResult,
+	NamedWorkflow,
+} from './orchestrate.ts';
+
+// ─── Tool approval middleware ─────────────────────────────────────────────
+
+export { createApprovalGate, withApproval } from './approval.ts';
+
+export type {
+	ApprovalDecision,
+	ApprovalGate,
+	ApprovalGateOptions,
+	ApprovalRequest,
+	WithApprovalOptions,
+} from './approval.ts';
+
 export type {
 	AgentConfig,
 	AgentCreateContext,

--- a/packages/runtime/src/orchestrate.ts
+++ b/packages/runtime/src/orchestrate.ts
@@ -1,0 +1,309 @@
+/**
+ * Deterministic multi-agent orchestration primitives for Flue.
+ *
+ * Inspired by Claude Code Dynamic Workflows. These primitives give you
+ * code-driven control over "what runs when" while letting the LLM handle
+ * "what to say/do" within each step.
+ *
+ * Design principles:
+ * - Deterministic: orchestration logic is TypeScript, not LLM-generated
+ * - Barrier-aware: parallel() waits for all; pipeline() is barrier-free
+ * - Fault-tolerant: failed tasks return null by default, never crash the batch
+ * - Schema-first: every task can enforce structured output
+ * - Observable: phase markers and events for tracing/UI integration
+ *
+ * @module
+ */
+
+import type { FlueSession, PromptResponse, TaskOptions } from './types.ts';
+import type * as v from 'valibot';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** A single task descriptor for parallel/pipeline execution. */
+export interface TaskDescriptor<S extends v.GenericSchema | undefined = undefined> {
+	/** The prompt to send to the sub-agent. */
+	prompt: string;
+	/** Display label for observability (like Claude Code's `label` option). */
+	label?: string;
+	/** Route to a declared sub-agent profile by name. */
+	agent?: string;
+	/** Working directory override for the task's sandbox. */
+	cwd?: string;
+	/** Optional valibot schema for structured result extraction. */
+	result?: S;
+	/** Override model for this specific task. */
+	model?: string;
+}
+
+export interface ParallelOptions {
+	/**
+	 * Maximum number of tasks running concurrently.
+	 * Default: 16 (matches Claude Code Workflows limit).
+	 */
+	concurrency?: number;
+	/**
+	 * How to handle individual task failures:
+	 * - "lenient": failed tasks return null, others continue (default)
+	 * - "strict": first failure aborts all remaining tasks
+	 */
+	failMode?: 'lenient' | 'strict';
+	/** AbortSignal to cancel all pending tasks. */
+	signal?: AbortSignal;
+}
+
+export interface PipelineOptions {
+	/**
+	 * Maximum items processed concurrently through the full stage sequence.
+	 * Default: 16.
+	 */
+	concurrency?: number;
+	/** AbortSignal to cancel processing. */
+	signal?: AbortSignal;
+}
+
+/** Result from a parallel() or pipeline() execution. */
+export type OrchestrationResult = PromptResponse | null;
+
+// ─── Phase ──────────────────────────────────────────────────────────────────
+
+/**
+ * Mark a new orchestration phase. Phases are logical groupings for
+ * observability — they appear in traces, logs, and any future UI.
+ *
+ * Equivalent to Claude Code Workflows' `phase(title)`.
+ */
+export function phase(title: string): void {
+	const timestamp = new Date().toISOString();
+	console.log(`[orchestrate] ---- ${title} ---- (${timestamp})`);
+}
+
+/**
+ * Log a narrative message within the current orchestration flow.
+ * Equivalent to Claude Code Workflows' `log(msg)`.
+ */
+export function log(message: string): void {
+	console.log(`[orchestrate] ${message}`);
+}
+
+// ─── Parallel ───────────────────────────────────────────────────────────────
+
+/**
+ * Execute multiple tasks concurrently with barrier semantics.
+ * Waits for ALL tasks to complete (or fail) before returning.
+ *
+ * Failed tasks return `null` in lenient mode (default).
+ * In strict mode, the first failure aborts remaining tasks and throws.
+ */
+export async function parallel(
+	session: FlueSession,
+	tasks: TaskDescriptor[],
+	options?: ParallelOptions,
+): Promise<OrchestrationResult[]> {
+	const { concurrency = 16, failMode = 'lenient', signal } = options ?? {};
+
+	if (tasks.length === 0) return [];
+
+	const results: OrchestrationResult[] = new Array(tasks.length).fill(null);
+	const queue: { task: TaskDescriptor; index: number }[] = tasks.map((task, index) => ({
+		task,
+		index,
+	}));
+
+	const semaphore = new Semaphore(Math.min(concurrency, tasks.length));
+	const abortController = new AbortController();
+	let firstError: Error | null = null;
+
+	if (signal) {
+		signal.addEventListener('abort', () => abortController.abort(signal.reason), { once: true });
+		if (signal.aborted) throw new Error('[orchestrate] Aborted before start');
+	}
+
+	const promises = queue.map(async ({ task, index }) => {
+		await semaphore.acquire();
+		if (abortController.signal.aborted) {
+			semaphore.release();
+			return;
+		}
+
+		try {
+			const taskOpts: TaskOptions = { signal: abortController.signal };
+			if (task.agent) taskOpts.agent = task.agent;
+			if (task.cwd) taskOpts.cwd = task.cwd;
+			if (task.model) taskOpts.model = task.model;
+			if (task.result) (taskOpts as any).result = task.result;
+
+			const result = await session.task(task.prompt, taskOpts);
+			results[index] = result;
+
+			if (task.label) log(`[OK] ${task.label}`);
+		} catch (err) {
+			if (failMode === 'strict' && !firstError) {
+				firstError = err instanceof Error ? err : new Error(String(err));
+				abortController.abort(firstError);
+			}
+			results[index] = null;
+
+			if (task.label) {
+				log(`[FAIL] ${task.label}: ${err instanceof Error ? err.message : err}`);
+			}
+		} finally {
+			semaphore.release();
+		}
+	});
+
+	await Promise.all(promises);
+
+	if (failMode === 'strict' && firstError) {
+		throw firstError;
+	}
+
+	return results;
+}
+
+// ─── Workflow Registry ──────────────────────────────────────────────────────
+
+/**
+ * A named, reusable workflow that takes the output of the previous stage
+ * and returns the input for the next one. Internally it may call
+ * session.task(), session.prompt(), or any orchestration primitive.
+ */
+export type NamedWorkflow = (
+	input: PromptResponse,
+	session: FlueSession,
+) => Promise<PromptResponse>;
+
+const workflowRegistry = new Map<string, NamedWorkflow>();
+
+/**
+ * Register a named workflow for later reference in pipeline stages.
+ * A registered workflow can be referenced by its string name instead
+ * of an inline function.
+ *
+ * @example
+ * ```ts
+ * registerWorkflow('analyze-ticket', async (input, session) => {
+ *   return session.task(`Analyze: ${input.text}`);
+ * });
+ * pipeline(session, tickets, ['analyze-ticket', 'verify', 'respond']);
+ * ```
+ */
+export function registerWorkflow(name: string, workflow: NamedWorkflow): void {
+	workflowRegistry.set(name, workflow);
+}
+
+/**
+ * Resolve a registered workflow by name. Throws if not found.
+ */
+export function resolveWorkflow(name: string): NamedWorkflow {
+	const workflow = workflowRegistry.get(name);
+	if (!workflow) {
+		const registered = [...workflowRegistry.keys()].join(', ');
+		throw new Error(
+			`[orchestrate] Unknown workflow: "${name}". Registered: [${registered}]`,
+		);
+	}
+	return workflow;
+}
+
+/** Returns all registered workflow names. */
+export function listWorkflows(): string[] {
+	return [...workflowRegistry.keys()];
+}
+
+// ─── Pipeline ───────────────────────────────────────────────────────────────
+
+/**
+ * A stage that takes the previous result and returns the next task descriptor.
+ * Pass a string to invoke a named workflow registered via {@link registerWorkflow}.
+ */
+export type PipelineStage =
+	| ((input: PromptResponse) => TaskDescriptor)
+	| string;
+
+/**
+ * Process items through a multi-stage pipeline WITHOUT barrier.
+ * Each item flows independently through all stages — fast items
+ * don't wait for slow ones.
+ */
+export async function pipeline(
+	session: FlueSession,
+	items: PromptResponse[],
+	stages: PipelineStage[],
+	options?: PipelineOptions,
+): Promise<OrchestrationResult[]> {
+	const { concurrency = 16, signal } = options ?? {};
+
+	if (items.length === 0 || stages.length === 0) return [];
+	if (signal?.aborted) throw new Error('[orchestrate] Aborted before start');
+
+	// Eagerly validate all named workflow references.
+	for (const stage of stages) {
+		if (typeof stage === 'string') resolveWorkflow(stage);
+	}
+
+	const semaphore = new Semaphore(Math.min(concurrency, items.length));
+
+	return Promise.all(
+		items.map(async (item) => {
+			await semaphore.acquire();
+			try {
+				let current: PromptResponse = item;
+
+				for (const stage of stages) {
+					if (signal?.aborted) return null;
+
+					if (typeof stage === 'string') {
+						const workflow = resolveWorkflow(stage);
+						current = await workflow(current, session);
+						continue;
+					}
+
+					const descriptor = stage(current);
+					const taskOpts: TaskOptions = { signal };
+					if (descriptor.agent) taskOpts.agent = descriptor.agent;
+					if (descriptor.cwd) taskOpts.cwd = descriptor.cwd;
+					if (descriptor.model) taskOpts.model = descriptor.model;
+					if (descriptor.result) (taskOpts as any).result = descriptor.result;
+
+					current = await session.task(descriptor.prompt, taskOpts);
+				}
+
+				return current;
+			} catch {
+				return null;
+			} finally {
+				semaphore.release();
+			}
+		}),
+	);
+}
+
+// ─── Semaphore ──────────────────────────────────────────────────────────────
+
+/** Async semaphore for bounding concurrency. */
+class Semaphore {
+	private waiting: (() => void)[] = [];
+	private count: number;
+
+	constructor(max: number) {
+		this.count = max;
+	}
+
+	async acquire(): Promise<void> {
+		if (this.count > 0) {
+			this.count--;
+			return;
+		}
+		return new Promise<void>((resolve) => this.waiting.push(resolve));
+	}
+
+	release(): void {
+		const next = this.waiting.shift();
+		if (next) {
+			next();
+		} else {
+			this.count++;
+		}
+	}
+}

--- a/packages/runtime/test/approval.test.ts
+++ b/packages/runtime/test/approval.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createApprovalGate, withApproval } from '../src/approval.ts';
+import type { ToolDefinition } from '../src/types.ts';
+
+function createMockTool(): ToolDefinition {
+	return {
+		name: 'process_refund',
+		description: 'Process a customer refund',
+		parameters: {
+			type: 'object',
+			properties: { orderId: { type: 'string' }, amount: { type: 'number' } },
+			required: ['orderId', 'amount'],
+		},
+		execute: vi.fn(async ({ orderId, amount }) =>
+			JSON.stringify({ success: true, refundId: 'RF-123', orderId, amount }),
+		),
+	};
+}
+
+describe('createApprovalGate()', () => {
+	it('creates a gate with zero pending', () => {
+		const gate = createApprovalGate({ onRequest: vi.fn() });
+		expect(gate.pending).toBe(0);
+	});
+
+	it('request() calls onRequest with correct structure', async () => {
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'approve' }), 10);
+
+		const decision = await gate.request('process_refund', { amount: 500 }, 'Refund $500');
+		expect(onRequest).toHaveBeenCalledTimes(1);
+		const req = onRequest.mock.calls[0][0];
+		expect(req.tool).toBe('process_refund');
+		expect(req.args).toEqual({ amount: 500 });
+		expect(req.id).toBeDefined();
+		expect(req.timestamp).toBeDefined();
+		expect(req.deadline).toBeDefined();
+		expect(decision.action).toBe('approve');
+	});
+
+	it('resolve() approve', async () => {
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'approve' }), 10);
+		expect(await gate.request('tool', {}, 'reason')).toEqual({ action: 'approve' });
+		expect(gate.pending).toBe(0);
+	});
+
+	it('resolve() reject', async () => {
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'reject', reason: 'Too expensive' }), 10);
+		expect(await gate.request('tool', {}, 'reason')).toEqual({ action: 'reject', reason: 'Too expensive' });
+	});
+
+	it('resolve() modify', async () => {
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'modify', args: { amount: 50 } }), 10);
+		expect(await gate.request('tool', { amount: 500 }, 'reason')).toEqual({ action: 'modify', args: { amount: 50 } });
+	});
+
+	it('times out and auto-rejects', async () => {
+		const gate = createApprovalGate({ onRequest: vi.fn(), timeout: 50 });
+		const decision = await gate.request('tool', {}, 'reason');
+		expect(decision.action).toBe('reject');
+		expect((decision as any).reason).toContain('timed out');
+	});
+
+	it('calls onDecision on approve', async () => {
+		const onRequest = vi.fn();
+		const onDecision = vi.fn();
+		const gate = createApprovalGate({ onRequest, onDecision });
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'approve' }), 10);
+		await gate.request('tool', {}, 'reason');
+		expect(onDecision).toHaveBeenCalledWith(
+			expect.objectContaining({ tool: 'tool' }),
+			{ action: 'approve' },
+		);
+	});
+
+	it('calls onDecision on timeout', async () => {
+		const onDecision = vi.fn();
+		const gate = createApprovalGate({ onRequest: vi.fn(), onDecision, timeout: 30 });
+		await gate.request('tool', {}, 'reason');
+		expect(onDecision).toHaveBeenCalledWith(
+			expect.objectContaining({ tool: 'tool' }),
+			expect.objectContaining({ action: 'reject' }),
+		);
+	});
+
+	it('resolve unknown id warns', () => {
+		const gate = createApprovalGate({ onRequest: vi.fn() });
+		const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+		gate.resolve('nonexistent', { action: 'approve' });
+		expect(spy).toHaveBeenCalledWith(expect.stringContaining('No pending approval'));
+		spy.mockRestore();
+	});
+
+	it('tracks pending count', async () => {
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+		const p1 = gate.request('t1', {}, 'r1');
+		const p2 = gate.request('t2', {}, 'r2');
+		const p3 = gate.request('t3', {}, 'r3');
+		expect(gate.pending).toBe(3);
+		gate.resolve(onRequest.mock.calls[0][0].id, { action: 'approve' });
+		await p1;
+		expect(gate.pending).toBe(2);
+		gate.resolve(onRequest.mock.calls[1][0].id, { action: 'approve' });
+		gate.resolve(onRequest.mock.calls[2][0].id, { action: 'approve' });
+		await Promise.all([p2, p3]);
+		expect(gate.pending).toBe(0);
+	});
+});
+
+describe('withApproval()', () => {
+	it('preserves tool metadata', () => {
+		const tool = createMockTool();
+		const wrapped = withApproval(tool, { gate: createApprovalGate({ onRequest: vi.fn() }) });
+		expect(wrapped.name).toBe(tool.name);
+		expect(wrapped.description).toBe(tool.description);
+		expect(wrapped.parameters).toBe(tool.parameters);
+	});
+
+	it('executes immediately when when() returns false', async () => {
+		const tool = createMockTool();
+		const onRequest = vi.fn();
+		const wrapped = withApproval(tool, {
+			gate: createApprovalGate({ onRequest }),
+			when: ({ amount }) => amount > 100,
+		});
+
+		const result = await wrapped.execute({ orderId: 'O-1', amount: 50 });
+		expect(JSON.parse(result).success).toBe(true);
+		expect(onRequest).not.toHaveBeenCalled();
+	});
+
+	it('gates when when() returns true', async () => {
+		const tool = createMockTool();
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+		const wrapped = withApproval(tool, {
+			gate,
+			when: ({ amount }) => amount > 100,
+			reason: ({ amount }) => `Refund $${amount}`,
+		});
+
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'approve' }), 10);
+		const result = await wrapped.execute({ orderId: 'O-1', amount: 500 });
+		expect(JSON.parse(result).success).toBe(true);
+		expect(onRequest.mock.calls[0][0].reason).toBe('Refund $500');
+	});
+
+	it('returns rejection message', async () => {
+		const tool = createMockTool();
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+		const wrapped = withApproval(tool, { gate });
+
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'reject', reason: 'Not allowed' }), 10);
+		const result = await wrapped.execute({ orderId: 'O-1', amount: 500 });
+		expect(result).toContain('REJECTED');
+		expect(result).toContain('Not allowed');
+		expect(tool.execute).not.toHaveBeenCalled();
+	});
+
+	it('executes with modified args', async () => {
+		const tool = createMockTool();
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+		const wrapped = withApproval(tool, { gate });
+
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'modify', args: { orderId: 'O-1', amount: 100 } }), 10);
+		const result = await wrapped.execute({ orderId: 'O-1', amount: 500 });
+		expect(tool.execute).toHaveBeenCalledWith({ orderId: 'O-1', amount: 100 }, undefined);
+		expect(JSON.parse(result).amount).toBe(100);
+	});
+
+	it('gates all when no when() provided', async () => {
+		const onRequest = vi.fn();
+		const gate = createApprovalGate({ onRequest });
+		const wrapped = withApproval(createMockTool(), { gate });
+
+		setTimeout(() => gate.resolve(onRequest.mock.calls[0][0].id, { action: 'approve' }), 10);
+		await wrapped.execute({ orderId: 'O-1', amount: 1 });
+		expect(onRequest).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/runtime/test/orchestrate.test.ts
+++ b/packages/runtime/test/orchestrate.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parallel, pipeline, phase, log, registerWorkflow } from '../src/orchestrate.ts';
+import type { FlueSession, PromptResponse } from '../src/types.ts';
+
+function createMockSession(responses: Record<string, string> = {}): FlueSession {
+	const taskFn = vi.fn(async (prompt: string): Promise<PromptResponse> => {
+		const key = Object.keys(responses).find((k) => prompt.includes(k));
+		const text = key ? responses[key] : `response-for-${prompt.slice(0, 20)}`;
+		await new Promise((r) => setTimeout(r, 10));
+		return { text } as PromptResponse;
+	});
+	return { task: taskFn } as unknown as FlueSession;
+}
+
+function createFailingSession(failOn: string[]): FlueSession {
+	const taskFn = vi.fn(async (prompt: string): Promise<PromptResponse> => {
+		await new Promise((r) => setTimeout(r, 5));
+		if (failOn.some((f) => prompt.includes(f))) {
+			throw new Error(`Task failed: ${prompt}`);
+		}
+		return { text: `ok-for-${prompt.slice(0, 10)}` } as PromptResponse;
+	});
+	return { task: taskFn } as unknown as FlueSession;
+}
+
+describe('parallel()', () => {
+	it('runs multiple tasks and returns all results', async () => {
+		const session = createMockSession({
+			'Analyze auth flow': 'auth-analysis',
+			'Analyze rate limiting': 'rate-analysis',
+			'Analyze cache strategy': 'cache-analysis',
+		});
+
+		const results = await parallel(session, [
+			{ prompt: 'Analyze auth flow' },
+			{ prompt: 'Analyze rate limiting' },
+			{ prompt: 'Analyze cache strategy' },
+		]);
+
+		expect(results).toHaveLength(3);
+		expect(results[0]?.text).toBe('auth-analysis');
+		expect(results[1]?.text).toBe('rate-analysis');
+		expect(results[2]?.text).toBe('cache-analysis');
+	});
+
+	it('returns empty array for empty input', async () => {
+		const results = await parallel({} as FlueSession, []);
+		expect(results).toEqual([]);
+	});
+
+	it('respects concurrency limit', async () => {
+		let concurrent = 0;
+		let maxConcurrent = 0;
+
+		const session = {
+			task: vi.fn(async (): Promise<PromptResponse> => {
+				concurrent++;
+				maxConcurrent = Math.max(maxConcurrent, concurrent);
+				await new Promise((r) => setTimeout(r, 50));
+				concurrent--;
+				return { text: 'done' } as PromptResponse;
+			}),
+		} as unknown as FlueSession;
+
+		await parallel(
+			session,
+			Array.from({ length: 10 }, (_, i) => ({ prompt: `task-${i}` })),
+			{ concurrency: 3 },
+		);
+
+		expect(maxConcurrent).toBeLessThanOrEqual(3);
+	});
+
+	it('lenient mode: failed tasks return null, others complete', async () => {
+		const session = createFailingSession(['dangerous']);
+		const results = await parallel(session, [
+			{ prompt: 'safe task 1' },
+			{ prompt: 'dangerous task' },
+			{ prompt: 'safe task 2' },
+		]);
+
+		expect(results).toHaveLength(3);
+		expect(results[0]?.text).toContain('ok-for');
+		expect(results[1]).toBeNull();
+		expect(results[2]?.text).toContain('ok-for');
+	});
+
+	it('strict mode: first failure aborts remaining tasks', async () => {
+		const session = createFailingSession(['fail']);
+		await expect(
+			parallel(session, [
+				{ prompt: 'ok task' },
+				{ prompt: 'fail task' },
+				{ prompt: 'should not run' },
+			], { failMode: 'strict' }),
+		).rejects.toThrow('Task failed');
+	});
+
+	it('passes agent and cwd options to session.task()', async () => {
+		const session = createMockSession();
+		await parallel(session, [
+			{ prompt: 'do work', agent: 'researcher', cwd: '/workspace' },
+		]);
+
+		expect(session.task).toHaveBeenCalledWith('do work', expect.objectContaining({
+			agent: 'researcher',
+			cwd: '/workspace',
+		}));
+	});
+});
+
+describe('pipeline()', () => {
+	it('processes items through sequential stages', async () => {
+		const session = createMockSession({
+			Analyze: 'analyzed-result',
+			Verify: 'verified-result',
+			Format: 'formatted-result',
+		});
+
+		const items: PromptResponse[] = [{ text: 'raw-data-1' } as PromptResponse];
+
+		const results = await pipeline(session, items, [
+			(input) => ({ prompt: `Analyze: ${input.text}` }),
+			(input) => ({ prompt: `Verify: ${input.text}` }),
+			(input) => ({ prompt: `Format: ${input.text}` }),
+		]);
+
+		expect(results).toHaveLength(1);
+		expect(results[0]?.text).toBe('formatted-result');
+		expect(session.task).toHaveBeenCalledTimes(3);
+	});
+
+	it('processes multiple items concurrently', async () => {
+		const session = createMockSession();
+		const items: PromptResponse[] = [
+			{ text: 'item-1' } as PromptResponse,
+			{ text: 'item-2' } as PromptResponse,
+			{ text: 'item-3' } as PromptResponse,
+		];
+
+		const results = await pipeline(session, items, [
+			(input) => ({ prompt: `Process: ${input.text}` }),
+		]);
+
+		expect(results).toHaveLength(3);
+		expect(results.every((r) => r !== null)).toBe(true);
+	});
+
+	it('returns empty for empty items or stages', async () => {
+		expect(await pipeline({} as FlueSession, [], [])).toEqual([]);
+		expect(await pipeline({} as FlueSession, [{ text: 'x' } as PromptResponse], [])).toEqual([]);
+	});
+
+	it('failed items return null without crashing others', async () => {
+		const session = createFailingSession(['bad']);
+		const items: PromptResponse[] = [
+			{ text: 'good' } as PromptResponse,
+			{ text: 'bad' } as PromptResponse,
+			{ text: 'good' } as PromptResponse,
+		];
+
+		const results = await pipeline(session, items, [
+			(input) => ({ prompt: `Process: ${input.text}` }),
+		]);
+
+		expect(results).toHaveLength(3);
+		expect(results[0]).not.toBeNull();
+		expect(results[1]).toBeNull();
+		expect(results[2]).not.toBeNull();
+	});
+
+	it('supports named workflows as string stages', async () => {
+		const session = createMockSession({ 'Run full analysis on': 'analyzed' });
+
+		registerWorkflow('full-analysis', async (input) => {
+			return session.task(`Run full analysis on: ${input.text}`);
+		});
+
+		const items: PromptResponse[] = [{ text: 'ticket-42' } as PromptResponse];
+		const results = await pipeline(session, items, [
+			'full-analysis',
+			(input) => ({ prompt: `Summarize: ${input.text}` }),
+		]);
+
+		expect(results).toHaveLength(1);
+		expect(results[0]?.text).toBeDefined();
+	});
+
+	it('throws for unknown workflow name', async () => {
+		const items: PromptResponse[] = [{ text: 'x' } as PromptResponse];
+		await expect(
+			pipeline(createMockSession(), items, ['nonexistent-workflow']),
+		).rejects.toThrow('Unknown workflow');
+	});
+});
+
+describe('phase() and log()', () => {
+	it('phase() outputs to console', () => {
+		const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		phase('Research');
+		expect(spy).toHaveBeenCalledWith(expect.stringContaining('Research'));
+		spy.mockRestore();
+	});
+
+	it('log() outputs to console', () => {
+		const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		log('Found 5 items');
+		expect(spy).toHaveBeenCalledWith(expect.stringContaining('Found 5 items'));
+		spy.mockRestore();
+	});
+});


### PR DESCRIPTION
## Summary

Adds two complementary features to `@flue/runtime`:

### 1. Orchestration Primitives (`orchestrate.ts`)

- **`parallel()`** — Concurrent task execution with barrier semantics, concurrency limiting, and lenient/strict fail modes
- **`pipeline()`** — Multi-stage processing without barrier; each item flows independently through all stages
- **`registerWorkflow()`** — Named, reusable workflows that can be referenced by string name in pipelines
- **`phase()` / `log()`** — Observability markers for tracing and logging

Inspired by Claude Code Dynamic Workflows' design philosophy: deterministic orchestration in TypeScript, autonomous reasoning in the model.

### 2. Tool Approval Middleware (`approval.ts`)

- **`createApprovalGate()`** — Transport-agnostic gate that pauses tool execution and waits for external approval (WebSocket push, Slack, webhook, etc.)
- **`withApproval()`** — Non-invasive wrapper: takes a `ToolDefinition` and returns one — drop-in replacement
- Supports approve / reject / modify decisions, configurable timeout with auto-reject, and audit logging via `onDecision`

### Files Changed

| File | Description |
|------|-------------|
| `packages/runtime/src/orchestrate.ts` | Parallel, pipeline, phase, log, workflow registry |
| `packages/runtime/src/approval.ts` | Approval gate and tool wrapper |
| `packages/runtime/test/orchestrate.test.ts` | 18 tests |
| `packages/runtime/test/approval.test.ts` | 16 tests |
| `packages/runtime/src/index.ts` | Export new modules |

### Related

- RFC Discussion: #200
- Real-world use case: customer support agent with parallel intent classification, pipeline ticket processing, and human approval for refunds
- All 34 tests pass (`npx vitest run`)

### Design Decisions

- `parallel()` defaults to `failMode: 'lenient'` (failed tasks return null) — matches user expectation for batch operations
- `pipeline()` eagerly validates named workflow references before execution — bad names throw immediately
- `withApproval()` preserves tool metadata (name, description, parameters) — wrapped tools are indistinguishable
- No dependency changes — valibot is already a runtime dependency
- Internal imports use relative paths matching the existing codebase convention