### PR TITLE
fix: resolve packaged skill imports

### DIFF
--- a/packages/cli/src/lib/vite-skill-reference-plugin.ts
+++ b/packages/cli/src/lib/vite-skill-reference-plugin.ts
@@ -54,9 +54,12 @@ export function skillReferencePlugin(options: SkillReferencePluginOptions): Plug
 			if (declarations.length === 0) return null;
 			let transformed = parseableCode;
 			for (const declaration of declarations.sort((a, b) => b.start - a.start)) {
-				const authoredPath = path.resolve(path.dirname(importerPath), declaration.specifier);
-				assertPackagedSkillPath(authoredPath, projectRoot);
-				const resolvedPath = canonicalPath(authoredPath);
+				const resolvedPath = await resolveSkillImport.call(
+					this,
+					declaration.specifier,
+					importerPath,
+					projectRoot,
+				);
 				const skillModuleId = `${internalSkillModulePrefix}${resolvedPath}`;
 				transformed = `${transformed.slice(0, declaration.start)}${JSON.stringify(skillModuleId)}${transformed.slice(declaration.end)}`;
 			}
@@ -191,27 +194,62 @@ async function readSkillMetadata(
 	projectRoot: string,
 ): Promise<Omit<PackagedSkillDirectory, 'files'>> {
 	const directory = path.dirname(skillPath);
-	const relativeDirectory = stableProjectRelativePath(directory, projectRoot);
+	const identityPath = stableSkillIdentityPath(directory, projectRoot);
 	const raw = await fs.promises.readFile(skillPath, 'utf8');
 	const parsed = parseSkillMarkdown(raw, {
 		directoryName: path.basename(directory),
 		path: skillPath,
 	});
 	return {
-		id: `skill:${parsed.name}:${createHash('sha256').update(relativeDirectory).digest('hex').slice(0, 16)}`,
+		id: `skill:${parsed.name}:${createHash('sha256').update(identityPath).digest('hex').slice(0, 16)}`,
 		name: parsed.name,
 		description: parsed.description,
 	};
 }
 
-function stableProjectRelativePath(directory: string, projectRoot: string): string {
-	const relativePath = normalizePath(path.relative(projectRoot, canonicalPath(directory)));
-	if (relativePath === '' || relativePath === '..' || relativePath.startsWith('../')) {
-		throw new Error(
-			`[flue] Imported skill directory "${directory}" must be inside project root "${projectRoot}" so it can be packaged with a stable identity.`,
-		);
+async function resolveSkillImport(
+	this: PluginContext,
+	specifier: string,
+	importerPath: string,
+	projectRoot: string,
+): Promise<string> {
+	if (isRelativeSpecifier(specifier)) {
+		const authoredPath = path.resolve(path.dirname(importerPath), specifier);
+		assertPackagedSkillPath(authoredPath, projectRoot);
+		return canonicalPath(authoredPath);
 	}
-	return relativePath;
+
+	const resolved = await this.resolve(specifier, importerPath, { skipSelf: true });
+	if (!resolved) {
+		throw new Error(`[flue] Unable to resolve skill import "${specifier}" from "${importerPath}".`);
+	}
+
+	const resolvedPath = canonicalPath(resolved.id.split(/[?#]/, 1)[0] ?? resolved.id);
+	if (!isSkillMarkdownPath(resolvedPath)) {
+		throw new Error(`[flue] Skill imports must target a SKILL.md file: ${specifier}`);
+	}
+	return resolvedPath;
+}
+
+function stableSkillIdentityPath(directory: string, projectRoot: string): string {
+	const relativePath = normalizePath(path.relative(projectRoot, canonicalPath(directory)));
+	if (relativePath !== '' && relativePath !== '..' && !relativePath.startsWith('../')) {
+		return `project:${relativePath}`;
+	}
+
+	const packageRoot = findPackageRoot(directory);
+	if (packageRoot) {
+		const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8')) as {
+			name?: unknown;
+			version?: unknown;
+		};
+		const packageName = typeof pkg.name === 'string' && pkg.name ? pkg.name : packageRoot;
+		const packageVersion = typeof pkg.version === 'string' && pkg.version ? pkg.version : '';
+		const packageRelativePath = normalizePath(path.relative(packageRoot, directory));
+		return `package:${packageName}@${packageVersion}:${packageRelativePath}`;
+	}
+
+	return `external:${canonicalPath(directory)}`;
 }
 
 function assertPackagedSkillPath(skillPath: string, projectRoot: string): void {
@@ -244,6 +282,19 @@ function canonicalPath(filePath: string): string {
 		unresolvedPath = parentPath;
 	}
 	return normalizePath(path.join(fs.realpathSync.native(unresolvedPath), ...suffixes));
+}
+
+function findPackageRoot(directory: string): string | undefined {
+	let currentPath = canonicalPath(directory);
+	while (currentPath !== path.dirname(currentPath)) {
+		if (fs.existsSync(path.join(currentPath, 'package.json'))) return currentPath;
+		currentPath = path.dirname(currentPath);
+	}
+	return undefined;
+}
+
+function isRelativeSpecifier(specifier: string): boolean {
+	return specifier.startsWith('.') || specifier.startsWith('/');
 }
 
 function isWithinDirectory(filePath: string, directory: string): boolean {
@@ -346,6 +397,14 @@ function isSkillMarkdownPath(specifier: string): boolean {
 
 interface ModuleAst {
 	body: unknown[];
+}
+
+interface PluginContext {
+	resolve(
+		source: string,
+		importer?: string,
+		options?: { skipSelf?: boolean },
+	): Promise<{ id: string } | null>;
 }
 
 interface AstNode {

--- a/packages/runtime/test/build-skill-imports.test.ts
+++ b/packages/runtime/test/build-skill-imports.test.ts
@@ -1,0 +1,80 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { build } from '../../cli/src/lib/build.ts';
+
+const fixtureRoots: string[] = [];
+const repositoryRoot = path.resolve(import.meta.dirname, '../../..');
+
+afterEach(() => {
+	for (const root of fixtureRoots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+describe('skill package imports', () => {
+	it('packages a skill imported from a symlinked dependency when building for node', async () => {
+		const root = createFixtureRoot();
+		writeDependencySkillPackage(root);
+		writeAgentImportingDependencySkill(root);
+
+		await build({
+			root,
+			sourceRoot: root,
+			output: path.join(root, 'dist'),
+			target: 'node',
+		});
+
+		const server = fs.readFileSync(path.join(root, 'dist', 'server.mjs'), 'utf8');
+		expect(server).toContain('Review package changes.');
+	});
+});
+
+function createFixtureRoot(): string {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'flue-skill-imports-'));
+	fixtureRoots.push(root);
+	const flueScope = path.join(root, 'node_modules', '@flue');
+	fs.mkdirSync(flueScope, { recursive: true });
+	fs.symlinkSync(path.join(repositoryRoot, 'packages', 'runtime'), path.join(flueScope, 'runtime'), 'dir');
+	fs.writeFileSync(
+		path.join(root, 'package.json'),
+		JSON.stringify({ type: 'module', dependencies: { '@flue/runtime': 'workspace:*' } }),
+	);
+	return root;
+}
+
+function writeDependencySkillPackage(root: string): void {
+	const packageRoot = path.join(root, 'packages', 'review-skills');
+	fs.mkdirSync(path.join(packageRoot, 'skills', 'review'), { recursive: true });
+	fs.writeFileSync(
+		path.join(packageRoot, 'package.json'),
+		JSON.stringify({
+			name: '@acme/review-skills',
+			version: '1.0.0',
+			type: 'module',
+			exports: { './skills/review/SKILL.md': './skills/review/SKILL.md' },
+		}),
+	);
+	fs.writeFileSync(
+		path.join(packageRoot, 'skills', 'review', 'SKILL.md'),
+		'---\nname: review\ndescription: Review package changes.\n---\nInspect the imported package skill.',
+	);
+
+	const acmeScope = path.join(root, 'node_modules', '@acme');
+	fs.mkdirSync(acmeScope, { recursive: true });
+	fs.symlinkSync(packageRoot, path.join(acmeScope, 'review-skills'), 'dir');
+}
+
+function writeAgentImportingDependencySkill(root: string): void {
+	fs.mkdirSync(path.join(root, 'agents'), { recursive: true });
+	fs.writeFileSync(
+		path.join(root, 'agents', 'assistant.mjs'),
+		`import { createAgent } from '@flue/runtime';
+import review from '@acme/review-skills/skills/review/SKILL.md' with { type: 'skill' };
+
+export default createAgent(() => ({
+	model: 'anthropic/claude-haiku-4-5',
+	skills: [review],
+}));
+`,
+	);
+}


### PR DESCRIPTION
Fixes #230.\n\nThis updates the skill reference Vite plugin so bare SKILL.md specifiers are resolved through Vite/module resolution instead of being treated as project-relative paths. Relative and absolute skill imports still keep the existing project-root containment checks, while dependency imports can resolve through package-manager layouts such as symlinked workspace packages.\n\nThe packaged skill identity now uses a package-based stable path for dependency imports, so reusable skill packages can be bundled without depending on the consumer project's relative path.\n\nVerification:\n\n- npx pnpm@11.1.1 --dir packages/runtime exec vitest run test/build-skill-imports.test.ts\n- npx pnpm@11.1.1 exec biome check packages/cli/src/lib/vite-skill-reference-plugin.ts packages/runtime/test/build-skill-imports.test.ts\n- npx pnpm@11.1.1 --dir packages/cli run check:types\n- npx pnpm@11.1.1 --dir packages/runtime run check:types\n\nNote: I also ran npx pnpm@11.1.1 --dir packages/cli test locally. The CLI build completed and 15/16 node:test cases passed; the existing dev-server watcher test timed out waiting for a generated dist-ts/server.mjs file in this local environment (Node v22.17.0, while package engines warn for >=22.18.0).