### PR TITLE
fix: avoid reopening docs search dialog

### DIFF
--- a/apps/docs/src/components/docs/DocsSearch.astro
+++ b/apps/docs/src/components/docs/DocsSearch.astro
@@ -59,7 +59,7 @@ import SearchIcon from './SearchIcon.astro';
 		};
 		const closeSearch = () => dialog.close();
 		const openSearch = () => {
-			dialog.showModal();
+			if (!dialog.open) dialog.showModal();
 			input.focus();
 			void loadPagefind().catch(() => undefined);
 		};


### PR DESCRIPTION
## Summary

- guard the docs search dialog before calling `showModal()`
- keep the existing behavior of focusing the search input and warming Pagefind

## Why

`HTMLDialogElement.showModal()` throws if the dialog is already open. The global `Cmd/Ctrl+K` handler can call `openSearch()` again while the search modal is open, so pressing the shortcut twice can raise an `InvalidStateError` instead of simply refocusing the input.

## Testing

- `pnpm --dir apps/docs run check:types`
- `pnpm --dir apps/docs run build` via Git Bash