### PR TITLE
fix(runtime): redact image bytes from events

### DIFF
--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -108,6 +108,7 @@ export type { MessageSource } from './session-history.ts';
 const MAX_TASK_DEPTH = 4;
 const MAX_TRANSIENT_MODEL_RETRIES = 3;
 const TRANSIENT_MODEL_RETRY_BASE_DELAY_MS = 2_000;
+const EVENT_IMAGE_DATA_OMITTED = '[image bytes omitted from event]';
 
 type TurnInputMessage = Extract<FlueEvent, { type: 'turn_request' }>['input']['messages'][number];
 type TurnInputTool = NonNullable<
@@ -166,7 +167,7 @@ function toTurnContent(block: ProviderContentBlock): TurnContent {
 		return { type: 'text', text: block.text, textSignature: block.textSignature };
 	}
 	if (block.type === 'image') {
-		return { type: 'image', data: block.data, mimeType: block.mimeType };
+		return { type: 'image', data: EVENT_IMAGE_DATA_OMITTED, mimeType: block.mimeType };
 	}
 	if (block.type === 'thinking') {
 		return {
@@ -182,6 +183,37 @@ function toTurnContent(block: ProviderContentBlock): TurnContent {
 		name: block.name,
 		arguments: block.arguments,
 		thoughtSignature: block.thoughtSignature,
+	};
+}
+
+function toEventMessage(message: AgentMessage): AgentMessage {
+	if (message.role === 'user') {
+		if (typeof message.content === 'string') return message;
+		return {
+			...message,
+			content: message.content.map(toTurnContent) as UserMessage['content'],
+		};
+	}
+	if (message.role === 'assistant') {
+		return {
+			...message,
+			content: message.content.map(toTurnContent) as AssistantMessage['content'],
+		};
+	}
+	if (message.role === 'toolResult') {
+		return {
+			...message,
+			content: message.content.map(toTurnContent) as ToolResultMessage['content'],
+		};
+	}
+	return message;
+}
+
+function toEventToolResult<T>(result: AgentToolResult<T>): AgentToolResult<T> {
+	if (!Array.isArray(result?.content)) return result;
+	return {
+		...result,
+		content: result.content.map(toTurnContent) as AgentToolResult<T>['content'],
 	};
 }
 
@@ -513,13 +545,13 @@ export class Session implements FlueSession {
 					this.emit({ type: 'turn_start', turnId: this.activeTurnId, purpose: 'agent' });
 					break;
 				case 'message_start':
-					this.emit({ type: 'message_start', message: event.message });
+					this.emit({ type: 'message_start', message: toEventMessage(event.message) });
 					break;
 				case 'message_update': {
 					this.activeStreamChunkWriter?.write(event.assistantMessageEvent);
 					this.emit({
 						type: 'message_update',
-						message: event.message,
+						message: toEventMessage(event.message),
 						assistantMessageEvent: event.assistantMessageEvent,
 					});
 					const aEvent = event.assistantMessageEvent;
@@ -548,7 +580,7 @@ export class Session implements FlueSession {
 						}
 					}
 					if (event.message.role === 'user') await this.checkpointHarnessMessages();
-					this.emit({ type: 'message_end', message: event.message });
+					this.emit({ type: 'message_end', message: toEventMessage(event.message) });
 					break;
 				case 'tool_execution_start':
 					this.toolStartTimes.set(event.toolCallId, Date.now());
@@ -567,7 +599,7 @@ export class Session implements FlueSession {
 						toolName: event.toolName,
 						toolCallId: event.toolCallId,
 						isError: event.isError,
-						result: event.result,
+						result: toEventToolResult(event.result),
 						durationMs: durationSince(this.toolStartTimes.get(event.toolCallId)),
 					});
 					this.toolStartTimes.delete(event.toolCallId);
@@ -581,8 +613,8 @@ export class Session implements FlueSession {
 						type: 'turn_end',
 						turnId,
 						purpose: 'agent',
-						message: event.message,
-						toolResults: event.toolResults,
+						message: toEventMessage(event.message),
+						toolResults: event.toolResults.map(toEventMessage),
 					});
 					const message = event.message;
 					const assistant =
@@ -612,7 +644,7 @@ export class Session implements FlueSession {
 				case 'agent_end':
 					await this.activeStreamChunkWriter?.flush();
 					await this.checkpointHarnessMessages();
-					this.emit({ type: 'agent_end', messages: event.messages });
+					this.emit({ type: 'agent_end', messages: event.messages.map(toEventMessage) });
 					this.turnStartTime = undefined;
 					this.activeTurnId = undefined;
 					await this.activeStreamChunkWriter?.close();

--- a/packages/runtime/test/event-images.test.ts
+++ b/packages/runtime/test/event-images.test.ts
@@ -1,0 +1,224 @@
+import type { AgentTool } from '@earendil-works/pi-agent-core';
+import {
+	type FauxProviderRegistration,
+	fauxAssistantMessage,
+	fauxToolCall,
+	registerFauxProvider,
+} from '@earendil-works/pi-ai';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createAgent, Type } from '../src/index.ts';
+import { createFlueContext, InMemorySessionStore } from '../src/internal.ts';
+import type { FlueEvent, SessionEnv, SessionStore } from '../src/types.ts';
+import { createNoopSessionEnv } from './fixtures/session-env.ts';
+
+const REDACTED_IMAGE_DATA = '[image bytes omitted from event]';
+const providers: FauxProviderRegistration[] = [];
+
+afterEach(() => {
+	for (const provider of providers.splice(0)) provider.unregister();
+});
+
+function createProvider(): FauxProviderRegistration {
+	const provider = registerFauxProvider({ provider: `event-images-test-${crypto.randomUUID()}` });
+	providers.push(provider);
+	return provider;
+}
+
+function createContext(
+	provider: FauxProviderRegistration,
+	events: FlueEvent[],
+	options: { env?: SessionEnv; store?: SessionStore } = {},
+) {
+	const ctx = createFlueContext({
+		id: 'event-images-instance',
+		payload: {},
+		env: {},
+		agentConfig: {
+			systemPrompt: '',
+			skills: {},
+			model: undefined,
+			resolveModel: () => provider.getModel(),
+		},
+		createDefaultEnv: async () => options.env ?? createNoopSessionEnv(),
+		defaultStore: options.store ?? new InMemorySessionStore(),
+	});
+	ctx.setEventCallback((event) => {
+		events.push(event);
+	});
+	return ctx;
+}
+
+describe('session image events', () => {
+	it('omits prompt image bytes from observable events when prompt() includes images', async () => {
+		const provider = createProvider();
+		const events: FlueEvent[] = [];
+		const imageData = 'raw-prompt-image-base64';
+		provider.setResponses([
+			(context) => {
+				expect(JSON.stringify(context.messages)).toContain(imageData);
+				return fauxAssistantMessage('Reviewed image.');
+			},
+		]);
+		const harness = await createContext(provider, events).init(
+			createAgent(() => ({ model: `${provider.getModel().provider}/${provider.getModel().id}` })),
+		);
+		const session = await harness.session();
+
+		await session.prompt('Review this image.', {
+			images: [{ type: 'image', data: imageData, mimeType: 'image/png' }],
+		});
+
+		expect(JSON.stringify(events)).not.toContain(imageData);
+		expect(JSON.stringify(events)).toContain(REDACTED_IMAGE_DATA);
+		expect(JSON.stringify(events)).toContain('image/png');
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'turn_request' }> =>
+					event.type === 'turn_request',
+			)?.input.messages[0],
+		).toMatchObject({
+			role: 'user',
+			content: [
+				{ type: 'text', text: 'Review this image.' },
+				{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/png' },
+			],
+		});
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'message_start' }> =>
+					event.type === 'message_start' && event.message.role === 'user',
+			)?.message,
+		).toMatchObject({
+			role: 'user',
+			content: [
+				{ type: 'text', text: 'Review this image.' },
+				{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/png' },
+			],
+		});
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'message_end' }> =>
+					event.type === 'message_end' && event.message.role === 'user',
+			)?.message,
+		).toMatchObject({
+			role: 'user',
+			content: [
+				{ type: 'text', text: 'Review this image.' },
+				{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/png' },
+			],
+		});
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'agent_end' }> =>
+					event.type === 'agent_end',
+			)?.messages[0],
+		).toMatchObject({
+			role: 'user',
+			content: [
+				{ type: 'text', text: 'Review this image.' },
+				{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/png' },
+			],
+		});
+	});
+
+	it('omits connector tool-result image bytes from observable events when a tool returns images', async () => {
+		const provider = createProvider();
+		const events: FlueEvent[] = [];
+		const imageData = 'raw-tool-result-image-base64';
+		const captureTool: AgentTool<any> = {
+			name: 'capture',
+			label: 'Capture Image',
+			description: 'Returns an image.',
+			parameters: Type.Object({}),
+			execute: async () => ({
+				content: [{ type: 'image', data: imageData, mimeType: 'image/jpeg' }],
+				details: { captured: true },
+			}),
+		};
+		provider.setResponses([
+			fauxAssistantMessage(fauxToolCall('capture', {}, { id: 'capture-call' }), {
+				stopReason: 'toolUse',
+			}),
+			(context) => {
+				expect(JSON.stringify(context.messages)).toContain(imageData);
+				return fauxAssistantMessage('Captured image.');
+			},
+		]);
+		const harness = await createContext(provider, events).init(
+			createAgent(() => ({
+				model: `${provider.getModel().provider}/${provider.getModel().id}`,
+				sandbox: {
+					createSessionEnv: async () => createNoopSessionEnv(),
+					tools: () => [captureTool],
+				},
+			})),
+		);
+		const session = await harness.session();
+
+		await session.prompt('Capture an image.');
+
+		expect(JSON.stringify(events)).not.toContain(imageData);
+		expect(JSON.stringify(events)).toContain(REDACTED_IMAGE_DATA);
+		expect(JSON.stringify(events)).toContain('image/jpeg');
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'tool_call' }> =>
+					event.type === 'tool_call' && event.toolName === 'capture',
+			)?.result,
+		).toMatchObject({
+			content: [{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/jpeg' }],
+			details: { captured: true },
+		});
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'message_start' }> =>
+					event.type === 'message_start' && event.message.role === 'toolResult',
+			)?.message,
+		).toMatchObject({
+			role: 'toolResult',
+			toolName: 'capture',
+			content: [{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/jpeg' }],
+		});
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'message_end' }> =>
+					event.type === 'message_end' && event.message.role === 'toolResult',
+			)?.message,
+		).toMatchObject({
+			role: 'toolResult',
+			toolName: 'capture',
+			content: [{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/jpeg' }],
+		});
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'turn_end' }> =>
+					event.type === 'turn_end' && event.toolResults.length > 0,
+			)?.toolResults[0],
+		).toMatchObject({
+			role: 'toolResult',
+			toolName: 'capture',
+			content: [{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/jpeg' }],
+		});
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'turn_request' }> =>
+					event.type === 'turn_request' &&
+					event.input.messages.some((message) => message.role === 'toolResult'),
+			)?.input.messages.find((message) => message.role === 'toolResult'),
+		).toMatchObject({
+			role: 'toolResult',
+			toolName: 'capture',
+			content: [{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/jpeg' }],
+		});
+		expect(
+			events.find(
+				(event): event is Extract<FlueEvent, { type: 'agent_end' }> =>
+					event.type === 'agent_end',
+			)?.messages.find((message) => message.role === 'toolResult'),
+		).toMatchObject({
+			role: 'toolResult',
+			toolName: 'capture',
+			content: [{ type: 'image', data: REDACTED_IMAGE_DATA, mimeType: 'image/jpeg' }],
+		});
+	});
+});


### PR DESCRIPTION
Replace image content data with an event-only sentinel while preserving image presence and MIME type. Apply across message, turn, agent, and tool-call events so observable and persisted run events don't retain raw multimodal image payloads.

Add regression coverage for prompt images and connector tool-result images.

Addresses https://github.com/withastro/flue/discussions/219