### PR TITLE
fix: parse split CRLF SSE frames

### DIFF
--- a/packages/sdk/src/public/stream.ts
+++ b/packages/sdk/src/public/stream.ts
@@ -78,17 +78,17 @@ export async function* readSse(body: ReadableStream<Uint8Array>): AsyncIterable<
 		while (true) {
 			const { done, value } = await reader.read();
 			if (done) break;
-			buffer += decoder.decode(value, { stream: true }).replace(/\r\n/g, '\n');
-			let idx = buffer.indexOf('\n\n');
-			while (idx !== -1) {
-				const raw = buffer.slice(0, idx);
-				buffer = buffer.slice(idx + 2);
+			buffer += decoder.decode(value, { stream: true });
+			let boundary = findFrameBoundary(buffer);
+			while (boundary) {
+				const raw = buffer.slice(0, boundary.index);
+				buffer = buffer.slice(boundary.index + boundary.length);
 				const frame = parseFrame(raw);
 				if (frame) yield frame;
-				idx = buffer.indexOf('\n\n');
+				boundary = findFrameBoundary(buffer);
 			}
 		}
-		buffer += decoder.decode().replace(/\r\n/g, '\n');
+		buffer += decoder.decode();
 		const frame = parseFrame(buffer);
 		if (frame) yield frame;
 	} finally {
@@ -99,11 +99,21 @@ export async function* readSse(body: ReadableStream<Uint8Array>): AsyncIterable<
 	}
 }
 
+function findFrameBoundary(buffer: string): { index: number; length: number } | undefined {
+	const candidates = [
+		{ index: buffer.indexOf('\r\n\r\n'), length: 4 },
+		{ index: buffer.indexOf('\n\n'), length: 2 },
+		{ index: buffer.indexOf('\r\r'), length: 2 },
+	].filter((candidate) => candidate.index !== -1);
+
+	return candidates.sort((a, b) => a.index - b.index)[0];
+}
+
 function parseFrame(raw: string): SseFrame | undefined {
 	if (!raw.trim() || raw.startsWith(':')) return undefined;
 	const frame: SseFrame = { data: '' };
 	const data: string[] = [];
-	for (const line of raw.split('\n')) {
+	for (const line of raw.split(/\r\n|\n|\r/)) {
 		if (line.startsWith(':')) continue;
 		const colon = line.indexOf(':');
 		const field = colon === -1 ? line : line.slice(0, colon);

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -466,12 +466,39 @@ describe('readSse', () => {
 		for await (const frame of readSse(stream)) frames.push(frame);
 		expect(frames).toEqual([{ event: 'run_end', id: '2', data: '{"type":"run_end"}' }]);
 	});
+
+	it('parses CRLF-delimited SSE frames split across chunks', async () => {
+		const stream = sseChunks([
+			'event: run_end\r',
+			'\nid: 2\r',
+			'\ndata: {"type":"run_end"}\r',
+			'\n\r',
+			'\n',
+		]);
+
+		const frames = [];
+		for await (const frame of readSse(stream)) frames.push(frame);
+		expect(frames).toEqual([{ event: 'run_end', id: '2', data: '{"type":"run_end"}' }]);
+	});
+
+	it('parses CR-delimited SSE frames', async () => {
+		const stream = sse('event: run_end\rid: 2\rdata: {"type":"run_end"}\r\r');
+
+		const frames = [];
+		for await (const frame of readSse(stream)) frames.push(frame);
+		expect(frames).toEqual([{ event: 'run_end', id: '2', data: '{"type":"run_end"}' }]);
+	});
 });
 
 function sse(text: string): ReadableStream<Uint8Array> {
+	return sseChunks([text]);
+}
+
+function sseChunks(chunks: string[]): ReadableStream<Uint8Array> {
 	return new ReadableStream<Uint8Array>({
 		start(controller) {
-			controller.enqueue(new TextEncoder().encode(text));
+			const encoder = new TextEncoder();
+			for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
 			controller.close();
 		},
 	});


### PR DESCRIPTION
## Summary

- parse SSE frame boundaries without normalizing each chunk independently
- support CRLF delimiters that are split across stream chunks
- support CR-only SSE line delimiters
- add regression coverage for both cases

## Why

`readSse()` previously replaced `\r\n` inside each decoded chunk and then looked for `\n\n`. If a CRLF sequence arrived split across chunks, the parser could miss the frame boundary. The SSE grammar also permits CR-only line endings, which the current `\n`-only parser did not handle.

## Testing

- `pnpm --dir packages/sdk test`
- `pnpm --dir packages/sdk run check:types`
- `pnpm exec biome check packages/sdk/src/public/stream.ts packages/sdk/test/client.test.ts`