### PR TITLE
feat(runtime): allow custom tools to return image content

### DIFF
--- a/apps/docs/src/content/docs/api/agent-api.md
+++ b/apps/docs/src/content/docs/api/agent-api.md
@@ -53,7 +53,9 @@ import {
   type ThinkingLevel,
   type ToolArgs,
   type ToolDefinition,
+  type ToolExecuteResult,
   type ToolParameters,
+  type ToolResultContent,
   type ToolValidationIssue,
 } from '@flue/runtime';
 ```
@@ -130,7 +132,9 @@ Valibot `parameters` are converted to plain JSON Schema once at definition time,
 | `name`        | `string`                                                             | Tool name. Must be unique across active built-in and custom tools.                                                                          |
 | `description` | `string`                                                             | Tells the model when and how to use this tool.                                                                                              |
 | `parameters`  | `ToolParameters`                                                     | Valibot object schema (`v.object({ ... })`), or a raw JSON Schema object for schemas produced elsewhere (e.g. MCP).                         |
-| `execute`     | `(args: ToolArgs<TParams>, signal?: AbortSignal) => Promise<string>` | Receives the parsed, typed arguments (the schema's `v.InferOutput`). Returns text sent back to the model. Thrown errors become tool errors. |
+| `execute`     | `(args: ToolArgs<TParams>, signal?: AbortSignal) => Promise<ToolExecuteResult>` | Receives the parsed, typed arguments (the schema's `v.InferOutput`). Returns text or text/image content sent back to the model. Thrown errors become tool errors. |
+
+`ToolExecuteResult` is `string | ToolResultContent[]`; `ToolResultContent` is a text or image content block. Image blocks use `{ type: 'image', data: '<base64>', mimeType: 'image/png' }`, and require a vision-capable model to be useful in the following model turn.
 
 ```ts
 import { defineTool } from '@flue/runtime';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -104,7 +104,9 @@ export type {
 	ThinkingLevel,
 	ToolArgs,
 	ToolDefinition,
+	ToolExecuteResult,
 	ToolParameters,
+	ToolResultContent,
 	WorkflowRouteHandler,
 } from './types.ts';
 

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -1151,9 +1151,9 @@ export class Session implements FlueSession, AgentSubmissionSession {
 				parameters: toolDef.parameters as any,
 				async execute(_toolCallId: string, params: unknown, signal?: AbortSignal) {
 					if (signal?.aborted) throw abortErrorFor(signal);
-					const resultText = await toolDef.execute(params as Record<string, any>, signal);
+					const result = await toolDef.execute(params as Record<string, any>, signal);
 					return {
-						content: [{ type: 'text' as const, text: resultText }],
+						content: typeof result === 'string' ? [{ type: 'text' as const, text: result }] : result,
 						details: { customTool: toolDef.name },
 					};
 				},

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1,5 +1,5 @@
 import type { AgentMessage, AgentTool, ThinkingLevel } from '@earendil-works/pi-agent-core';
-import type { ImageContent, Model } from '@earendil-works/pi-ai';
+import type { ImageContent, Model, TextContent } from '@earendil-works/pi-ai';
 
 export interface SignalMessage {
 	role: 'signal';
@@ -124,6 +124,12 @@ export type ToolArgs<TParams extends ToolParameters> = [TParams] extends [v.Gene
 	? v.InferOutput<TParams>
 	: Record<string, any>;
 
+/** Content a custom tool can return to the model. */
+export type ToolResultContent = TextContent | ImageContent;
+
+/** Result returned from a custom tool callback. */
+export type ToolExecuteResult = string | ToolResultContent[];
+
 /**
  * Custom tool passed to createAgent(), init(), prompt(), skill(), or task().
  * Agent and init tools are available to every session call; prompt/skill/task
@@ -138,8 +144,8 @@ export interface ToolDefinition<TParams extends ToolParameters = ToolParameters>
 	description: string;
 	/** Valibot object schema or raw JSON Schema object. */
 	parameters: TParams;
-	/** Returns a string result sent back to the LLM. Thrown errors become tool errors. */
-	execute: (args: ToolArgs<TParams>, signal?: AbortSignal) => Promise<string>;
+	/** Returns text or content blocks sent back to the LLM. Thrown errors become tool errors. */
+	execute: (args: ToolArgs<TParams>, signal?: AbortSignal) => Promise<ToolExecuteResult>;
 }
 
 // ─── File Stat ──────────────────────────────────────────────────────────────

--- a/packages/runtime/test/tool.test.ts
+++ b/packages/runtime/test/tool.test.ts
@@ -409,7 +409,7 @@ describe('custom tools', () => {
 		expect(provider.state.callCount).toBe(1);
 	});
 
-	it('returns callback output to the model when a custom tool completes', async () => {
+	it('returns callback text output to the model when a custom tool completes', async () => {
 		const provider = createProvider();
 		const execute = vi.fn(async () => 'Found the requested value.');
 		let modelToolResult: unknown;
@@ -444,6 +444,47 @@ describe('custom tools', () => {
 			isError: false,
 		});
 		expect(result.text).toBe('Lookup complete.');
+	});
+
+	it('returns callback image content to the model when a custom tool completes', async () => {
+		const provider = createProvider();
+		let modelToolResult: unknown;
+		provider.setResponses([
+			fauxAssistantMessage(fauxToolCall('screenshot', {}), { stopReason: 'toolUse' }),
+			(context) => {
+				modelToolResult = context.messages.at(-1);
+				return fauxAssistantMessage('Screenshot reviewed.');
+			},
+		]);
+		const screenshot = defineTool({
+			name: 'screenshot',
+			description: 'Capture a screenshot.',
+			parameters: v.object({}),
+			execute: async () => [
+				{ type: 'text' as const, text: 'Attached screenshot.' },
+				{ type: 'image' as const, data: 'aW1hZ2UtYnl0ZXM=', mimeType: 'image/png' },
+			],
+		});
+		const harness = await createContext(provider).init(
+			createAgent(() => ({
+				model: `${provider.getModel().provider}/${provider.getModel().id}`,
+				tools: [screenshot],
+			})),
+		);
+		const session = await harness.session();
+
+		const result = await session.prompt('Capture the screenshot.');
+
+		expect(modelToolResult).toMatchObject({
+			role: 'toolResult',
+			toolName: 'screenshot',
+			content: [
+				{ type: 'text', text: 'Attached screenshot.' },
+				{ type: 'image', data: 'aW1hZ2UtYnl0ZXM=', mimeType: 'image/png' },
+			],
+			isError: false,
+		});
+		expect(result.text).toBe('Screenshot reviewed.');
 	});
 
 	it('exposes valibot parameters to the provider as one stable plain JSON Schema object', async () => {


### PR DESCRIPTION
## Summary
- widen `ToolDefinition.execute` so custom tools can return text/image content blocks, not only strings
- pass custom tool content blocks through to pi-agent-core instead of wrapping every result as text
- add runtime test coverage for image content returned from a `defineTool` custom tool
- document the new `ToolExecuteResult` / `ToolResultContent` return shape

## Validation
- `pnpm run build` in `packages/runtime`
- `pnpm run check:types` in `packages/runtime`
- `pnpm test -- test/tool.test.ts test/session-event-images.test.ts` in `packages/runtime`

Note: root `pnpm run check:lint` currently reports pre-existing warnings in unrelated files (e.g. packages/cli/test/logs.test.mjs, packages/postgres/src/postgres-adapter.ts, packages/sdk/test/client.test.ts).
