### PR TITLE
Clarify Cloudflare model and routing docs

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/deploy/cloudflare.md
+++ b/apps/docs/src/content/docs/ecosystem/deploy/cloudflare.md
@@ -93,6 +93,23 @@ npx wrangler deploy
 
 `flue build --target cloudflare` compiles your project into a `./dist` directory containing a Cloudflare Workers-compatible artifact. `wrangler deploy` pushes it live.
 
+### Serving assets from the same Worker
+
+Workers static assets are served before your Worker script unless `assets.run_worker_first` says otherwise. If a single Worker serves a front-end build and application routes that invoke Flue, include every application-owned API prefix and every mounted Flue prefix in `run_worker_first` so those requests reach Hono instead of the asset handler or SPA fallback:
+
+```jsonc title="wrangler.jsonc"
+{
+  "assets": {
+    "directory": "./dist/client",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/api/*", "/_flue/*"],
+  },
+}
+```
+
+Adjust the prefixes to match where your `app.ts` mounts public routes and `flue()`. If Flue is mounted at `/api`, include `/api/*`; if your application mounts Flue at a private internal prefix, include that prefix too and protect it with middleware.
+
 ### 5. Add your API key
 
 For local Cloudflare development, put provider API keys in `.dev.vars` beside your Wrangler configuration:

--- a/apps/docs/src/content/docs/guide/models.md
+++ b/apps/docs/src/content/docs/guide/models.md
@@ -18,6 +18,7 @@ A model specifier is the unique string Flue uses to refer to a specific model ac
 | `openai/gpt-5.5`                      | `openai`     | `gpt-5.5`                  |
 | `openrouter/moonshotai/kimi-k2.6`     | `openrouter` | `moonshotai/kimi-k2.6`     |
 | `cloudflare/@cf/moonshotai/kimi-k2.6` | `cloudflare` | `@cf/moonshotai/kimi-k2.6` |
+| `cloudflare/openai/gpt-5.5`           | `cloudflare` | `openai/gpt-5.5`           |
 
 Use a model specifier to choose an agent's default model:
 
@@ -154,6 +155,8 @@ Choose a new provider ID unless you intend to override a built-in connection pat
 ## Cloudflare Workers AI (Cloudflare only)
 
 For applications built with `--target cloudflare`, Flue provides the `cloudflare/...` provider ID for running model calls through a [Workers AI](https://developers.cloudflare.com/workers-ai/) binding. This path uses the binding attached to your Worker rather than URL-backed provider credentials.
+
+Everything after `cloudflare/` is passed as the model ID to `env.AI.run(...)`. Use Workers AI model IDs such as `@cf/moonshotai/kimi-k2.6`, or a binding-supported AI Gateway model ID such as `openai/gpt-5.5` when your Worker should reach that model through Cloudflare's binding and gateway path. Use `openai/gpt-5.5` without the `cloudflare/` prefix only when you intend to use Flue's direct OpenAI provider and its credentials.
 
 ```ts title="src/agents/assistant.ts"
 import { createAgent } from '@flue/runtime';

--- a/apps/docs/src/content/docs/guide/workflows.md
+++ b/apps/docs/src/content/docs/guide/workflows.md
@@ -38,6 +38,8 @@ In this example:
 
 A workflow can contain ordinary TypeScript logic before, between, or after agent operations: load application data, branch on input, log progress, or transform a response before returning it. Configure the agent's model, instructions, tools, skills, and sandbox through `createAgent(...)`, as you would for an addressable agent.
 
+Prefer `init(agent)` and `session.prompt(...)` for model-backed work inside a workflow, even when the workflow only makes one model call. Calling a provider binding or SDK directly bypasses Flue's model resolution, tools, skills, sandbox configuration, operation events, and response handling.
+
 See [Project Layout](/docs/guide/project-layout/) for supported source layouts, [Models & Providers](/docs/guide/models/) for model configuration, and [Agents](/docs/guide/building-agents/) for agent configuration concepts.
 
 ## Running a workflow


### PR DESCRIPTION
Clarify a few Cloudflare and workflow docs gaps that came up while wiring a real Flue-backed app.

The confusing parts were whether a workflow should call model providers directly, which model specifier keeps Cloudflare binding behavior, and what Wrangler asset routing needs when Flue shares a Worker with a front end.

- Recommend `init(agent)` and `session.prompt(...)` inside workflows instead of direct provider calls.
- Clarify `cloudflare/...` model IDs and the direct-provider vs. binding-backed distinction.
- Add `assets.run_worker_first` guidance for same-Worker front ends and Flue/API prefixes.

Verified with `pnpm --dir apps/docs run build`.