### PR TITLE
Clarify Cloudflare target docs

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/deploy/cloudflare.md
+++ b/apps/docs/src/content/docs/ecosystem/deploy/cloudflare.md
@@ -88,10 +88,16 @@ Keep deployed migration entries in order. When you add an agent or workflow late
 
 ```bash
 npx flue build --target cloudflare
-npx wrangler deploy
+npx wrangler deploy --config dist/my-flue-worker/wrangler.json
 ```
 
-`flue build --target cloudflare` compiles your project into a `./dist` directory containing a Cloudflare Workers-compatible artifact. `wrangler deploy` pushes it live.
+`flue build --target cloudflare` compiles your project into a `./dist` directory containing a Cloudflare Workers-compatible artifact. Deploy the generated Wrangler config from the build output, not the source-root `wrangler.jsonc`, so Wrangler uses Flue's generated entrypoint, merged bindings, and Cloudflare Vite output. The generated directory is named from your Worker name, so this example writes `dist/my-flue-worker/wrangler.json`.
+
+Before deploying, run the same generated config through Wrangler's dry run:
+
+```bash
+npx wrangler deploy --dry-run --config dist/my-flue-worker/wrangler.json
+```
 
 ### Serving assets from the same Worker
 
@@ -129,7 +135,7 @@ For a deployed Worker, add secrets through Wrangler rather than treating a local
 ```bash
 npx wrangler secret put ANTHROPIC_API_KEY
 npx flue build --target cloudflare
-npx wrangler deploy
+npx wrangler deploy --config dist/my-flue-worker/wrangler.json
 ```
 
 For CI or a managed deployment pipeline, `wrangler deploy --secrets-file <path>` is also available when your pipeline provides a protected secrets file.
@@ -464,11 +470,11 @@ Agent events are durably stored and can be replayed from any offset via the Dura
 
 A deployment or code update can reset a Durable Object while an operation is running. Flue handles interrupted Cloudflare operations according to their execution model:
 
-| Operation                                                                    | After interruption                                                                                                                                                                                                                                                                   |
-| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Direct attached agent HTTP prompt                                            | The accepted prompt remains queued independently of its transport. Flue requeues only when canonical input is provably absent, recognizes provably completed canonical output, and otherwise records a visible terminal interruption without blindly replaying provider work. No public agent run exists. |
-| Dispatched agent input                                                       | Durable delivery and internal deduplication are keyed by `dispatchId` and persisted submission state, not by a run. Direct and dispatched inputs to one agent instance share one accepted order. Reconciliation uses the same conservative replay rules.                                                   |
-| Flue workflow invocation (`202` or `?wait=result`)                           | Flue terminalizes the interrupted run as errored. An attached synchronous response may fail. Flue does not automatically start a replacement run.                                                                                                                                      |
+| Operation                                          | After interruption                                                                                                                                                                                                                                                                                        |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Direct attached agent HTTP prompt                  | The accepted prompt remains queued independently of its transport. Flue requeues only when canonical input is provably absent, recognizes provably completed canonical output, and otherwise records a visible terminal interruption without blindly replaying provider work. No public agent run exists. |
+| Dispatched agent input                             | Durable delivery and internal deduplication are keyed by `dispatchId` and persisted submission state, not by a run. Direct and dispatched inputs to one agent instance share one accepted order. Reconciliation uses the same conservative replay rules.                                                  |
+| Flue workflow invocation (`202` or `?wait=result`) | Flue terminalizes the interrupted run as errored. An attached synchronous response may fail. Flue does not automatically start a replacement run.                                                                                                                                                         |
 
 Cloudflare direct prompts and dispatched inputs enter one SQLite-backed submission queue owned by the target agent Durable Object. The attached transport observes accepted backend work but does not own it: losing an HTTP response does not cancel the accepted submission. Agent events are durably stored and can be replayed from any offset via the Durable Streams protocol.
 
@@ -537,7 +543,7 @@ npx flue build --target cloudflare
 
 # Configure a deployed secret interactively, then deploy
 npx wrangler secret put ANTHROPIC_API_KEY
-npx wrangler deploy
+npx wrangler deploy --config dist/my-agent/wrangler.json
 ```
 
 Every workflow that exports `route` gets an HTTP endpoint automatically. The middleware may authenticate the request and call `next()` to admit it. The route follows the pattern `/workflows/<name>` — for example, `.flue/workflows/translate.ts` becomes `/workflows/translate`.

--- a/apps/docs/src/content/docs/guide/targets/cloudflare.md
+++ b/apps/docs/src/content/docs/guide/targets/cloudflare.md
@@ -23,6 +23,8 @@ The class name is how Cloudflare identifies the Durable Object in migrations. Th
 
 Agent session state, accepted submissions, and workflow run history are stored in the owning Durable Object's SQLite storage automatically. The Cloudflare target does not use `db.ts`; a source-root `db.ts` is rejected at build time.
 
+Do not hand-author Flue's generated `FLUE_*` bindings in `wrangler.jsonc`. Declare migrations for generated classes, and declare bindings only for application-owned resources such as your own Durable Objects, R2 buckets, Queues, Hyperdrive configs, Browser Rendering bindings, or Send Email bindings.
+
 ## `wrangler.jsonc`
 
 Your project's `wrangler.jsonc` at the project root configures your Worker's name, compatibility settings, and Durable Object migrations. Flue reads this file during builds and merges its generated bindings alongside your authored configuration.
@@ -41,13 +43,9 @@ Flue generates the Durable Object classes and bindings, but your `wrangler.jsonc
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": [
-        "FlueRegistry",
-        "FlueSupportChatAgent",
-        "FlueTranslateWorkflow"
-      ]
-    }
-  ]
+      "new_sqlite_classes": ["FlueRegistry", "FlueSupportChatAgent", "FlueTranslateWorkflow"],
+    },
+  ],
 }
 ```
 
@@ -61,8 +59,8 @@ Cloudflare requires an ordered migration history that accounts for every Durable
 {
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["FlueRegistry", "FlueSupportChatAgent"] },
-    { "tag": "v2", "new_sqlite_classes": ["FlueTranslateWorkflow"] }
-  ]
+    { "tag": "v2", "new_sqlite_classes": ["FlueTranslateWorkflow"] },
+  ],
 }
 ```
 
@@ -73,9 +71,12 @@ For example, if you remove an agent or workflow that was previously deployed, ap
 ```jsonc
 {
   "migrations": [
-    { "tag": "v1", "new_sqlite_classes": ["FlueRegistry", "FlueSupportChatAgent", "FlueTranslateWorkflow"] },
-    { "tag": "v2", "deleted_classes": ["FlueSupportChatAgent"] }
-  ]
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["FlueRegistry", "FlueSupportChatAgent", "FlueTranslateWorkflow"],
+    },
+    { "tag": "v2", "deleted_classes": ["FlueSupportChatAgent"] },
+  ],
 }
 ```
 
@@ -85,8 +86,11 @@ Similarly, use `renamed_classes` when a deployed class changes its name, such as
 {
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["FlueRegistry", "FlueSupportChatAgent"] },
-    { "tag": "v2", "renamed_classes": [{ "from": "FlueSupportChatAgent", "to": "FlueSupportAssistantAgent" }] }
-  ]
+    {
+      "tag": "v2",
+      "renamed_classes": [{ "from": "FlueSupportChatAgent", "to": "FlueSupportAssistantAgent" }],
+    },
+  ],
 }
 ```
 
@@ -195,14 +199,13 @@ export const cloudflare = extend({
 ```ts
 export const cloudflare = extend({
   wrap: (Final) =>
-    Sentry.instrumentDurableObjectWithSentry(
-      (env) => ({ dsn: env.SENTRY_DSN }),
-      Final,
-    ),
+    Sentry.instrumentDurableObjectWithSentry((env) => ({ dsn: env.SENTRY_DSN }), Final),
 });
 ```
 
 Both `base` and `wrap` are optional. Do not override Flue-owned `fetch()`, `onRequest()`, `onFiberRecovered()`, or `alarm()` methods.
+
+Use this module-local extension point for scheduled or queued behavior that belongs to one generated agent or workflow Durable Object. Do not add a Worker cron trigger just to reach `scheduleEvery(...)`; the Agents SDK scheduling APIs run inside the generated Durable Object after that object is created. If your application needs to create the first instance, expose an authenticated bootstrap route in `app.ts` or otherwise obtain the Durable Object namespace from `env` and address the instance once.
 
 ## Extending `cloudflare.ts` Entrypoint
 
@@ -235,6 +238,8 @@ export default {
 ```
 
 Use `app.ts` for custom HTTP routes and middleware. `cloudflare.ts` must not define a default `fetch` handler because Flue keeps HTTP composition in `app.ts`.
+
+Use `cloudflare.ts` for Worker-level events such as inbound email, queues, or cron handlers that are not owned by a specific generated agent or workflow class. If one of those handlers needs to start a Flue workflow and preserve run history, invoke the mounted workflow route through the application HTTP surface instead of importing and calling the workflow's `run(...)` function directly.
 
 ## Reference
 

--- a/apps/docs/src/content/docs/guide/workflows.md
+++ b/apps/docs/src/content/docs/guide/workflows.md
@@ -70,6 +70,8 @@ An exposed `summarize` workflow accepts requests at `POST /workflows/summarize`.
 
 By default, `POST /workflows/summarize` returns `202 { runId, streamUrl, offset }` after admission. Add `?wait=result` to wait for the completed result in the same request. For HTTP response modes, authentication, and custom application mounts, see [Routing](/docs/guide/routing/).
 
+Application-owned routes, Worker handlers, and other workflows should use the same admission boundary when they want a real workflow run. Do not import a workflow module and call `run(...)` directly from `app.ts`, `cloudflare.ts`, an email handler, or a scheduler; that bypasses Flue's admission path, durable run storage, events, route middleware, and run inspection APIs. Instead, call the mounted workflow route with an authenticated `Request`, or extract shared pure application logic into a separate module that both the workflow and the caller can use.
+
 ## Working with the harness
 
 `init(agent)` returns a harness: the initialized environment your workflow uses for that agent. Through the harness, application code can prepare the agent's workspace and open sessions where the agent performs work.
@@ -157,12 +159,12 @@ Use structured results when later application code depends on specific fields, i
 
 When a workflow is invoked through a running application, its `runId` lets you inspect the run independently of the HTTP request that started it. This is useful for background work, live progress, debugging, and operational tooling.
 
-| Surface                                           | Use it for                                                              |
-| ------------------------------------------------- | ----------------------------------------------------------------------- |
-| `flue logs <runId>`                               | Inspect or follow events for a workflow run from the command line.      |
-| `GET /runs/<runId>`                               | Stream run events via the Durable Streams protocol.                     |
-| `GET /runs/<runId>?meta`                          | Read the workflow-run record as plain JSON.                             |
-| `client.runs.get()`, `.events()`, and `.stream()` | Build application tooling around a known workflow run.                  |
+| Surface                                           | Use it for                                                                                                                                                         |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `flue logs <runId>`                               | Inspect or follow events for a workflow run from the command line.                                                                                                 |
+| `GET /runs/<runId>`                               | Stream run events via the Durable Streams protocol.                                                                                                                |
+| `GET /runs/<runId>?meta`                          | Read the workflow-run record as plain JSON.                                                                                                                        |
+| `client.runs.get()`, `.events()`, and `.stream()` | Build application tooling around a known workflow run.                                                                                                             |
 | `listRuns()` from `@flue/runtime`                 | List workflow runs from your own protected server-side endpoints. See [compose your own admin endpoints](/docs/api/routing-api/#compose-your-own-admin-endpoints). |
 
 Run listing can reveal workflow payloads, results, model activity, and application logs. Only publish a listing surface behind an authorization boundary appropriate for that data.


### PR DESCRIPTION
Docs-only PR for the Cloudflare target issues from https://github.com/withastro/flue/discussions/257.

- Deploy with the generated config: `dist/<worker>/wrangler.json`, not the source-root `wrangler.jsonc`.
- Add a `wrangler deploy --dry-run --config dist/<worker>/wrangler.json` step before deploy.
- Make it clearer that Flue generates `FLUE_*` bindings; users only declare migrations for those classes.
- Clarify when `scheduleEvery(...)` belongs in `cloudflare = extend(...)` instead of a Worker cron handler.
- Warn against direct `run(...)` calls from app routes, email handlers, or schedulers when users want workflow run history.
- Point users at the mounted workflow route, or shared pure helper modules, for app-owned ingress.

Validated with `pnpm --dir apps/docs run check:types` and Prettier on the touched docs files.