### PR TITLE
fix(runtime): move large session blobs out of entry rows

### DIFF
--- a/packages/cli/src/lib/build-plugin-cloudflare.ts
+++ b/packages/cli/src/lib/build-plugin-cloudflare.ts
@@ -154,6 +154,7 @@ import {
   CLOUDFLARE_AGENT_INTERNAL_DISPATCH_PATH,
   CLOUDFLARE_WORKFLOW_INTERNAL_METADATA_PATH,
   createCloudflareAgentRuntime,
+  createR2SessionAttachmentStore,
   createSqlSessionStore,
    SqliteEventStreamStore,
   bashFactoryToSessionEnv,
@@ -204,6 +205,7 @@ if (!hasRegisteredProvider('cloudflare')) {
 const skills = {};
 const packagedSkills = ${packagedSkillsValue};
 const systemPrompt = '';
+const sessionAttachmentStore = createR2SessionAttachmentStore(env.FLUE_SESSION_ATTACHMENTS);
 
 ${builtModuleNormalizationSource}
 const agentModules = {
@@ -346,7 +348,7 @@ function createAgentContextForRequest(executionStore, id, payload, doInstance, r
 
 function createWorkflowContextForRequest(id, runId, payload, doInstance, req, initialEventIndex, dispatchId) {
   const storage = doInstance?.ctx?.storage;
-  const defaultStore = storage?.sql ? createSqlSessionStore(storage) : memoryWorkflowSessionStore;
+  const defaultStore = storage?.sql ? createSqlSessionStore(storage, { attachmentStore: sessionAttachmentStore }) : memoryWorkflowSessionStore;
   return createContextForRequest(id, runId, payload, doInstance, req, defaultStore, initialEventIndex, dispatchId);
 }
 
@@ -401,6 +403,7 @@ function createEventStreamStoreForInstance(doInstance) {
 
 const cloudflareAgents = createCloudflareAgentRuntime({
   createdAgents,
+  sessionStoreOptions: { attachmentStore: sessionAttachmentStore },
   createContext: ({ executionStore, instance, payload, request, initialEventIndex, dispatchId }) =>
     createAgentContextForRequest(executionStore, instance.name, payload, instance, request, initialEventIndex, dispatchId),
   runWithInstanceContext: (instance, agentName, fn) => runWithInstanceContext(instance, agentRuntimeIdentity(agentName), fn),

--- a/packages/runtime/src/adapter.ts
+++ b/packages/runtime/src/adapter.ts
@@ -75,4 +75,5 @@ export { formatOffset, parseOffset } from './runtime/event-stream-store.ts';
 
 // ─── Re-export session types needed for SessionStore implementations ────────
 
+export type { SessionAttachmentStore } from './sql-agent-execution-store.ts';
 export type { SessionData, SessionStore } from './types.ts';

--- a/packages/runtime/src/cloudflare/agent-coordinator.ts
+++ b/packages/runtime/src/cloudflare/agent-coordinator.ts
@@ -22,6 +22,7 @@ const FLUE_AGENT_SUBMISSION_ATTEMPT_STALE_MS = 15 * 60 * 1000;
 const FLUE_AGENT_SUBMISSION_ATTEMPT_FIBER = 'flue:submission-attempt';
 
 import type { SqlStorage } from '../sql-storage.ts';
+import type { SqlSessionStoreOptions } from '../sql-agent-execution-store.ts';
 
 interface CloudflareAgentStorage {
 	sql?: SqlStorage;
@@ -74,6 +75,7 @@ interface CloudflareAgentRuntimeOptions {
 		callback: () => T,
 	) => T;
 	readonly createEventStreamStore: (instance: CloudflareAgentInstance) => import('../runtime/event-stream-store.ts').EventStreamStore;
+	readonly sessionStoreOptions?: SqlSessionStoreOptions;
 }
 
 export interface CloudflareAgentRuntime {
@@ -113,7 +115,7 @@ export function createCloudflareAgentRuntime(options: CloudflareAgentRuntimeOpti
 		prepare({ storage, className, agentName }) {
 			return {
 				agentName,
-				executionStore: createSqlAgentExecutionStore(storage, className),
+				executionStore: createSqlAgentExecutionStore(storage, className, options.sessionStoreOptions),
 			};
 		},
 		attach(instance, prepared) {

--- a/packages/runtime/src/cloudflare/agent-execution-store.ts
+++ b/packages/runtime/src/cloudflare/agent-execution-store.ts
@@ -30,8 +30,8 @@ export function createSqlSessionStore(
 	if (!sql || typeof transactionSync !== 'function') {
 		throw new Error('[flue] Cloudflare workflow session persistence requires Durable Object SQLite.');
 	}
-	ensureSessionTable(sql);
 	const runTransaction = <T>(closure: () => T): T => transactionSync.call(storage, closure) as T;
+	ensureSessionTable(sql, runTransaction);
 	return new SqlSessionStore(sql, runTransaction, options);
 }
 
@@ -73,8 +73,8 @@ export function createSqlAgentExecutionStore(
 		);
 	}
 	try {
-		ensureSqlAgentExecutionTables(sql);
 		const runTransaction = <T>(closure: () => T): T => transactionSync.call(storage, closure) as T;
+		ensureSqlAgentExecutionTables(sql, runTransaction);
 		return createSqlAgentExecutionStoreFromSql(sql, runTransaction, options);
 	} catch (cause) {
 		const detail = cause instanceof Error ? cause.message : String(cause);

--- a/packages/runtime/src/cloudflare/agent-execution-store.ts
+++ b/packages/runtime/src/cloudflare/agent-execution-store.ts
@@ -4,6 +4,8 @@ import {
 	createSqlAgentExecutionStoreFromSql,
 	ensureSqlAgentExecutionTables,
 	ensureSessionTable,
+	type SessionAttachmentStore,
+	type SqlSessionStoreOptions,
 	SqlSessionStore,
 } from '../sql-agent-execution-store.ts';
 import type { SessionStore } from '../types.ts';
@@ -13,7 +15,16 @@ interface DurableObjectStorage {
 	transactionSync?<T>(closure: () => T): T;
 }
 
-export function createSqlSessionStore(storage: DurableObjectStorage): SessionStore {
+interface R2BucketLike {
+	put(key: string, value: string, options?: unknown): Promise<unknown>;
+	get(key: string): Promise<{ text(): Promise<string> } | null>;
+	delete(key: string): Promise<unknown>;
+}
+
+export function createSqlSessionStore(
+	storage: DurableObjectStorage,
+	options: SqlSessionStoreOptions = {},
+): SessionStore {
 	const sql = storage.sql;
 	const transactionSync = storage.transactionSync;
 	if (!sql || typeof transactionSync !== 'function') {
@@ -21,12 +32,35 @@ export function createSqlSessionStore(storage: DurableObjectStorage): SessionSto
 	}
 	ensureSessionTable(sql);
 	const runTransaction = <T>(closure: () => T): T => transactionSync.call(storage, closure) as T;
-	return new SqlSessionStore(sql, runTransaction);
+	return new SqlSessionStore(sql, runTransaction, options);
+}
+
+export function createR2SessionAttachmentStore(
+	bucket: R2BucketLike | null | undefined,
+): SessionAttachmentStore | undefined {
+	if (!bucket) return undefined;
+	return {
+		async put(key: string, data: string): Promise<void> {
+			await bucket.put(key, data, {
+				httpMetadata: { contentType: 'text/plain; charset=utf-8' },
+				customMetadata: { flue: 'session-attachment' },
+			});
+		},
+		async get(key: string): Promise<string> {
+			const object = await bucket.get(key);
+			if (!object) throw new Error('[flue] Persisted session attachment object is missing.');
+			return object.text();
+		},
+		async delete(key: string): Promise<void> {
+			await bucket.delete(key);
+		},
+	};
 }
 
 export function createSqlAgentExecutionStore(
 	storage: DurableObjectStorage | undefined,
 	className: string,
+	options: SqlSessionStoreOptions = {},
 ): AgentExecutionStore {
 	const sql = storage?.sql;
 	const transactionSync = storage?.transactionSync;
@@ -41,7 +75,7 @@ export function createSqlAgentExecutionStore(
 	try {
 		ensureSqlAgentExecutionTables(sql);
 		const runTransaction = <T>(closure: () => T): T => transactionSync.call(storage, closure) as T;
-		return createSqlAgentExecutionStoreFromSql(sql, runTransaction);
+		return createSqlAgentExecutionStoreFromSql(sql, runTransaction, options);
 	} catch (cause) {
 		const detail = cause instanceof Error ? cause.message : String(cause);
 		throw new Error(

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -26,7 +26,10 @@ export {
 	createCloudflareAgentRuntime,
 } from './cloudflare/agent-coordinator.ts';
 export { CLOUDFLARE_WORKFLOW_INTERNAL_METADATA_PATH } from './runtime/flue-app.ts';
-export { createSqlSessionStore } from './cloudflare/agent-execution-store.ts';
+export {
+	createR2SessionAttachmentStore,
+	createSqlSessionStore,
+} from './cloudflare/agent-execution-store.ts';
 export { createDurableRunStore } from './cloudflare/run-store.ts';
 export { createNodeAgentCoordinator, createNodeDispatchQueue } from './node/agent-coordinator.ts';
 export { InMemoryRunStore } from './node/run-store.ts';
@@ -95,7 +98,10 @@ export { SqliteEventStreamStore } from './runtime/event-stream-store.ts';
 export type { RunRecord, RunStatus, RunStore } from './runtime/run-store.ts';
 
 export { bashFactoryToSessionEnv } from './sandbox.ts';
-export type { DirectAgentSubmissionInput, DispatchAgentSubmissionInput } from './runtime/agent-submissions.ts';
+export type {
+	DirectAgentSubmissionInput,
+	DispatchAgentSubmissionInput,
+} from './runtime/agent-submissions.ts';
 export { InMemorySessionStore } from './session.ts';
 export { parseSkillMarkdown } from './skill-frontmatter.ts';
 

--- a/packages/runtime/src/node/agent-execution-store.ts
+++ b/packages/runtime/src/node/agent-execution-store.ts
@@ -14,7 +14,18 @@ import { InMemoryRunRegistry } from './run-registry.ts';
 import { InMemoryRunStore } from './run-store.ts';
 import type { SqlStorage } from '../sql-storage.ts';
 import { SqliteEventStreamStore } from '../runtime/event-stream-store.ts';
-import { createSqlAgentExecutionStoreFromSql, ensureSqlAgentExecutionTables } from '../sql-agent-execution-store.ts';
+import {
+	createSqlAgentExecutionStoreFromSql,
+	ensureSqlAgentExecutionTables,
+	type SessionAttachmentStore,
+} from '../sql-agent-execution-store.ts';
+
+export type { SessionAttachmentStore };
+
+export interface SqlitePersistenceOptions {
+	attachmentStore?: SessionAttachmentStore;
+	externalBlobThreshold?: number;
+}
 
 /**
  * Adapt `node:sqlite` {@link DatabaseSync} to the Cloudflare {@link SqlStorage}
@@ -96,10 +107,11 @@ function openDatabase(path: string): { db: DatabaseSync; sql: SqlStorage; runTra
  */
 export function createNodeAgentExecutionStore(
 	path: string = ':memory:',
+	options: SqlitePersistenceOptions = {},
 ): AgentExecutionStore {
 	const { sql, runTransaction } = openDatabase(path);
 	ensureSqlAgentExecutionTables(sql);
-	return createSqlAgentExecutionStoreFromSql(sql, runTransaction);
+	return createSqlAgentExecutionStoreFromSql(sql, runTransaction, options);
 }
 
 /**
@@ -116,7 +128,7 @@ export function createNodeAgentExecutionStore(
  * export default sqlite('./data/flue.db');
  * ```
  */
-export function sqlite(path?: string): PersistenceAdapter {
+export function sqlite(path?: string, options: SqlitePersistenceOptions = {}): PersistenceAdapter {
 	if (path !== undefined && path !== ':memory:' && path.trim() === '') {
 		throw new Error('[flue] sqlite() requires a non-empty file path, or omit the argument for an in-memory database.');
 	}
@@ -134,7 +146,7 @@ export function sqlite(path?: string): PersistenceAdapter {
 		},
 		connect() {
 			const { sql, runTransaction } = ensureOpen();
-			return createSqlAgentExecutionStoreFromSql(sql, runTransaction);
+			return createSqlAgentExecutionStoreFromSql(sql, runTransaction, options);
 		},
 		connectRunStore() {
 			return new InMemoryRunStore();

--- a/packages/runtime/src/node/agent-execution-store.ts
+++ b/packages/runtime/src/node/agent-execution-store.ts
@@ -7,7 +7,9 @@
  */
 
 import { mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
+import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { basename, dirname, resolve, sep } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import type { AgentExecutionStore, PersistenceAdapter } from '../agent-execution-store.ts';
 import { InMemoryRunRegistry } from './run-registry.ts';
@@ -25,6 +27,52 @@ export type { SessionAttachmentStore };
 export interface SqlitePersistenceOptions {
 	attachmentStore?: SessionAttachmentStore;
 	externalBlobThreshold?: number;
+}
+
+/**
+ * Create a filesystem-backed session attachment store for Node SQLite persistence.
+ * SQL rows remain the authoritative manifest; files only hold attachment bytes.
+ */
+export function fileSessionAttachmentStore(root: string): SessionAttachmentStore {
+	const rootPath = resolve(root);
+	const rootPrefix = rootPath.endsWith(sep) ? rootPath : `${rootPath}${sep}`;
+
+	function pathFor(key: string): string {
+		const filePath = resolve(rootPath, key);
+		if (!filePath.startsWith(rootPrefix)) {
+			throw new Error('[flue] Invalid session attachment file key.');
+		}
+		return filePath;
+	}
+
+	return {
+		async put(key: string, data: string): Promise<void> {
+			const filePath = pathFor(key);
+			const directory = dirname(filePath);
+			await mkdir(directory, { recursive: true });
+			const tempPath = resolve(directory, `.${basename(filePath)}.${randomUUID()}.tmp`);
+			try {
+				await writeFile(tempPath, data, 'utf8');
+				await rename(tempPath, filePath);
+			} catch (error) {
+				await rm(tempPath, { force: true });
+				throw error;
+			}
+		},
+
+		async get(key: string): Promise<string> {
+			const filePath = pathFor(key);
+			try {
+				return await readFile(filePath, 'utf8');
+			} catch (cause) {
+				throw new Error('[flue] Persisted session attachment file is missing.', { cause });
+			}
+		},
+
+		async delete(key: string): Promise<void> {
+			await rm(pathFor(key), { force: true });
+		},
+	};
 }
 
 /**

--- a/packages/runtime/src/node/agent-execution-store.ts
+++ b/packages/runtime/src/node/agent-execution-store.ts
@@ -158,7 +158,7 @@ export function createNodeAgentExecutionStore(
 	options: SqlitePersistenceOptions = {},
 ): AgentExecutionStore {
 	const { sql, runTransaction } = openDatabase(path);
-	ensureSqlAgentExecutionTables(sql);
+	ensureSqlAgentExecutionTables(sql, runTransaction);
 	return createSqlAgentExecutionStoreFromSql(sql, runTransaction, options);
 }
 
@@ -190,7 +190,8 @@ export function sqlite(path?: string, options: SqlitePersistenceOptions = {}): P
 
 	return {
 		migrate() {
-			ensureSqlAgentExecutionTables(ensureOpen().sql);
+			const { sql, runTransaction } = ensureOpen();
+			ensureSqlAgentExecutionTables(sql, runTransaction);
 		},
 		connect() {
 			const { sql, runTransaction } = ensureOpen();

--- a/packages/runtime/src/node/index.ts
+++ b/packages/runtime/src/node/index.ts
@@ -7,6 +7,7 @@
  * from `@flue/runtime`.
  */
 export {
+	fileSessionAttachmentStore,
 	sqlite,
 	type SessionAttachmentStore,
 	type SqlitePersistenceOptions,

--- a/packages/runtime/src/node/index.ts
+++ b/packages/runtime/src/node/index.ts
@@ -6,5 +6,9 @@
  * Import platform-agnostic types (`FlueContext`, `PersistenceAdapter`, etc.)
  * from `@flue/runtime`.
  */
-export { sqlite } from './agent-execution-store.ts';
+export {
+	sqlite,
+	type SessionAttachmentStore,
+	type SqlitePersistenceOptions,
+} from './agent-execution-store.ts';
 export { type LocalSandboxOptions, local } from './local.ts';

--- a/packages/runtime/src/sql-agent-execution-store.ts
+++ b/packages/runtime/src/sql-agent-execution-store.ts
@@ -48,11 +48,28 @@ import type { SessionData, SessionEntry, SessionStore } from './types.ts';
 const SESSION_BLOB_CHUNK_SIZE = 512 * 1024;
 const SESSION_BLOB_REF_KEY = '__flueSessionBlobRef';
 const SESSION_BLOB_REF_TYPE = 'flue.sessionBlob.v1';
+const DEFAULT_EXTERNAL_BLOB_THRESHOLD = SESSION_BLOB_CHUNK_SIZE;
+
+export interface SessionAttachmentStore {
+	put(key: string, data: string): Promise<void>;
+	get(key: string): Promise<string>;
+	delete(key: string): Promise<void>;
+}
+
+export interface SqlSessionStoreOptions {
+	attachmentStore?: SessionAttachmentStore;
+	externalBlobThreshold?: number;
+}
 
 interface StoredSessionBlob {
 	entryId: string;
 	blobId: string;
 	data: string;
+}
+
+interface PreparedSessionBlob extends StoredSessionBlob {
+	storageKind: 'sql_chunk' | 'external';
+	objectKey?: string;
 }
 
 interface SerializedSessionEntry {
@@ -83,9 +100,10 @@ export function ensureSqlAgentExecutionTables(sql: SqlStorage): void {
 export function createSqlAgentExecutionStoreFromSql(
 	sql: SqlStorage,
 	runTransaction: <T>(closure: () => T) => T,
+	options: SqlSessionStoreOptions = {},
 ): AgentExecutionStore {
 	return {
-		sessions: new SqlSessionStore(sql, runTransaction),
+		sessions: new SqlSessionStore(sql, runTransaction, options),
 		submissions: new AgentSubmissionStoreImpl(sql, runTransaction),
 	};
 }
@@ -94,106 +112,176 @@ export class SqlSessionStore implements SessionStore {
 	constructor(
 		private sql: SqlStorage,
 		private transactionSync: <T>(closure: () => T) => T,
+		private options: SqlSessionStoreOptions = {},
 	) {}
 
 	async save(id: string, data: SessionData): Promise<void> {
-		const entries = data.entries.map((entry, position) => {
-			const serialized = serializeSessionEntry(entry);
-			return {
-				entry,
-				position,
-				data: serialized.entryJson,
-				blobs: serialized.blobs,
-			};
-		});
-		this.transactionSync(() => {
-			this.sql.exec(
-				`INSERT INTO flue_sessions (id, data) VALUES (?, ?)
-				 ON CONFLICT (id) DO UPDATE SET data = excluded.data`,
-				id,
-				JSON.stringify(sessionMetadata(data)),
-			);
-			this.sql.exec('DELETE FROM flue_session_blobs WHERE session_id = ?', id);
-			const existingRows = this.sql.exec(
-				'SELECT entry_id, position, data FROM flue_session_entries WHERE session_id = ?',
-				id,
-			).toArray();
-			const existing = new Map(existingRows.map((row) => [row.entry_id, row]));
-			const retained = new Set<string>();
-			for (const { entry, position, data: entryData, blobs } of entries) {
-				retained.add(entry.id);
-				const current = existing.get(entry.id);
-				if (current?.position !== position || current.data !== entryData) {
-					this.sql.exec(
-						`INSERT INTO flue_session_entries (session_id, entry_id, position, data)
-						 VALUES (?, ?, ?, ?)
-						 ON CONFLICT (session_id, entry_id) DO UPDATE SET
-						 position = excluded.position, data = excluded.data`,
+		const serializedEntries = data.entries.map((entry) => serializeSessionEntry(entry));
+		const entries = data.entries.map((entry, position) => ({
+			entry,
+			position,
+			data: serializedEntries[position]!.entryJson,
+		}));
+		const oldExternalKeys = this.selectExternalObjectKeys(id);
+		const preparedBlobs = await this.prepareSessionBlobs(id, serializedEntries);
+		const uploadedExternalKeys = preparedBlobs
+			.filter((blob) => blob.storageKind === 'external' && blob.objectKey)
+			.map((blob) => blob.objectKey!);
+		const currentExternalKeys = new Set(uploadedExternalKeys);
+		const staleExternalKeys = oldExternalKeys.filter((key) => !currentExternalKeys.has(key));
+		try {
+			this.transactionSync(() => {
+				this.sql.exec('DELETE FROM flue_session_blobs WHERE session_id = ?', id);
+				this.sql.exec(
+					`INSERT INTO flue_sessions (id, data) VALUES (?, ?)
+					 ON CONFLICT (id) DO UPDATE SET data = excluded.data`,
+					id,
+					JSON.stringify(sessionMetadata(data)),
+				);
+				const existingRows = this.sql
+					.exec(
+						'SELECT entry_id, position, data FROM flue_session_entries WHERE session_id = ?',
 						id,
-						entry.id,
-						position,
-						entryData,
-					);
+					)
+					.toArray();
+				const existing = new Map(existingRows.map((row) => [row.entry_id, row]));
+				const retained = new Set<string>();
+
+				for (const { entry, position, data: entryData } of entries) {
+					retained.add(entry.id);
+					const current = existing.get(entry.id);
+					if (current?.position !== position || current.data !== entryData) {
+						this.sql.exec(
+							`INSERT INTO flue_session_entries (session_id, entry_id, position, data)
+							 VALUES (?, ?, ?, ?)
+							 ON CONFLICT (session_id, entry_id) DO UPDATE SET
+							 position = excluded.position, data = excluded.data`,
+							id,
+							entry.id,
+							position,
+							entryData,
+						);
+					}
 				}
-				for (const blob of blobs) {
+				for (const row of existingRows) {
+					if (typeof row.entry_id === 'string' && !retained.has(row.entry_id)) {
+						this.sql.exec(
+							'DELETE FROM flue_session_entries WHERE session_id = ? AND entry_id = ?',
+							id,
+							row.entry_id,
+						);
+					}
+				}
+				for (const blob of preparedBlobs) {
 					this.insertSessionBlob(id, blob);
 				}
-			}
-			for (const row of existingRows) {
-				if (typeof row.entry_id === 'string' && !retained.has(row.entry_id)) {
-					this.sql.exec(
-						'DELETE FROM flue_session_entries WHERE session_id = ? AND entry_id = ?',
-						id,
-						row.entry_id,
-					);
-				}
-			}
-		});
+				this.enqueueExternalObjectDeletions(staleExternalKeys);
+			});
+		} catch (error) {
+			this.enqueueExternalObjectDeletionsBestEffort(uploadedExternalKeys);
+			await this.deleteExternalObjectsBestEffort(uploadedExternalKeys);
+			throw error;
+		}
+
+		await this.deleteExternalObjectsBestEffort(staleExternalKeys);
+		await this.drainExternalObjectDeletions();
 	}
 
 	async load(id: string): Promise<SessionData | null> {
-		return this.transactionSync(() => {
-			const rows = this.sql.exec('SELECT data FROM flue_sessions WHERE id = ?', id).toArray();
-			const row = rows[0];
-			if (!row) return null;
-			if (typeof row.data !== 'string') {
-				throw new Error('[flue] Persisted session row is malformed.');
-			}
-			const session = JSON.parse(row.data) as SessionData | SessionMetadata;
-			const entryRows = this.sql.exec(
+		const rows = this.sql.exec('SELECT data FROM flue_sessions WHERE id = ?', id).toArray();
+		const row = rows[0];
+		if (!row) return null;
+		if (typeof row.data !== 'string') {
+			throw new Error('[flue] Persisted session row is malformed.');
+		}
+		const session = JSON.parse(row.data) as SessionData | SessionMetadata;
+		const entryRows = this.sql
+			.exec(
 				'SELECT entry_id, data FROM flue_session_entries WHERE session_id = ? ORDER BY position ASC',
 				id,
-			).toArray();
-			if (entryRows.length === 0 && Array.isArray((session as SessionData).entries)) {
-				return session as SessionData;
-			}
-			const blobs = sessionBlobMap(
-				this.sql
-					.exec(
-						`SELECT entry_id, blob_id, segment_index, segment_count, data
-						 FROM flue_session_blobs
-						 WHERE session_id = ?
-						 ORDER BY entry_id ASC, blob_id ASC, segment_index ASC`,
-						id,
-					)
-					.toArray(),
-			);
-			return {
-				...session,
-				entries: entryRows.map((entryRow) => parseSessionEntryRow(entryRow, blobs)),
-			} as SessionData;
-		});
+			)
+			.toArray();
+		if (entryRows.length === 0 && Array.isArray((session as SessionData).entries)) {
+			return session as SessionData;
+		}
+
+		const blobs = await sessionBlobMap(
+			this.sql
+				.exec(
+					`SELECT entry_id, blob_id, storage_kind, object_key, segment_index, segment_count, data
+					 FROM flue_session_blobs
+					 WHERE session_id = ?
+					 ORDER BY entry_id ASC, blob_id ASC, segment_index ASC`,
+					id,
+				)
+				.toArray(),
+			this.options.attachmentStore,
+		);
+		return {
+			...session,
+			entries: entryRows.map((entryRow) => parseSessionEntryRow(entryRow, blobs)),
+		} as SessionData;
 	}
 
 	async delete(id: string): Promise<void> {
+		const externalKeys = this.selectExternalObjectKeys(id);
 		this.transactionSync(() => {
+			this.enqueueExternalObjectDeletions(externalKeys);
 			this.sql.exec('DELETE FROM flue_session_blobs WHERE session_id = ?', id);
 			this.sql.exec('DELETE FROM flue_session_entries WHERE session_id = ?', id);
 			this.sql.exec('DELETE FROM flue_sessions WHERE id = ?', id);
 		});
+		await this.deleteExternalObjectsBestEffort(externalKeys);
+		await this.drainExternalObjectDeletions();
 	}
 
-	private insertSessionBlob(sessionId: string, blob: StoredSessionBlob): void {
+	private async prepareSessionBlobs(
+		sessionId: string,
+		entries: SerializedSessionEntry[],
+	): Promise<PreparedSessionBlob[]> {
+		const prepared: PreparedSessionBlob[] = [];
+		try {
+			for (const entry of entries) {
+				for (const blob of entry.blobs) {
+					if (!this.shouldStoreExternally(blob)) {
+						prepared.push({ ...blob, storageKind: 'sql_chunk' });
+						continue;
+					}
+					const objectKey = createSessionAttachmentObjectKey(sessionId, blob.entryId, blob.blobId);
+					await this.options.attachmentStore!.put(objectKey, blob.data);
+					prepared.push({ ...blob, storageKind: 'external', objectKey });
+				}
+			}
+		} catch (error) {
+			await this.deleteExternalObjectsBestEffort(
+				prepared
+					.filter((blob) => blob.storageKind === 'external' && blob.objectKey)
+					.map((blob) => blob.objectKey!),
+			);
+			throw error;
+		}
+		return prepared;
+	}
+
+	private shouldStoreExternally(blob: StoredSessionBlob): boolean {
+		const threshold = this.options.externalBlobThreshold ?? DEFAULT_EXTERNAL_BLOB_THRESHOLD;
+		return Boolean(this.options.attachmentStore && blob.data.length >= threshold);
+	}
+
+	private insertSessionBlob(sessionId: string, blob: PreparedSessionBlob): void {
+		if (blob.storageKind === 'external') {
+			this.sql.exec(
+				`INSERT INTO flue_session_blobs
+				 (session_id, entry_id, blob_id, storage_kind, object_key, segment_index, segment_count, data)
+				 VALUES (?, ?, ?, 'external', ?, 0, 1, NULL)`,
+				sessionId,
+				blob.entryId,
+				blob.blobId,
+				blob.objectKey,
+			);
+			return;
+		}
+
 		const segmentCount = Math.ceil(blob.data.length / SESSION_BLOB_CHUNK_SIZE);
 		for (
 			let offset = 0, segmentIndex = 0;
@@ -202,8 +290,8 @@ export class SqlSessionStore implements SessionStore {
 		) {
 			this.sql.exec(
 				`INSERT INTO flue_session_blobs
-				 (session_id, entry_id, blob_id, segment_index, segment_count, data)
-				 VALUES (?, ?, ?, ?, ?, ?)`,
+				 (session_id, entry_id, blob_id, storage_kind, object_key, segment_index, segment_count, data)
+				 VALUES (?, ?, ?, 'sql_chunk', NULL, ?, ?, ?)`,
 				sessionId,
 				blob.entryId,
 				blob.blobId,
@@ -212,6 +300,75 @@ export class SqlSessionStore implements SessionStore {
 				blob.data.slice(offset, offset + SESSION_BLOB_CHUNK_SIZE),
 			);
 		}
+	}
+
+	private selectExternalObjectKeys(sessionId: string): string[] {
+		return this.sql
+			.exec(
+				`SELECT object_key
+				 FROM flue_session_blobs
+				 WHERE session_id = ? AND storage_kind = 'external' AND object_key IS NOT NULL`,
+				sessionId,
+			)
+			.toArray()
+			.map((row) => {
+				if (typeof row.object_key !== 'string') {
+					throw new Error('[flue] Persisted session blob row is malformed.');
+				}
+				return row.object_key;
+			});
+	}
+
+	private async deleteExternalObjectsBestEffort(keys: string[]): Promise<void> {
+		if (!this.options.attachmentStore || keys.length === 0) return;
+		const failures: Array<{ key: string; error: unknown }> = [];
+		for (const key of new Set(keys)) {
+			try {
+				await this.options.attachmentStore.delete(key);
+				this.sql.exec('DELETE FROM flue_session_attachment_deletions WHERE object_key = ?', key);
+			} catch (error) {
+				failures.push({ key, error });
+			}
+		}
+		if (failures.length > 0) {
+			console.warn(
+				`[flue] Failed to delete ${failures.length} external session attachment object(s); cleanup will be retried by a later session storage operation.`,
+				failures.map(({ key }) => key),
+			);
+		}
+	}
+
+	private enqueueExternalObjectDeletions(keys: string[]): void {
+		for (const key of new Set(keys)) {
+			this.sql.exec(
+				`INSERT OR IGNORE INTO flue_session_attachment_deletions (object_key, created_at)
+				 VALUES (?, ?)`,
+				key,
+				Date.now(),
+			);
+		}
+	}
+
+	private enqueueExternalObjectDeletionsBestEffort(keys: string[]): void {
+		try {
+			this.enqueueExternalObjectDeletions(keys);
+		} catch (error) {
+			console.warn('[flue] Failed to queue external session attachment cleanup.', error);
+		}
+	}
+
+	private async drainExternalObjectDeletions(): Promise<void> {
+		if (!this.options.attachmentStore) return;
+		const keys = this.sql
+			.exec('SELECT object_key FROM flue_session_attachment_deletions ORDER BY created_at ASC')
+			.toArray()
+			.map((row) => {
+				if (typeof row.object_key !== 'string') {
+					throw new Error('[flue] Persisted session attachment deletion row is malformed.');
+				}
+				return row.object_key;
+			});
+		await this.deleteExternalObjectsBestEffort(keys);
 	}
 }
 
@@ -270,19 +427,41 @@ function isExternalizableSessionBlob(
 	);
 }
 
-function sessionBlobMap(rows: SqlRow[]): Map<string, string> {
+async function sessionBlobMap(
+	rows: SqlRow[],
+	attachmentStore: SessionAttachmentStore | undefined,
+): Promise<Map<string, string>> {
 	const chunks = new Map<string, { segmentCount: number; segments: string[] }>();
+	const externalObjects = new Map<string, string>();
 	for (const row of rows) {
 		if (
 			typeof row.entry_id !== 'string' ||
 			typeof row.blob_id !== 'string' ||
+			(row.storage_kind !== 'sql_chunk' && row.storage_kind !== 'external') ||
 			!isNonNegativeInteger(row.segment_index) ||
 			!isPositiveInteger(row.segment_count) ||
-			typeof row.data !== 'string'
+			(row.object_key !== null &&
+				row.object_key !== undefined &&
+				typeof row.object_key !== 'string')
 		) {
 			throw new Error('[flue] Persisted session blob row is malformed.');
 		}
 		const key = sessionBlobKey(row.entry_id, row.blob_id);
+		if (row.storage_kind === 'external') {
+			if (
+				typeof row.object_key !== 'string' ||
+				row.segment_index !== 0 ||
+				row.segment_count !== 1
+			) {
+				throw new Error('[flue] Persisted session blob row is malformed.');
+			}
+			externalObjects.set(key, row.object_key);
+			continue;
+		}
+
+		if (typeof row.data !== 'string') {
+			throw new Error('[flue] Persisted session blob row is malformed.');
+		}
 		const chunk = chunks.get(key) ?? { segmentCount: row.segment_count, segments: [] };
 		if (chunk.segmentCount !== row.segment_count || row.segment_index >= chunk.segmentCount) {
 			throw new Error('[flue] Persisted session blob row is malformed.');
@@ -302,6 +481,14 @@ function sessionBlobMap(rows: SqlRow[]): Map<string, string> {
 			}
 		}
 		blobs.set(key, chunk.segments.join(''));
+	}
+	for (const [key, objectKey] of externalObjects) {
+		if (!attachmentStore) {
+			throw new Error(
+				'[flue] Session attachment storage is not configured for persisted external blobs.',
+			);
+		}
+		blobs.set(key, await attachmentStore.get(objectKey));
 	}
 	return blobs;
 }
@@ -335,6 +522,20 @@ function hydrateSessionValue(value: unknown, entryId: string, blobs: Map<string,
 
 function sessionBlobKey(entryId: string, blobId: string): string {
 	return `${entryId}\0${blobId}`;
+}
+
+function createSessionAttachmentObjectKey(
+	sessionId: string,
+	entryId: string,
+	blobId: string,
+): string {
+	return [
+		'flue-sessions',
+		encodeURIComponent(sessionId),
+		'entries',
+		encodeURIComponent(entryId),
+		`${encodeURIComponent(blobId)}-${crypto.randomUUID()}`,
+	].join('/');
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -1073,14 +1274,62 @@ export function ensureSessionTable(sql: SqlStorage): void {
 		`CREATE INDEX IF NOT EXISTS flue_session_entries_session_position_idx
 		 ON flue_session_entries (session_id, position ASC)`,
 	);
+	ensureSessionBlobTable(sql);
+	sql.exec(
+		`CREATE TABLE IF NOT EXISTS flue_session_attachment_deletions (
+		 object_key TEXT PRIMARY KEY,
+		 created_at INTEGER NOT NULL
+		)`,
+	);
+}
+
+function ensureSessionBlobTable(sql: SqlStorage): void {
+	const columns = sql
+		.exec('SELECT name, "notnull" FROM pragma_table_info(\'flue_session_blobs\')')
+		.toArray();
+	if (columns.length === 0) {
+		createSessionBlobTable(sql);
+		return;
+	}
+
+	const byName = new Map(
+		columns.map((row) => {
+			if (typeof row.name !== 'string' || typeof row.notnull !== 'number') {
+				throw new Error('[flue] Persisted session blob schema is malformed.');
+			}
+			return [row.name, row];
+		}),
+	);
+	const dataColumn = byName.get('data');
+	const current =
+		byName.has('storage_kind') && byName.has('object_key') && dataColumn?.notnull === 0;
+	if (current) return;
+
+	const storageKindExpr = byName.has('storage_kind') ? 'storage_kind' : "'sql_chunk'";
+	const objectKeyExpr = byName.has('object_key') ? 'object_key' : 'NULL';
+	sql.exec('DROP TABLE IF EXISTS flue_session_blobs_migration_old');
+	sql.exec('ALTER TABLE flue_session_blobs RENAME TO flue_session_blobs_migration_old');
+	createSessionBlobTable(sql);
+	sql.exec(
+		`INSERT INTO flue_session_blobs
+		 (session_id, entry_id, blob_id, storage_kind, object_key, segment_index, segment_count, data)
+		 SELECT session_id, entry_id, blob_id, ${storageKindExpr}, ${objectKeyExpr}, segment_index, segment_count, data
+		 FROM flue_session_blobs_migration_old`,
+	);
+	sql.exec('DROP TABLE flue_session_blobs_migration_old');
+}
+
+function createSessionBlobTable(sql: SqlStorage): void {
 	sql.exec(
 		`CREATE TABLE IF NOT EXISTS flue_session_blobs (
 		 session_id TEXT NOT NULL,
 		 entry_id TEXT NOT NULL,
 		 blob_id TEXT NOT NULL,
+		 storage_kind TEXT NOT NULL DEFAULT 'sql_chunk',
+		 object_key TEXT,
 		 segment_index INTEGER NOT NULL,
 		 segment_count INTEGER NOT NULL,
-		 data TEXT NOT NULL,
+		 data TEXT,
 		 PRIMARY KEY (session_id, entry_id, blob_id, segment_index)
 		)`,
 	);

--- a/packages/runtime/src/sql-agent-execution-store.ts
+++ b/packages/runtime/src/sql-agent-execution-store.ts
@@ -43,7 +43,24 @@ import {
 } from './runtime/agent-submissions.ts';
 import type { DispatchInput } from './runtime/dispatch-queue.ts';
 import { createSessionStorageKey } from './session-identity.ts';
-import type { SessionData, SessionStore } from './types.ts';
+import type { SessionData, SessionEntry, SessionStore } from './types.ts';
+
+const SESSION_BLOB_CHUNK_SIZE = 512 * 1024;
+const SESSION_BLOB_REF_KEY = '__flueSessionBlobRef';
+const SESSION_BLOB_REF_TYPE = 'flue.sessionBlob.v1';
+
+interface StoredSessionBlob {
+	entryId: string;
+	blobId: string;
+	data: string;
+}
+
+interface SerializedSessionEntry {
+	entryJson: string;
+	blobs: StoredSessionBlob[];
+}
+
+type SessionMetadata = Omit<SessionData, 'entries'>;
 
 /**
  * Run idempotent DDL for all agent execution store tables.
@@ -80,39 +97,47 @@ export class SqlSessionStore implements SessionStore {
 	) {}
 
 	async save(id: string, data: SessionData): Promise<void> {
-		const { entries: sessionEntries, ...session } = data;
-		const entries = sessionEntries.map((entry, position) => ({
-			entry,
-			position,
-			data: JSON.stringify(entry),
-		}));
+		const entries = data.entries.map((entry, position) => {
+			const serialized = serializeSessionEntry(entry);
+			return {
+				entry,
+				position,
+				data: serialized.entryJson,
+				blobs: serialized.blobs,
+			};
+		});
 		this.transactionSync(() => {
 			this.sql.exec(
 				`INSERT INTO flue_sessions (id, data) VALUES (?, ?)
 				 ON CONFLICT (id) DO UPDATE SET data = excluded.data`,
 				id,
-				JSON.stringify(session),
+				JSON.stringify(sessionMetadata(data)),
 			);
+			this.sql.exec('DELETE FROM flue_session_blobs WHERE session_id = ?', id);
 			const existingRows = this.sql.exec(
 				'SELECT entry_id, position, data FROM flue_session_entries WHERE session_id = ?',
 				id,
 			).toArray();
 			const existing = new Map(existingRows.map((row) => [row.entry_id, row]));
 			const retained = new Set<string>();
-			for (const { entry, position, data: entryData } of entries) {
+			for (const { entry, position, data: entryData, blobs } of entries) {
 				retained.add(entry.id);
 				const current = existing.get(entry.id);
-				if (current?.position === position && current.data === entryData) continue;
-				this.sql.exec(
-					`INSERT INTO flue_session_entries (session_id, entry_id, position, data)
-					 VALUES (?, ?, ?, ?)
-					 ON CONFLICT (session_id, entry_id) DO UPDATE SET
-					 position = excluded.position, data = excluded.data`,
-					id,
-					entry.id,
-					position,
-					entryData,
-				);
+				if (current?.position !== position || current.data !== entryData) {
+					this.sql.exec(
+						`INSERT INTO flue_session_entries (session_id, entry_id, position, data)
+						 VALUES (?, ?, ?, ?)
+						 ON CONFLICT (session_id, entry_id) DO UPDATE SET
+						 position = excluded.position, data = excluded.data`,
+						id,
+						entry.id,
+						position,
+						entryData,
+					);
+				}
+				for (const blob of blobs) {
+					this.insertSessionBlob(id, blob);
+				}
 			}
 			for (const row of existingRows) {
 				if (typeof row.entry_id === 'string' && !retained.has(row.entry_id)) {
@@ -134,29 +159,194 @@ export class SqlSessionStore implements SessionStore {
 			if (typeof row.data !== 'string') {
 				throw new Error('[flue] Persisted session row is malformed.');
 			}
-			const session = JSON.parse(row.data) as Omit<SessionData, 'entries'>;
+			const session = JSON.parse(row.data) as SessionData | SessionMetadata;
 			const entryRows = this.sql.exec(
-				'SELECT data FROM flue_session_entries WHERE session_id = ? ORDER BY position ASC',
+				'SELECT entry_id, data FROM flue_session_entries WHERE session_id = ? ORDER BY position ASC',
 				id,
 			).toArray();
+			if (entryRows.length === 0 && Array.isArray((session as SessionData).entries)) {
+				return session as SessionData;
+			}
+			const blobs = sessionBlobMap(
+				this.sql
+					.exec(
+						`SELECT entry_id, blob_id, segment_index, segment_count, data
+						 FROM flue_session_blobs
+						 WHERE session_id = ?
+						 ORDER BY entry_id ASC, blob_id ASC, segment_index ASC`,
+						id,
+					)
+					.toArray(),
+			);
 			return {
 				...session,
-				entries: entryRows.map((entryRow) => {
-					if (typeof entryRow.data !== 'string') {
-						throw new Error('[flue] Persisted session entry row is malformed.');
-					}
-					return JSON.parse(entryRow.data);
-				}),
-			};
+				entries: entryRows.map((entryRow) => parseSessionEntryRow(entryRow, blobs)),
+			} as SessionData;
 		});
 	}
 
 	async delete(id: string): Promise<void> {
 		this.transactionSync(() => {
+			this.sql.exec('DELETE FROM flue_session_blobs WHERE session_id = ?', id);
 			this.sql.exec('DELETE FROM flue_session_entries WHERE session_id = ?', id);
 			this.sql.exec('DELETE FROM flue_sessions WHERE id = ?', id);
 		});
 	}
+
+	private insertSessionBlob(sessionId: string, blob: StoredSessionBlob): void {
+		const segmentCount = Math.ceil(blob.data.length / SESSION_BLOB_CHUNK_SIZE);
+		for (
+			let offset = 0, segmentIndex = 0;
+			offset < blob.data.length;
+			offset += SESSION_BLOB_CHUNK_SIZE, segmentIndex++
+		) {
+			this.sql.exec(
+				`INSERT INTO flue_session_blobs
+				 (session_id, entry_id, blob_id, segment_index, segment_count, data)
+				 VALUES (?, ?, ?, ?, ?, ?)`,
+				sessionId,
+				blob.entryId,
+				blob.blobId,
+				segmentIndex,
+				segmentCount,
+				blob.data.slice(offset, offset + SESSION_BLOB_CHUNK_SIZE),
+			);
+		}
+	}
+}
+
+function sessionMetadata(data: SessionData): SessionMetadata {
+	const { entries: _entries, ...metadata } = data;
+	return metadata;
+}
+
+function serializeSessionEntry(entry: SessionEntry): SerializedSessionEntry {
+	const blobs: StoredSessionBlob[] = [];
+	let nextBlobIndex = 0;
+	return {
+		entryJson: JSON.stringify(
+			externalizeSessionValue(entry, entry.id, blobs, () => `blob_${nextBlobIndex++}`),
+		),
+		blobs,
+	};
+}
+
+function externalizeSessionValue(
+	value: unknown,
+	entryId: string,
+	blobs: StoredSessionBlob[],
+	nextBlobId: () => string,
+): unknown {
+	if (Array.isArray(value)) {
+		return value.map((item) => externalizeSessionValue(item, entryId, blobs, nextBlobId));
+	}
+	if (!isRecord(value)) return value;
+
+	const output: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(value)) {
+		if (isExternalizableSessionBlob(value, key, child)) {
+			const blobId = nextBlobId();
+			blobs.push({ entryId, blobId, data: child });
+			output[key] = { [SESSION_BLOB_REF_KEY]: { type: SESSION_BLOB_REF_TYPE, id: blobId } };
+			continue;
+		}
+		output[key] = externalizeSessionValue(child, entryId, blobs, nextBlobId);
+	}
+	return output;
+}
+
+function isExternalizableSessionBlob(
+	parent: Record<string, unknown>,
+	key: string,
+	value: unknown,
+): value is string {
+	if (value === '' || typeof value !== 'string') return false;
+	if (key !== 'data' && key !== 'blob') return false;
+	return (
+		parent.type === 'image' ||
+		parent.type === 'blob' ||
+		parent.type === 'document' ||
+		parent.type === 'file'
+	);
+}
+
+function sessionBlobMap(rows: SqlRow[]): Map<string, string> {
+	const chunks = new Map<string, { segmentCount: number; segments: string[] }>();
+	for (const row of rows) {
+		if (
+			typeof row.entry_id !== 'string' ||
+			typeof row.blob_id !== 'string' ||
+			!isNonNegativeInteger(row.segment_index) ||
+			!isPositiveInteger(row.segment_count) ||
+			typeof row.data !== 'string'
+		) {
+			throw new Error('[flue] Persisted session blob row is malformed.');
+		}
+		const key = sessionBlobKey(row.entry_id, row.blob_id);
+		const chunk = chunks.get(key) ?? { segmentCount: row.segment_count, segments: [] };
+		if (chunk.segmentCount !== row.segment_count || row.segment_index >= chunk.segmentCount) {
+			throw new Error('[flue] Persisted session blob row is malformed.');
+		}
+		chunk.segments[row.segment_index] = row.data;
+		chunks.set(key, chunk);
+	}
+
+	const blobs = new Map<string, string>();
+	for (const [key, chunk] of chunks) {
+		if (chunk.segments.length !== chunk.segmentCount) {
+			throw new Error('[flue] Persisted session blob row is malformed.');
+		}
+		for (const segment of chunk.segments) {
+			if (typeof segment !== 'string') {
+				throw new Error('[flue] Persisted session blob row is malformed.');
+			}
+		}
+		blobs.set(key, chunk.segments.join(''));
+	}
+	return blobs;
+}
+
+function parseSessionEntryRow(row: SqlRow, blobs: Map<string, string>): SessionEntry {
+	if (typeof row.entry_id !== 'string' || typeof row.data !== 'string') {
+		throw new Error('[flue] Persisted session entry row is malformed.');
+	}
+	return hydrateSessionValue(JSON.parse(row.data), row.entry_id, blobs) as SessionEntry;
+}
+
+function hydrateSessionValue(value: unknown, entryId: string, blobs: Map<string, string>): unknown {
+	if (Array.isArray(value)) {
+		return value.map((item) => hydrateSessionValue(item, entryId, blobs));
+	}
+	if (!isRecord(value)) return value;
+
+	const ref = value[SESSION_BLOB_REF_KEY];
+	if (isRecord(ref) && ref.type === SESSION_BLOB_REF_TYPE && typeof ref.id === 'string') {
+		const blob = blobs.get(sessionBlobKey(entryId, ref.id));
+		if (blob === undefined) throw new Error('[flue] Persisted session blob reference is missing.');
+		return blob;
+	}
+
+	const output: Record<string, unknown> = {};
+	for (const [key, child] of Object.entries(value)) {
+		output[key] = hydrateSessionValue(child, entryId, blobs);
+	}
+	return output;
+}
+
+function sessionBlobKey(entryId: string, blobId: string): string {
+	return `${entryId}\0${blobId}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+	return typeof value === 'number' && Number.isInteger(value) && value >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+	return typeof value === 'number' && Number.isInteger(value) && value > 0;
 }
 
 class AgentSubmissionStoreImpl implements AgentSubmissionStore {
@@ -882,6 +1072,17 @@ export function ensureSessionTable(sql: SqlStorage): void {
 	sql.exec(
 		`CREATE INDEX IF NOT EXISTS flue_session_entries_session_position_idx
 		 ON flue_session_entries (session_id, position ASC)`,
+	);
+	sql.exec(
+		`CREATE TABLE IF NOT EXISTS flue_session_blobs (
+		 session_id TEXT NOT NULL,
+		 entry_id TEXT NOT NULL,
+		 blob_id TEXT NOT NULL,
+		 segment_index INTEGER NOT NULL,
+		 segment_count INTEGER NOT NULL,
+		 data TEXT NOT NULL,
+		 PRIMARY KEY (session_id, entry_id, blob_id, segment_index)
+		)`,
 	);
 }
 

--- a/packages/runtime/src/sql-agent-execution-store.ts
+++ b/packages/runtime/src/sql-agent-execution-store.ts
@@ -67,10 +67,9 @@ interface StoredSessionBlob {
 	data: string;
 }
 
-interface PreparedSessionBlob extends StoredSessionBlob {
-	storageKind: 'sql_chunk' | 'external';
-	objectKey?: string;
-}
+type PreparedSessionBlob =
+	| (StoredSessionBlob & { storageKind: 'sql_chunk' })
+	| (StoredSessionBlob & { storageKind: 'external'; objectKey: string });
 
 interface SerializedSessionEntry {
 	entryJson: string;
@@ -78,14 +77,18 @@ interface SerializedSessionEntry {
 }
 
 type SessionMetadata = Omit<SessionData, 'entries'>;
+export type SqlTransactionSync = <T>(closure: () => T) => T;
 
 /**
  * Run idempotent DDL for all agent execution store tables.
  * Called by `createSqlAgentExecutionStore` (Cloudflare DO path) and
  * by the `sqlite()` adapter's `migrate()` method (Node).
  */
-export function ensureSqlAgentExecutionTables(sql: SqlStorage): void {
-	ensureSessionTable(sql);
+export function ensureSqlAgentExecutionTables(
+	sql: SqlStorage,
+	runTransaction?: SqlTransactionSync,
+): void {
+	ensureSessionTable(sql, runTransaction);
 	ensureSubmissionTable(sql);
 	ensureTurnJournalTable(sql);
 }
@@ -99,7 +102,7 @@ export function ensureSqlAgentExecutionTables(sql: SqlStorage): void {
  */
 export function createSqlAgentExecutionStoreFromSql(
 	sql: SqlStorage,
-	runTransaction: <T>(closure: () => T) => T,
+	runTransaction: SqlTransactionSync,
 	options: SqlSessionStoreOptions = {},
 ): AgentExecutionStore {
 	return {
@@ -111,22 +114,28 @@ export function createSqlAgentExecutionStoreFromSql(
 export class SqlSessionStore implements SessionStore {
 	constructor(
 		private sql: SqlStorage,
-		private transactionSync: <T>(closure: () => T) => T,
+		private transactionSync: SqlTransactionSync,
 		private options: SqlSessionStoreOptions = {},
 	) {}
 
 	async save(id: string, data: SessionData): Promise<void> {
-		const serializedEntries = data.entries.map((entry) => serializeSessionEntry(entry));
-		const entries = data.entries.map((entry, position) => ({
-			entry,
-			position,
-			data: serializedEntries[position]!.entryJson,
-		}));
+		const entries = data.entries.map((entry, position) => {
+			const serialized = serializeSessionEntry(entry);
+			return {
+				entry,
+				position,
+				data: serialized.entryJson,
+				blobs: serialized.blobs,
+			};
+		});
 		const oldExternalKeys = this.selectExternalObjectKeys(id);
-		const preparedBlobs = await this.prepareSessionBlobs(id, serializedEntries);
+		const preparedBlobs = await this.prepareSessionBlobs(id, entries);
 		const uploadedExternalKeys = preparedBlobs
-			.filter((blob) => blob.storageKind === 'external' && blob.objectKey)
-			.map((blob) => blob.objectKey!);
+			.filter(
+				(blob): blob is Extract<PreparedSessionBlob, { storageKind: 'external' }> =>
+					blob.storageKind === 'external',
+			)
+			.map((blob) => blob.objectKey);
 		const currentExternalKeys = new Set(uploadedExternalKeys);
 		const staleExternalKeys = oldExternalKeys.filter((key) => !currentExternalKeys.has(key));
 		try {
@@ -237,9 +246,10 @@ export class SqlSessionStore implements SessionStore {
 
 	private async prepareSessionBlobs(
 		sessionId: string,
-		entries: SerializedSessionEntry[],
+		entries: Array<Pick<SerializedSessionEntry, 'blobs'>>,
 	): Promise<PreparedSessionBlob[]> {
 		const prepared: PreparedSessionBlob[] = [];
+		const attemptedExternalKeys: string[] = [];
 		try {
 			for (const entry of entries) {
 				for (const blob of entry.blobs) {
@@ -248,16 +258,14 @@ export class SqlSessionStore implements SessionStore {
 						continue;
 					}
 					const objectKey = createSessionAttachmentObjectKey(sessionId, blob.entryId, blob.blobId);
+					attemptedExternalKeys.push(objectKey);
 					await this.options.attachmentStore!.put(objectKey, blob.data);
 					prepared.push({ ...blob, storageKind: 'external', objectKey });
 				}
 			}
 		} catch (error) {
-			await this.deleteExternalObjectsBestEffort(
-				prepared
-					.filter((blob) => blob.storageKind === 'external' && blob.objectKey)
-					.map((blob) => blob.objectKey!),
-			);
+			this.enqueueExternalObjectDeletionsBestEffort(attemptedExternalKeys);
+			await this.deleteExternalObjectsBestEffort(attemptedExternalKeys);
 			throw error;
 		}
 		return prepared;
@@ -380,10 +388,24 @@ function sessionMetadata(data: SessionData): SessionMetadata {
 function serializeSessionEntry(entry: SessionEntry): SerializedSessionEntry {
 	const blobs: StoredSessionBlob[] = [];
 	let nextBlobIndex = 0;
+	const message = entry.type === 'message' ? (entry.message as unknown) : undefined;
+	const serializedEntry: SessionEntry =
+		isRecord(message) && 'content' in message
+			? ({
+					...entry,
+					message: {
+						...message,
+						content: externalizeSessionValue(
+							message.content,
+							entry.id,
+							blobs,
+							() => `blob_${nextBlobIndex++}`,
+						),
+					},
+				} as SessionEntry)
+			: entry;
 	return {
-		entryJson: JSON.stringify(
-			externalizeSessionValue(entry, entry.id, blobs, () => `blob_${nextBlobIndex++}`),
-		),
+		entryJson: JSON.stringify(serializedEntry),
 		blobs,
 	};
 }
@@ -419,6 +441,10 @@ function isExternalizableSessionBlob(
 ): value is string {
 	if (value === '' || typeof value !== 'string') return false;
 	if (key !== 'data' && key !== 'blob') return false;
+	return isExternalizableSessionBlobParent(parent);
+}
+
+function isExternalizableSessionBlobParent(parent: Record<string, unknown>): boolean {
 	return (
 		parent.type === 'image' ||
 		parent.type === 'blob' ||
@@ -497,7 +523,17 @@ function parseSessionEntryRow(row: SqlRow, blobs: Map<string, string>): SessionE
 	if (typeof row.entry_id !== 'string' || typeof row.data !== 'string') {
 		throw new Error('[flue] Persisted session entry row is malformed.');
 	}
-	return hydrateSessionValue(JSON.parse(row.data), row.entry_id, blobs) as SessionEntry;
+	const entry = JSON.parse(row.data) as SessionEntry;
+	if (entry.type !== 'message') return entry;
+	const message = entry.message as unknown;
+	if (!isRecord(message) || !('content' in message)) return entry;
+	return {
+		...entry,
+		message: {
+			...message,
+			content: hydrateSessionValue(message.content, row.entry_id, blobs),
+		} as typeof entry.message,
+	};
 }
 
 function hydrateSessionValue(value: unknown, entryId: string, blobs: Map<string, string>): unknown {
@@ -506,18 +542,36 @@ function hydrateSessionValue(value: unknown, entryId: string, blobs: Map<string,
 	}
 	if (!isRecord(value)) return value;
 
-	const ref = value[SESSION_BLOB_REF_KEY];
-	if (isRecord(ref) && ref.type === SESSION_BLOB_REF_TYPE && typeof ref.id === 'string') {
-		const blob = blobs.get(sessionBlobKey(entryId, ref.id));
-		if (blob === undefined) throw new Error('[flue] Persisted session blob reference is missing.');
-		return blob;
-	}
-
 	const output: Record<string, unknown> = {};
 	for (const [key, child] of Object.entries(value)) {
+		const refId = hydratableSessionBlobRefId(value, key, child);
+		if (refId) {
+			const blob = blobs.get(sessionBlobKey(entryId, refId));
+			if (blob === undefined) {
+				throw new Error('[flue] Persisted session blob reference is missing.');
+			}
+			output[key] = blob;
+			continue;
+		}
 		output[key] = hydrateSessionValue(child, entryId, blobs);
 	}
 	return output;
+}
+
+function hydratableSessionBlobRefId(
+	parent: Record<string, unknown>,
+	key: string,
+	value: unknown,
+): string | undefined {
+	if (!isExternalizableSessionBlobParent(parent) || (key !== 'data' && key !== 'blob')) {
+		return undefined;
+	}
+	if (!isRecord(value) || Object.keys(value).length !== 1) return undefined;
+	const ref = value[SESSION_BLOB_REF_KEY];
+	if (!isRecord(ref) || ref.type !== SESSION_BLOB_REF_TYPE || typeof ref.id !== 'string') {
+		return undefined;
+	}
+	return ref.id;
 }
 
 function sessionBlobKey(entryId: string, blobId: string): string {
@@ -555,7 +609,7 @@ class AgentSubmissionStoreImpl implements AgentSubmissionStore {
 
 	constructor(
 		private sql: SqlStorage,
-		private transactionSync: <T>(closure: () => T) => T,
+		private transactionSync: SqlTransactionSync,
 	) {}
 
 	async getSubmission(submissionId: string): Promise<AgentSubmission | null> {
@@ -1254,7 +1308,7 @@ function parseSubmission(row: SqlRow): AgentSubmission {
 	};
 }
 
-export function ensureSessionTable(sql: SqlStorage): void {
+export function ensureSessionTable(sql: SqlStorage, runTransaction?: SqlTransactionSync): void {
 	sql.exec(
 		`CREATE TABLE IF NOT EXISTS flue_sessions (
 		 id TEXT PRIMARY KEY,
@@ -1274,7 +1328,7 @@ export function ensureSessionTable(sql: SqlStorage): void {
 		`CREATE INDEX IF NOT EXISTS flue_session_entries_session_position_idx
 		 ON flue_session_entries (session_id, position ASC)`,
 	);
-	ensureSessionBlobTable(sql);
+	ensureSessionBlobTable(sql, runTransaction);
 	sql.exec(
 		`CREATE TABLE IF NOT EXISTS flue_session_attachment_deletions (
 		 object_key TEXT PRIMARY KEY,
@@ -1283,7 +1337,7 @@ export function ensureSessionTable(sql: SqlStorage): void {
 	);
 }
 
-function ensureSessionBlobTable(sql: SqlStorage): void {
+function ensureSessionBlobTable(sql: SqlStorage, runTransaction?: SqlTransactionSync): void {
 	const columns = sql
 		.exec('SELECT name, "notnull" FROM pragma_table_info(\'flue_session_blobs\')')
 		.toArray();
@@ -1305,8 +1359,20 @@ function ensureSessionBlobTable(sql: SqlStorage): void {
 		byName.has('storage_kind') && byName.has('object_key') && dataColumn?.notnull === 0;
 	if (current) return;
 
-	const storageKindExpr = byName.has('storage_kind') ? 'storage_kind' : "'sql_chunk'";
-	const objectKeyExpr = byName.has('object_key') ? 'object_key' : 'NULL';
+	const migrate = () => migrateSessionBlobTable(sql, byName);
+	if (runTransaction) {
+		runTransaction(migrate);
+		return;
+	}
+	migrate();
+}
+
+function migrateSessionBlobTable(
+	sql: SqlStorage,
+	columns: Map<string, SqlRow>,
+): void {
+	const storageKindExpr = columns.has('storage_kind') ? 'storage_kind' : "'sql_chunk'";
+	const objectKeyExpr = columns.has('object_key') ? 'object_key' : 'NULL';
 	sql.exec('DROP TABLE IF EXISTS flue_session_blobs_migration_old');
 	sql.exec('ALTER TABLE flue_session_blobs RENAME TO flue_session_blobs_migration_old');
 	createSessionBlobTable(sql);

--- a/packages/runtime/test/agent-execution-store-contract.test.ts
+++ b/packages/runtime/test/agent-execution-store-contract.test.ts
@@ -64,7 +64,7 @@ function createCloudflareSqlBackend(): AgentExecutionStore {
 			throw error;
 		}
 	};
-	ensureSqlAgentExecutionTables(sql);
+	ensureSqlAgentExecutionTables(sql, runTransaction);
 	return createSqlAgentExecutionStoreFromSql(sql, runTransaction);
 }
 

--- a/packages/runtime/test/agent-execution-store-contract.test.ts
+++ b/packages/runtime/test/agent-execution-store-contract.test.ts
@@ -21,7 +21,11 @@ import {
 	ensureSqlAgentExecutionTables,
 	type SessionAttachmentStore,
 } from '../src/sql-agent-execution-store.ts';
-import { createNodeAgentExecutionStore, sqlite } from '../src/node/agent-execution-store.ts';
+import {
+	createNodeAgentExecutionStore,
+	fileSessionAttachmentStore,
+	sqlite,
+} from '../src/node/agent-execution-store.ts';
 import type { SessionData } from '../src/types.ts';
 import { defineStoreContractTests } from '../src/test-utils/define-store-contract-tests.ts';
 
@@ -136,6 +140,77 @@ describe('createNodeAgentExecutionStore()', () => {
 		const objectKey = [...attachments.objects.keys()][0]!;
 		await store.sessions.delete('s1');
 		expect(attachments.deleted).toEqual([objectKey]);
+	});
+
+	it('stores large session blobs in filesystem attachments when configured', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'flue-file-attachments-'));
+		try {
+			const attachments = fileSessionAttachmentStore(join(dir, 'attachments'));
+			const store = createNodeAgentExecutionStore(':memory:', {
+				attachmentStore: attachments,
+				externalBlobThreshold: 1,
+			});
+			const imageData = 'a'.repeat(600_000);
+			const data: SessionData = {
+				version: 5,
+				affinityKey: 'affinity-1',
+				entries: [
+					{
+						type: 'message',
+						id: 'entry-1',
+						parentId: null,
+						timestamp: '2026-06-03T00:00:00.000Z',
+						source: 'prompt',
+						message: {
+							role: 'user',
+							content: [{ type: 'image', data: imageData, mimeType: 'image/png' }],
+							timestamp: 0,
+						},
+					},
+				],
+				leafId: 'entry-1',
+				metadata: {},
+				createdAt: '2026-06-03T00:00:00.000Z',
+				updatedAt: '2026-06-03T00:00:00.000Z',
+			};
+
+			await store.sessions.save('s1', data);
+
+			await expect(store.sessions.load('s1')).resolves.toEqual(data);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe('fileSessionAttachmentStore()', () => {
+	it('writes, reads, and deletes attachment files under the configured root', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'flue-file-attachments-'));
+		try {
+			const store = fileSessionAttachmentStore(join(dir, 'attachments'));
+			await store.put('flue-sessions/s1/entries/blob-1', 'image-data');
+
+			expect(await store.get('flue-sessions/s1/entries/blob-1')).toBe('image-data');
+			await store.delete('flue-sessions/s1/entries/blob-1');
+			await expect(store.get('flue-sessions/s1/entries/blob-1')).rejects.toThrow(
+				'[flue] Persisted session attachment file is missing.',
+			);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('rejects attachment keys outside the configured root', async () => {
+		const dir = mkdtempSync(join(tmpdir(), 'flue-file-attachments-'));
+		try {
+			const store = fileSessionAttachmentStore(join(dir, 'attachments'));
+
+			await expect(store.put('../outside', 'image-data')).rejects.toThrow(
+				'[flue] Invalid session attachment file key.',
+			);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 });
 

--- a/packages/runtime/test/agent-execution-store-contract.test.ts
+++ b/packages/runtime/test/agent-execution-store-contract.test.ts
@@ -16,7 +16,11 @@ import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
 import type { AgentExecutionStore } from '../src/agent-execution-store.ts';
 import type { SqlStorage } from '../src/sql-storage.ts';
-import { createSqlAgentExecutionStoreFromSql, ensureSqlAgentExecutionTables } from '../src/sql-agent-execution-store.ts';
+import {
+	createSqlAgentExecutionStoreFromSql,
+	ensureSqlAgentExecutionTables,
+	type SessionAttachmentStore,
+} from '../src/sql-agent-execution-store.ts';
 import { createNodeAgentExecutionStore, sqlite } from '../src/node/agent-execution-store.ts';
 import type { SessionData } from '../src/types.ts';
 import { defineStoreContractTests } from '../src/test-utils/define-store-contract-tests.ts';
@@ -64,6 +68,26 @@ function createNodeBackend(): AgentExecutionStore {
 	return createNodeAgentExecutionStore();
 }
 
+class RecordingAttachmentStore implements SessionAttachmentStore {
+	readonly objects = new Map<string, string>();
+	readonly deleted: string[] = [];
+
+	async put(key: string, data: string): Promise<void> {
+		this.objects.set(key, data);
+	}
+
+	async get(key: string): Promise<string> {
+		const data = this.objects.get(key);
+		if (data === undefined) throw new Error(`missing object ${key}`);
+		return data;
+	}
+
+	async delete(key: string): Promise<void> {
+		this.deleted.push(key);
+		this.objects.delete(key);
+	}
+}
+
 // ─── Contract tests (shared) ────────────────────────────────────────────────
 
 defineStoreContractTests('AgentExecutionStore (cloudflare-sql)', {
@@ -72,6 +96,47 @@ defineStoreContractTests('AgentExecutionStore (cloudflare-sql)', {
 
 defineStoreContractTests('AgentExecutionStore (node-sqlite)', {
 	create: createNodeBackend,
+});
+
+describe('createNodeAgentExecutionStore()', () => {
+	it('stores large session blobs in a custom attachment store when configured', async () => {
+		const attachments = new RecordingAttachmentStore();
+		const store = createNodeAgentExecutionStore(':memory:', {
+			attachmentStore: attachments,
+			externalBlobThreshold: 1,
+		});
+		const imageData = 'a'.repeat(600_000);
+		const data: SessionData = {
+			version: 5,
+			affinityKey: 'affinity-1',
+			entries: [
+				{
+					type: 'message',
+					id: 'entry-1',
+					parentId: null,
+					timestamp: '2026-06-03T00:00:00.000Z',
+					source: 'prompt',
+					message: {
+						role: 'user',
+						content: [{ type: 'image', data: imageData, mimeType: 'image/png' }],
+						timestamp: 0,
+					},
+				},
+			],
+			leafId: 'entry-1',
+			metadata: {},
+			createdAt: '2026-06-03T00:00:00.000Z',
+			updatedAt: '2026-06-03T00:00:00.000Z',
+		};
+
+		await store.sessions.save('s1', data);
+
+		expect([...attachments.objects.values()]).toEqual([imageData]);
+		await expect(store.sessions.load('s1')).resolves.toEqual(data);
+		const objectKey = [...attachments.objects.keys()][0]!;
+		await store.sessions.delete('s1');
+		expect(attachments.deleted).toEqual([objectKey]);
+	});
 });
 
 // ─── sqlite() PersistenceAdapter tests ──────────────────────────────────────

--- a/packages/runtime/test/build-plugin-cloudflare.test.ts
+++ b/packages/runtime/test/build-plugin-cloudflare.test.ts
@@ -26,6 +26,7 @@ describe('CloudflarePlugin', () => {
 		);
 
 		expect(entry).toContain('createCloudflareAgentRuntime');
+		expect(entry).toContain('createR2SessionAttachmentStore');
 		expect(entry).toContain('createSqlSessionStore');
 		expect(entry).toContain(
 			`constructor(ctx, env) {
@@ -41,7 +42,11 @@ describe('CloudflarePlugin', () => {
 		expect(entry).not.toContain('finishSessionDeletion');
 		expect(entry).toContain('const memoryWorkflowSessionStore = new InMemorySessionStore();');
 		expect(entry).toContain(
-			'const defaultStore = storage?.sql ? createSqlSessionStore(storage) : memoryWorkflowSessionStore;',
+			'const sessionAttachmentStore = createR2SessionAttachmentStore(env.FLUE_SESSION_ATTACHMENTS);',
+		);
+		expect(entry).toContain('sessionStoreOptions: { attachmentStore: sessionAttachmentStore },');
+		expect(entry).toContain(
+			'const defaultStore = storage?.sql ? createSqlSessionStore(storage, { attachmentStore: sessionAttachmentStore }) : memoryWorkflowSessionStore;',
 		);
 		expect(entry).toContain('createDurableRunStore(doInstance.ctx.storage.sql)');
 		expect(entry).toContain(': memoryRunStore;');

--- a/packages/runtime/test/cloudflare-agent-execution-store.test.ts
+++ b/packages/runtime/test/cloudflare-agent-execution-store.test.ts
@@ -435,6 +435,63 @@ describe('createSqlAgentExecutionStore()', () => {
 		);
 	});
 
+	it('queues external attachment cleanup when a later object upload fails', async () => {
+		const { db, sql, transactionSync } = makeFakeSql();
+		const attachments = new RecordingAttachmentStore();
+		let putCount = 0;
+		let failDelete = true;
+		attachments.put = async (key: string, data: string): Promise<void> => {
+			putCount++;
+			attachments.objects.set(key, data);
+			if (putCount === 2) throw new Error('r2 put failed');
+		};
+		attachments.delete = async (key: string): Promise<void> => {
+			attachments.deleted.push(key);
+			if (failDelete) throw new Error('r2 delete failed');
+			attachments.objects.delete(key);
+		};
+		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent', {
+			attachmentStore: attachments,
+			externalBlobThreshold: 1,
+		});
+		const data = sessionData({
+			entries: [
+				{
+					type: 'message',
+					id: 'entry-1',
+					parentId: null,
+					timestamp: '2026-06-03T00:00:00.000Z',
+					source: 'prompt',
+					message: {
+						role: 'user',
+						content: [
+							{ type: 'image', data: 'image-1', mimeType: 'image/png' },
+							{ type: 'image', data: 'image-2', mimeType: 'image/png' },
+						],
+						timestamp: 0,
+					},
+				},
+			],
+			leafId: 'entry-1',
+		});
+
+		await expect(store.sessions.save('s1', data)).rejects.toThrow('r2 put failed');
+
+		const queued = db
+			.prepare('SELECT object_key FROM flue_session_attachment_deletions ORDER BY object_key')
+			.all() as Array<{ object_key: string }>;
+		expect(queued).toHaveLength(2);
+		expect(attachments.objects.size).toBe(2);
+
+		failDelete = false;
+		await store.sessions.save('s2', sessionData());
+
+		expect(attachments.objects.size).toBe(0);
+		expect(db.prepare('SELECT object_key FROM flue_session_attachment_deletions').all()).toEqual(
+			[],
+		);
+	});
+
 	it('adapts an R2 bucket binding for session attachment storage', async () => {
 		const bucketObjects = new Map<string, string>();
 		const bucket = {
@@ -536,7 +593,61 @@ describe('createSqlAgentExecutionStore()', () => {
 		).toEqual({ is_not_null: 0 });
 	});
 
-	it('preserves user JSON with blob-ref-like keys when a session is saved', async () => {
+	it('rolls back session blob table migration when copying old rows fails', () => {
+		const { db, sql, transactionSync } = makeFakeSql();
+		db.prepare(
+			`CREATE TABLE flue_session_blobs (
+			 session_id TEXT NOT NULL,
+			 entry_id TEXT NOT NULL,
+			 blob_id TEXT NOT NULL,
+			 segment_index INTEGER NOT NULL,
+			 segment_count INTEGER NOT NULL,
+			 data TEXT NOT NULL,
+			 PRIMARY KEY (session_id, entry_id, blob_id, segment_index)
+			)`,
+		).run();
+		db.prepare(
+			`INSERT INTO flue_session_blobs
+			 (session_id, entry_id, blob_id, segment_index, segment_count, data)
+			 VALUES ('s1', 'entry-1', 'blob-1', 0, 1, 'image-data')`,
+		).run();
+		const failingSql = {
+			exec(query: string, ...bindings: unknown[]) {
+				if (
+					query.includes('INSERT INTO flue_session_blobs') &&
+					query.includes('flue_session_blobs_migration_old')
+				) {
+					throw new Error('copy failed');
+				}
+				return sql.exec(query, ...bindings);
+			},
+		};
+
+		expect(() =>
+			createSqlAgentExecutionStore({ sql: failingSql, transactionSync }, 'FlueAssistantAgent'),
+		).toThrow('copy failed');
+
+		expect(
+			db.prepare("SELECT name FROM pragma_table_info('flue_session_blobs') ORDER BY cid").all(),
+		).toEqual([
+			{ name: 'session_id' },
+			{ name: 'entry_id' },
+			{ name: 'blob_id' },
+			{ name: 'segment_index' },
+			{ name: 'segment_count' },
+			{ name: 'data' },
+		]);
+		expect(db.prepare('SELECT data FROM flue_session_blobs').get()).toEqual({
+			data: 'image-data',
+		});
+		expect(
+			db
+				.prepare("SELECT name FROM sqlite_schema WHERE name = 'flue_session_blobs_migration_old'")
+				.all(),
+		).toEqual([]);
+	});
+
+	it('preserves user JSON with blob-ref-like content outside message content when a session is saved', async () => {
 		const { sql, transactionSync } = makeFakeSql();
 		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent');
 		const data = sessionData({
@@ -548,7 +659,13 @@ describe('createSqlAgentExecutionStore()', () => {
 					timestamp: '2026-06-03T00:00:00.000Z',
 					fromId: 'entry-0',
 					summary: 'Preserve user details.',
-					details: { __flueSessionBlobRef: 'user-owned-value' },
+					details: {
+						type: 'image',
+						data: {
+							__flueSessionBlobRef: { type: 'flue.sessionBlob.v1', id: 'user-owned-id' },
+						},
+						mimeType: 'image/png',
+					},
 				},
 			],
 			leafId: 'entry-1',

--- a/packages/runtime/test/cloudflare-agent-execution-store.test.ts
+++ b/packages/runtime/test/cloudflare-agent-execution-store.test.ts
@@ -2,9 +2,11 @@ import { DatabaseSync } from 'node:sqlite';
 import { describe, expect, it } from 'vitest';
 import {
 	createSqlAgentExecutionStore,
+	createR2SessionAttachmentStore,
 	createSqlSessionStore,
 } from '../src/cloudflare/agent-execution-store.ts';
 import type { DispatchInput } from '../src/runtime/dispatch-queue.ts';
+import type { SessionAttachmentStore } from '../src/sql-agent-execution-store.ts';
 import type { SessionData } from '../src/types.ts';
 
 function makeFakeSql() {
@@ -76,6 +78,26 @@ function sessionData(overrides: Partial<SessionData> = {}): SessionData {
 	};
 }
 
+class RecordingAttachmentStore implements SessionAttachmentStore {
+	readonly objects = new Map<string, string>();
+	readonly deleted: string[] = [];
+
+	async put(key: string, data: string): Promise<void> {
+		this.objects.set(key, data);
+	}
+
+	async get(key: string): Promise<string> {
+		const data = this.objects.get(key);
+		if (data === undefined) throw new Error(`missing object ${key}`);
+		return data;
+	}
+
+	async delete(key: string): Promise<void> {
+		this.deleted.push(key);
+		this.objects.delete(key);
+	}
+}
+
 describe('createSqlAgentExecutionStore()', () => {
 	it('creates the initial flue_agent_submissions schema and ordering indexes when initialized', () => {
 		const { db, sql, transactionSync } = makeFakeSql();
@@ -134,6 +156,7 @@ describe('createSqlAgentExecutionStore()', () => {
 			{ name: 'flue_agent_stream_chunks' },
 			{ name: 'flue_agent_submissions' },
 			{ name: 'flue_agent_turn_journals' },
+			{ name: 'flue_session_attachment_deletions' },
 			{ name: 'flue_session_blobs' },
 			{ name: 'flue_session_entries' },
 			{ name: 'flue_sessions' },
@@ -305,6 +328,138 @@ describe('createSqlAgentExecutionStore()', () => {
 		});
 	});
 
+	it('stores large image content in an external attachment store when configured', async () => {
+		const { db, sql, transactionSync } = makeFakeSql();
+		const attachments = new RecordingAttachmentStore();
+		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent', {
+			attachmentStore: attachments,
+			externalBlobThreshold: 1,
+		});
+		const imageData = 'a'.repeat(600_000);
+		const data = sessionData({
+			entries: [
+				{
+					type: 'message',
+					id: 'entry-1',
+					parentId: null,
+					timestamp: '2026-06-03T00:00:00.000Z',
+					source: 'prompt',
+					message: {
+						role: 'user',
+						content: [
+							{ type: 'text', text: 'Describe this image.' },
+							{ type: 'image', data: imageData, mimeType: 'image/png' },
+						],
+						timestamp: 0,
+					},
+				},
+			],
+			leafId: 'entry-1',
+		});
+
+		await store.sessions.save('s1', data);
+
+		const blobRow = db
+			.prepare(
+				`SELECT storage_kind, object_key, data
+				 FROM flue_session_blobs
+				 WHERE session_id = ?`,
+			)
+			.get('s1') as { storage_kind: string; object_key: string; data: string | null };
+		const entryRow = db
+			.prepare('SELECT data FROM flue_session_entries WHERE session_id = ?')
+			.get('s1') as { data: string };
+
+		expect(blobRow.storage_kind).toBe('external');
+		expect(blobRow.object_key).toMatch(/^flue-sessions\//);
+		expect(blobRow.data).toBeNull();
+		expect(attachments.objects.get(blobRow.object_key)).toBe(imageData);
+		expect(entryRow.data).toContain('__flueSessionBlobRef');
+		expect(entryRow.data).not.toContain(imageData);
+		await expect(store.sessions.load('s1')).resolves.toEqual(data);
+
+		await store.sessions.delete('s1');
+
+		expect(attachments.objects.has(blobRow.object_key)).toBe(false);
+		expect(attachments.deleted).toEqual([blobRow.object_key]);
+	});
+
+	it('retries external attachment cleanup when object deletion fails', async () => {
+		const { db, sql, transactionSync } = makeFakeSql();
+		const attachments = new RecordingAttachmentStore();
+		let failDelete = true;
+		attachments.delete = async (key: string): Promise<void> => {
+			attachments.deleted.push(key);
+			if (failDelete) throw new Error('r2 unavailable');
+			attachments.objects.delete(key);
+		};
+		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent', {
+			attachmentStore: attachments,
+			externalBlobThreshold: 1,
+		});
+		const data = sessionData({
+			entries: [
+				{
+					type: 'message',
+					id: 'entry-1',
+					parentId: null,
+					timestamp: '2026-06-03T00:00:00.000Z',
+					source: 'prompt',
+					message: {
+						role: 'user',
+						content: [{ type: 'image', data: 'image-data', mimeType: 'image/png' }],
+						timestamp: 0,
+					},
+				},
+			],
+			leafId: 'entry-1',
+		});
+
+		await store.sessions.save('s1', data);
+		const objectKey = db
+			.prepare('SELECT object_key FROM flue_session_blobs WHERE session_id = ?')
+			.get('s1') as { object_key: string };
+		await store.sessions.delete('s1');
+
+		expect(attachments.objects.has(objectKey.object_key)).toBe(true);
+		expect(db.prepare('SELECT object_key FROM flue_session_attachment_deletions').all()).toEqual([
+			{ object_key: objectKey.object_key },
+		]);
+
+		failDelete = false;
+		await store.sessions.save('s2', sessionData());
+
+		expect(attachments.objects.has(objectKey.object_key)).toBe(false);
+		expect(db.prepare('SELECT object_key FROM flue_session_attachment_deletions').all()).toEqual(
+			[],
+		);
+	});
+
+	it('adapts an R2 bucket binding for session attachment storage', async () => {
+		const bucketObjects = new Map<string, string>();
+		const bucket = {
+			async put(key: string, value: string): Promise<void> {
+				bucketObjects.set(key, value);
+			},
+			async get(key: string): Promise<{ text(): Promise<string> } | null> {
+				const value = bucketObjects.get(key);
+				return value === undefined ? null : { text: async () => value };
+			},
+			async delete(key: string): Promise<void> {
+				bucketObjects.delete(key);
+			},
+		};
+		const store = createR2SessionAttachmentStore(bucket)!;
+
+		await store.put('object-key', 'image-data');
+
+		expect(await store.get('object-key')).toBe('image-data');
+		await store.delete('object-key');
+		await expect(store.get('object-key')).rejects.toThrow(
+			'[flue] Persisted session attachment object is missing.',
+		);
+	});
+
 	it('loads legacy session rows when entries still live in flue_sessions', async () => {
 		const { db, sql, transactionSync } = makeFakeSql();
 		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent');
@@ -321,13 +476,64 @@ describe('createSqlAgentExecutionStore()', () => {
 			],
 			leafId: 'entry-1',
 		});
-		db.prepare('INSERT INTO flue_sessions (id, data, updated_at) VALUES (?, ?, ?)').run(
+		db.prepare('INSERT INTO flue_sessions (id, data) VALUES (?, ?)').run(
 			'legacy',
 			JSON.stringify(data),
-			1,
 		);
 
 		await expect(store.sessions.load('legacy')).resolves.toEqual(data);
+	});
+
+	it('migrates existing SQL chunk blob tables when session persistence is initialized', async () => {
+		const { db, sql, transactionSync } = makeFakeSql();
+		db.prepare(
+			`CREATE TABLE flue_sessions (
+			 id TEXT PRIMARY KEY,
+			 data TEXT NOT NULL
+			)`,
+		).run();
+		db.prepare(
+			`CREATE TABLE flue_session_entries (
+			 session_id TEXT NOT NULL,
+			 entry_id TEXT NOT NULL,
+			 position INTEGER NOT NULL,
+			 data TEXT NOT NULL,
+			 PRIMARY KEY (session_id, entry_id)
+			)`,
+		).run();
+		db.prepare(
+			`CREATE TABLE flue_session_blobs (
+			 session_id TEXT NOT NULL,
+			 entry_id TEXT NOT NULL,
+			 blob_id TEXT NOT NULL,
+			 segment_index INTEGER NOT NULL,
+			 segment_count INTEGER NOT NULL,
+			 data TEXT NOT NULL,
+			 PRIMARY KEY (session_id, entry_id, blob_id, segment_index)
+			)`,
+		).run();
+
+		createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent');
+
+		expect(
+			db.prepare("SELECT name FROM pragma_table_info('flue_session_blobs') ORDER BY cid").all(),
+		).toEqual([
+			{ name: 'session_id' },
+			{ name: 'entry_id' },
+			{ name: 'blob_id' },
+			{ name: 'storage_kind' },
+			{ name: 'object_key' },
+			{ name: 'segment_index' },
+			{ name: 'segment_count' },
+			{ name: 'data' },
+		]);
+		expect(
+			db
+				.prepare(
+					"SELECT \"notnull\" AS is_not_null FROM pragma_table_info('flue_session_blobs') WHERE name = 'data'",
+				)
+				.get(),
+		).toEqual({ is_not_null: 0 });
 	});
 
 	it('preserves user JSON with blob-ref-like keys when a session is saved', async () => {
@@ -388,6 +594,7 @@ describe('createSqlSessionStore()', () => {
 		expect(
 			db.prepare("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name").all(),
 		).toEqual([
+			{ name: 'flue_session_attachment_deletions' },
 			{ name: 'flue_session_blobs' },
 			{ name: 'flue_session_entries' },
 			{ name: 'flue_sessions' },

--- a/packages/runtime/test/cloudflare-agent-execution-store.test.ts
+++ b/packages/runtime/test/cloudflare-agent-execution-store.test.ts
@@ -5,6 +5,7 @@ import {
 	createSqlSessionStore,
 } from '../src/cloudflare/agent-execution-store.ts';
 import type { DispatchInput } from '../src/runtime/dispatch-queue.ts';
+import type { SessionData } from '../src/types.ts';
 
 function makeFakeSql() {
 	const db = new DatabaseSync(':memory:');
@@ -27,7 +28,9 @@ function makeFakeSql() {
 				let rows: unknown[];
 				const trimmed = query.trimStart().toUpperCase();
 				const expectsRows =
-					trimmed.startsWith('SELECT') || trimmed.startsWith('WITH') || /\bRETURNING\b/i.test(query);
+					trimmed.startsWith('SELECT') ||
+					trimmed.startsWith('WITH') ||
+					/\bRETURNING\b/i.test(query);
 				if (expectsRows) {
 					rows = stmt.all(...(bindings as never[]));
 				} else {
@@ -60,6 +63,19 @@ function attempt(submissionId: string, attemptId: string) {
 	return { submissionId, attemptId };
 }
 
+function sessionData(overrides: Partial<SessionData> = {}): SessionData {
+	return {
+		version: 5,
+		affinityKey: 'aff_01J00000000000000000000000',
+		entries: [],
+		leafId: null,
+		metadata: {},
+		createdAt: '2026-06-03T00:00:00.000Z',
+		updatedAt: '2026-06-03T00:00:00.000Z',
+		...overrides,
+	};
+}
+
 describe('createSqlAgentExecutionStore()', () => {
 	it('creates the initial flue_agent_submissions schema and ordering indexes when initialized', () => {
 		const { db, sql, transactionSync } = makeFakeSql();
@@ -89,7 +105,9 @@ describe('createSqlAgentExecutionStore()', () => {
 			{ name: 'lease_expires_at' },
 		]);
 		expect(
-			db.prepare("SELECT name FROM pragma_table_info('flue_agent_turn_journals') ORDER BY cid").all(),
+			db
+				.prepare("SELECT name FROM pragma_table_info('flue_agent_turn_journals') ORDER BY cid")
+				.all(),
 		).toEqual([
 			{ name: 'submission_id' },
 			{ name: 'session_key' },
@@ -109,23 +127,21 @@ describe('createSqlAgentExecutionStore()', () => {
 			{ name: 'committed_leaf_id' },
 		]);
 		expect(
-			db
-			.prepare("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name")
-			.all(),
+			db.prepare("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name").all(),
 		).toEqual([
 			{ name: 'flue_agent_dispatch_receipts' },
 			{ name: 'flue_agent_session_deletions' },
 			{ name: 'flue_agent_stream_chunks' },
 			{ name: 'flue_agent_submissions' },
 			{ name: 'flue_agent_turn_journals' },
+			{ name: 'flue_session_blobs' },
 			{ name: 'flue_session_entries' },
 			{ name: 'flue_sessions' },
 			{ name: 'sqlite_sequence' },
 		]);
 		expect(
 			db
-			.prepare(
-	
+				.prepare(
 					"SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'flue_agent_submissions' ORDER BY name",
 				)
 				.all(),
@@ -140,18 +156,14 @@ describe('createSqlAgentExecutionStore()', () => {
 					"SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'flue_agent_dispatch_receipts' ORDER BY name",
 				)
 				.all(),
-		).toEqual([
-			{ name: 'sqlite_autoindex_flue_agent_dispatch_receipts_1' },
-		]);
+		).toEqual([{ name: 'sqlite_autoindex_flue_agent_dispatch_receipts_1' }]);
 		expect(
 			db
 				.prepare(
 					"SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'flue_agent_turn_journals' ORDER BY name",
 				)
 				.all(),
-		).toEqual([
-			{ name: 'sqlite_autoindex_flue_agent_turn_journals_1' },
-		]);
+		).toEqual([{ name: 'sqlite_autoindex_flue_agent_turn_journals_1' }]);
 	});
 
 	it('ensures only one SQL row per replayed dispatch admission', async () => {
@@ -190,10 +202,9 @@ describe('createSqlAgentExecutionStore()', () => {
 		const { db, sql, transactionSync } = makeFakeSql();
 		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent');
 		await store.submissions.admitDispatch(dispatchInput());
-		db.prepare('UPDATE flue_agent_submissions SET input_applied_at = ? WHERE submission_id = ?').run(
-			1,
-			'dispatch-1',
-		);
+		db.prepare(
+			'UPDATE flue_agent_submissions SET input_applied_at = ? WHERE submission_id = ?',
+		).run(1, 'dispatch-1');
 
 		expect(await store.submissions.listRunnableSubmissions()).toEqual([]);
 		expect(await store.submissions.getSubmission('dispatch-1')).toMatchObject({
@@ -207,19 +218,139 @@ describe('createSqlAgentExecutionStore()', () => {
 		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent');
 		const sessionKey = 'agent-session:["agent-1","default","default"]';
 		await store.submissions.admitDispatch(dispatchInput());
-		await store.submissions.claimSubmission({ ...attempt('dispatch-1', 'attempt-1'), ownerId: 'test-owner', leaseExpiresAt: Date.now() + 30_000 });
+		await store.submissions.claimSubmission({
+			...attempt('dispatch-1', 'attempt-1'),
+			ownerId: 'test-owner',
+			leaseExpiresAt: Date.now() + 30_000,
+		});
 		await store.submissions.completeSubmission(attempt('dispatch-1', 'attempt-1'));
 
 		await store.submissions.deleteSession(sessionKey, async () => {});
 
 		expect(
-			db.prepare('SELECT dispatch_id, accepted_at FROM flue_agent_dispatch_receipts WHERE dispatch_id = ?').get(
-				'dispatch-1',
-			),
+			db
+				.prepare(
+					'SELECT dispatch_id, accepted_at FROM flue_agent_dispatch_receipts WHERE dispatch_id = ?',
+				)
+				.get('dispatch-1'),
 		).toEqual({
 			dispatch_id: 'dispatch-1',
 			accepted_at: Date.parse('2026-06-03T00:00:00.000Z'),
 		});
+	});
+
+	it('stores session entries separately and chunks image content when a session is saved', async () => {
+		const { db, sql, transactionSync } = makeFakeSql();
+		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent');
+		const imageData = 'a'.repeat(600_000);
+		const data = sessionData({
+			entries: [
+				{
+					type: 'message',
+					id: 'entry-1',
+					parentId: null,
+					timestamp: '2026-06-03T00:00:00.000Z',
+					source: 'prompt',
+					message: {
+						role: 'user',
+						content: [
+							{ type: 'text', text: 'Describe this image.' },
+							{ type: 'image', data: imageData, mimeType: 'image/png' },
+						],
+						timestamp: 0,
+					},
+				},
+			],
+			leafId: 'entry-1',
+		});
+
+		await store.sessions.save('s1', data);
+
+		const sessionRow = db.prepare('SELECT data FROM flue_sessions WHERE id = ?').get('s1') as {
+			data: string;
+		};
+		const entryRows = db
+			.prepare('SELECT data FROM flue_session_entries WHERE session_id = ?')
+			.all('s1') as Array<{ data: string }>;
+		const blobRows = db
+			.prepare(
+				'SELECT data FROM flue_session_blobs WHERE session_id = ? ORDER BY segment_index ASC',
+			)
+			.all('s1') as Array<{ data: string }>;
+
+		expect(JSON.parse(sessionRow.data)).not.toHaveProperty('entries');
+		expect(sessionRow.data).not.toContain(imageData);
+		expect(entryRows).toHaveLength(1);
+		expect(entryRows[0]!.data).toContain('__flueSessionBlobRef');
+		expect(entryRows[0]!.data).not.toContain(imageData);
+		expect(blobRows.length).toBeGreaterThan(1);
+		expect(blobRows.map((row) => row.data).join('')).toBe(imageData);
+		await expect(store.sessions.load('s1')).resolves.toEqual(data);
+
+		db.prepare(
+			'DELETE FROM flue_session_blobs WHERE session_id = ? AND entry_id = ? AND blob_id = ? AND segment_index = ?',
+		).run('s1', 'entry-1', 'blob_0', 1);
+		await expect(store.sessions.load('s1')).rejects.toThrow(
+			'[flue] Persisted session blob row is malformed.',
+		);
+
+		await store.sessions.delete('s1');
+
+		expect(db.prepare('SELECT COUNT(*) AS count FROM flue_sessions').get()).toEqual({ count: 0 });
+		expect(db.prepare('SELECT COUNT(*) AS count FROM flue_session_entries').get()).toEqual({
+			count: 0,
+		});
+		expect(db.prepare('SELECT COUNT(*) AS count FROM flue_session_blobs').get()).toEqual({
+			count: 0,
+		});
+	});
+
+	it('loads legacy session rows when entries still live in flue_sessions', async () => {
+		const { db, sql, transactionSync } = makeFakeSql();
+		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent');
+		const data = sessionData({
+			entries: [
+				{
+					type: 'message',
+					id: 'entry-1',
+					parentId: null,
+					timestamp: '2026-06-03T00:00:00.000Z',
+					source: 'prompt',
+					message: { role: 'user', content: 'Hello', timestamp: 0 },
+				},
+			],
+			leafId: 'entry-1',
+		});
+		db.prepare('INSERT INTO flue_sessions (id, data, updated_at) VALUES (?, ?, ?)').run(
+			'legacy',
+			JSON.stringify(data),
+			1,
+		);
+
+		await expect(store.sessions.load('legacy')).resolves.toEqual(data);
+	});
+
+	it('preserves user JSON with blob-ref-like keys when a session is saved', async () => {
+		const { sql, transactionSync } = makeFakeSql();
+		const store = createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent');
+		const data = sessionData({
+			entries: [
+				{
+					type: 'branch_summary',
+					id: 'entry-1',
+					parentId: null,
+					timestamp: '2026-06-03T00:00:00.000Z',
+					fromId: 'entry-0',
+					summary: 'Preserve user details.',
+					details: { __flueSessionBlobRef: 'user-owned-value' },
+				},
+			],
+			leafId: 'entry-1',
+		});
+
+		await store.sessions.save('s1', data);
+
+		await expect(store.sessions.load('s1')).resolves.toEqual(data);
 	});
 
 	it('rejects missing Durable Object SQLite with migration guidance', () => {
@@ -240,7 +371,9 @@ describe('createSqlAgentExecutionStore()', () => {
 		const { sql, transactionSync } = makeFakeSql();
 		sql.exec('CREATE TABLE flue_agent_submissions (sequence INTEGER PRIMARY KEY AUTOINCREMENT)');
 
-		expect(() => createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent')).toThrow(
+		expect(() =>
+			createSqlAgentExecutionStore({ sql, transactionSync }, 'FlueAssistantAgent'),
+		).toThrow(
 			'[flue] Cloudflare durable agent class "FlueAssistantAgent" could not initialize its SQLite execution store. Underlying error: no such column: status',
 		);
 	});
@@ -254,7 +387,11 @@ describe('createSqlSessionStore()', () => {
 
 		expect(
 			db.prepare("SELECT name FROM sqlite_schema WHERE type = 'table' ORDER BY name").all(),
-		).toEqual([{ name: 'flue_session_entries' }, { name: 'flue_sessions' }]);
+		).toEqual([
+			{ name: 'flue_session_blobs' },
+			{ name: 'flue_session_entries' },
+			{ name: 'flue_sessions' },
+		]);
 		expect(
 			db.prepare("SELECT name FROM pragma_table_info('flue_sessions') ORDER BY cid").all(),
 		).toEqual([{ name: 'id' }, { name: 'data' }]);


### PR DESCRIPTION
Builds on the session-entry storage added in `main` by moving large inline session payloads out of each entry JSON row.

## Summary

- Stores image/blob/document/file payloads in `flue_session_blobs` instead of inline in `flue_session_entries.data`.
- Chunks blob data in SQL by default, so built-in Node SQLite and Cloudflare Durable Object SQLite avoid oversized cells without extra configuration.
- Adds `SessionAttachmentStore` for optional external blob storage.
- Wires Cloudflare to use an R2 binding named `FLUE_SESSION_ATTACHMENTS` when present.
- Exposes the same attachment-store option from the Node SQLite adapter for filesystem, S3-compatible, or application-provided stores.
- Keeps SQL as the authoritative manifest for blob references and cleanup state.
- Adds retry tracking for failed external object deletes.
- Adds schema migration handling for intermediate `flue_session_blobs` schemas.

## Behavior

Without external attachment storage, blobs remain in SQL chunk rows.

On Cloudflare, defining an R2 binding named `FLUE_SESSION_ATTACHMENTS` stores large blobs externally in R2. Without that binding, Cloudflare falls back to SQL chunk rows.

On Node SQLite, callers can pass a custom `attachmentStore`; otherwise Node keeps using SQL chunk rows.

Fixes https://github.com/withastro/flue/issues/240