### PR TITLE
Polish flue CLI output.

### DIFF
--- a/examples/hello-world/src/app.ts
+++ b/examples/hello-world/src/app.ts
@@ -30,7 +30,7 @@ app.use('*', async (c, next) => {
 	const started = Date.now();
 	await next();
 	const ms = Date.now() - started;
-	console.log(`[app] ${c.req.method} ${c.req.path} → ${c.res.status} (${ms}ms)`);
+	console.log(`app: ${c.req.method} ${c.req.path} → ${c.res.status} (${ms}ms)`);
 });
 
 // Custom route outside Flue's agent API.

--- a/packages/cli/bin/flue.ts
+++ b/packages/cli/bin/flue.ts
@@ -19,6 +19,15 @@ import {
 import { resolveConfigCandidates } from '../src/lib/config-paths.ts';
 import { DEFAULT_DEV_PORT, dev } from '../src/lib/dev.ts';
 import { createEnvLoader, type EnvLoader, selectEnvFile } from '../src/lib/env.ts';
+import {
+	brand,
+	brandRows,
+	dim,
+	error as cliError,
+	note,
+	row,
+	success,
+} from '../src/lib/terminal.ts';
 import { BLUEPRINTS, KIND_ROOTS } from './_blueprints.generated.ts';
 
 interface ApplicationConfigArgs {
@@ -39,11 +48,10 @@ function loadCliEnvironment(args: ApplicationConfigArgs): EnvLoader {
 				: resolveConfigPath({ cwd: searchFrom, configFile: undefined });
 		const baseDir = configPath ? path.dirname(configPath) : searchFrom;
 		const envLoader = createEnvLoader(selectEnvFile(args.envFile, baseDir));
-		if (fs.existsSync(envLoader.file)) console.error(`[flue] Loading env from: ${envLoader.file}`);
 		envLoader.apply();
 		return envLoader;
 	} catch (err) {
-		console.error(err instanceof Error ? err.message : String(err));
+		cliError(err instanceof Error ? err.message : String(err));
 		process.exit(1);
 	}
 }
@@ -54,7 +62,7 @@ async function resolveCliConfig(args: {
 	explicitRoot: string | undefined;
 	explicitOutput: string | undefined;
 	configFile: string | undefined;
-}): Promise<FlueConfig> {
+}): Promise<{ cfg: FlueConfig; configPath?: string }> {
 	const inline: UserFlueConfig = {};
 	if (args.target) inline.target = args.target;
 	if (args.explicitRoot) inline.root = args.explicitRoot;
@@ -67,24 +75,19 @@ async function resolveCliConfig(args: {
 			configFile: args.configFile,
 			inline,
 		});
-		if (configPath) {
-			console.error(
-				`[flue] Loaded config: ${path.relative(process.cwd(), configPath) || configPath}`,
-			);
-		}
-		return flueConfig;
+		return { cfg: flueConfig, configPath };
 	} catch (err) {
-		console.error(err instanceof Error ? err.message : String(err));
+		cliError(err instanceof Error ? err.message : String(err));
 		process.exit(1);
 	}
 }
 
 async function resolveApplicationCommand(
 	args: ApplicationConfigArgs,
-): Promise<{ cfg: FlueConfig; envLoader: EnvLoader }> {
+): Promise<{ cfg: FlueConfig; envLoader: EnvLoader; configPath?: string }> {
 	const envLoader = loadCliEnvironment(args);
-	const cfg = await resolveCliConfig(args);
-	return { cfg, envLoader };
+	const { cfg, configPath } = await resolveCliConfig(args);
+	return { cfg, envLoader, configPath };
 }
 
 // ─── Arg Parsing ────────────────────────────────────────────────────────────
@@ -402,7 +405,7 @@ function shellQuote(value: string): string {
 
 function printCloudflareRunUnsupported(workflow: string, payload: string): never {
 	console.error(
-		'[flue] `flue run --target cloudflare` is not supported.\n\n' +
+		'`flue run --target cloudflare` is not supported.\n\n' +
 			'`flue run` is a one-shot Node.js invoker; Cloudflare builds need a Workers runtime.\n\n' +
 			'For local development of a Cloudflare target, use `flue dev`:\n\n' +
 			`  flue dev --target cloudflare\n\n` +
@@ -416,7 +419,7 @@ function printCloudflareRunUnsupported(workflow: string, payload: string): never
 
 function printCloudflareConnectUnsupported(): never {
 	console.error(
-		'[flue] `flue connect --target cloudflare` is not supported.\n\n' +
+		'`flue connect --target cloudflare` is not supported.\n\n' +
 			'`flue connect` currently starts a local Node.js process; Cloudflare connections require a Workers runtime.',
 	);
 	process.exit(1);
@@ -885,7 +888,7 @@ function logEvent(event: any) {
 
 		case 'thinking_start':
 			flushTextBuffer();
-			console.error('\x1b[2m[flue] thinking:start\x1b[0m');
+			console.error(dim('thinking'));
 			break;
 
 		case 'thinking_delta': {
@@ -921,7 +924,7 @@ function logEvent(event: any) {
 					toolDetail += `  ${event.args.pattern}`;
 				}
 			}
-			console.error(`[flue] tool:start  ${toolDetail}`);
+			console.error(`${dim('tool')} ${toolDetail}`);
 			break;
 		}
 
@@ -936,7 +939,7 @@ function logEvent(event: any) {
 					resultPreview = `  ${text}`;
 				}
 			}
-			console.error(`[flue] tool:${status}   ${event.toolName}${resultPreview}`);
+			console.error(`${dim(`tool ${status}`)} ${event.toolName}${resultPreview}`);
 			break;
 		}
 
@@ -950,20 +953,16 @@ function logEvent(event: any) {
 
 		case 'compaction_start':
 			flushBuffers();
-			console.error(
-				`[flue] compaction:start  reason=${event.reason} tokens=${event.estimatedTokens}`,
-			);
+			console.error(dim(`compaction start reason=${event.reason} tokens=${event.estimatedTokens}`));
 			break;
 
 		case 'compaction':
-			console.error(
-				`[flue] compaction:done   messages: ${event.messagesBefore} → ${event.messagesAfter}`,
-			);
+			console.error(dim(`compaction done messages ${event.messagesBefore} → ${event.messagesAfter}`));
 			break;
 
 		case 'log':
 			flushBuffers();
-			console.error(`[flue] ${event.level ?? 'info'}: ${event.message ?? ''}`);
+			console.error(`${dim(event.level ?? 'info')} ${event.message ?? ''}`);
 			break;
 
 		case 'idle':
@@ -975,9 +974,7 @@ function logEvent(event: any) {
 			// Envelope: { type: 'error', error: { type, message, details, dev?, meta? } }
 			// `dev` is only present when the server is in local/dev mode —
 			// `flue run` always is, so we render it whenever it's present.
-			console.error(
-				`[flue] ERROR [${event.error?.type ?? 'unknown'}]: ${event.error?.message ?? ''}`,
-			);
+			cliError(`[${event.error?.type ?? 'unknown'}] ${event.error?.message ?? ''}`);
 			if (event.error?.details) {
 				for (const line of String(event.error.details).split('\n')) {
 					if (line) console.error(`  ${line}`);
@@ -1043,7 +1040,7 @@ function startLocalProcess(
 	});
 	const pipeOutput = (data: Buffer) => {
 		for (const line of data.toString().trimEnd().split('\n')) {
-			if (line.trim()) console.error(line);
+			if (line.trim()) console.error(dim(line));
 		}
 	};
 	child.stdout?.on('data', pipeOutput);
@@ -1157,16 +1154,18 @@ function sendLocalRequest(
 // ─── Main ───────────────────────────────────────────────────────────────────
 
 async function buildCommand(args: BuildArgs) {
-	const { cfg } = await resolveApplicationCommand(args);
+	const { cfg, configPath, envLoader } = await resolveApplicationCommand(args);
 	try {
 		await build({
 			root: cfg.root,
 			sourceRoot: cfg.sourceRoot,
 			output: cfg.output,
 			target: cfg.target,
+			configFile: configPath,
+			envFile: fs.existsSync(envLoader.file) ? envLoader.file : undefined,
 		});
 	} catch (err) {
-		console.error(`[flue] Build failed:`, err instanceof Error ? err.message : String(err));
+		cliError(`Build failed: ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(1);
 	}
 }
@@ -1184,7 +1183,7 @@ function devConfigFiles(args: DevArgs): string[] {
 }
 
 async function devCommand(args: DevArgs) {
-	const { cfg, envLoader } = await resolveApplicationCommand(args);
+	const { cfg, envLoader, configPath } = await resolveApplicationCommand(args);
 	try {
 		// dev() blocks until SIGINT/SIGTERM exits the process. We don't expect
 		// it to return; if it ever does, just exit cleanly.
@@ -1197,10 +1196,11 @@ async function devCommand(args: DevArgs) {
 			envFile: envLoader.file,
 			envLoader,
 			configFiles: devConfigFiles(args),
+			configFile: configPath,
 			onReady: () => process.send?.(INTERNAL_DEV_READY),
 		});
 	} catch (err) {
-		console.error(`[flue] Dev server failed:`, err instanceof Error ? err.message : String(err));
+		cliError(`Dev server failed: ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(1);
 	}
 }
@@ -1263,7 +1263,7 @@ function superviseDevCommand(args: DevArgs) {
 				return;
 			}
 			if (replacementSession && !sessionReady) {
-				console.error('[flue] Dev server restart failed. Waiting for a configuration change...');
+				cliError('Dev server restart failed. Waiting for a configuration change...');
 				return;
 			}
 			exit(code ?? 1);
@@ -1273,7 +1273,7 @@ function superviseDevCommand(args: DevArgs) {
 		for (const configFile of configFiles) {
 			configFileStates.set(configFile, readConfigFileState(configFile));
 		}
-		console.error(`[flue] Configuration changed: ${file}. Restarting dev server...`);
+		console.error(`${dim('config')} ${file} changed; restarting`);
 		restartRequested = true;
 		if (restartTimer) clearTimeout(restartTimer);
 		restartTimer = setTimeout(() => {
@@ -1300,17 +1300,13 @@ function superviseDevCommand(args: DevArgs) {
 				}
 			});
 			watcher.on('error', (err) => {
-				console.error(
-					`[flue] Config watcher failed: ${err instanceof Error ? err.message : String(err)}`,
-				);
+				cliError(`Config watcher failed: ${err instanceof Error ? err.message : String(err)}`);
 				exit(1);
 			});
 			watchers.push(watcher);
 		}
 	} catch (err) {
-		console.error(
-			`[flue] Config watcher failed: ${err instanceof Error ? err.message : String(err)}`,
-		);
+		cliError(`Config watcher failed: ${err instanceof Error ? err.message : String(err)}`);
 		exit(1);
 	}
 
@@ -1334,7 +1330,7 @@ async function buildLocalTarget(
 		'target' | 'explicitRoot' | 'explicitOutput' | 'configFile' | 'envFile'
 	>,
 ) {
-	const { cfg } = await resolveApplicationCommand(args);
+	const { cfg, configPath, envLoader } = await resolveApplicationCommand(args);
 	if (cfg.target === 'cloudflare') return { cfg, serverPath: undefined };
 	try {
 		await build({
@@ -1342,9 +1338,12 @@ async function buildLocalTarget(
 			sourceRoot: cfg.sourceRoot,
 			output: cfg.output,
 			target: cfg.target,
+			log: 'silent',
+			configFile: configPath,
+			envFile: fs.existsSync(envLoader.file) ? envLoader.file : undefined,
 		});
 	} catch (err) {
-		console.error(`[flue] Build failed:`, err instanceof Error ? err.message : String(err));
+		cliError(`Build failed: ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(1);
 	}
 	return { cfg, serverPath: path.join(cfg.output, 'server.mjs') };
@@ -1355,6 +1354,7 @@ async function run(args: RunArgs) {
 	if (built.cfg.target === 'cloudflare') printCloudflareRunUnsupported(args.workflow, args.payload);
 	if (!built.serverPath)
 		throw new Error('[flue] Node local workflow build did not produce an executable artifact.');
+	console.error(brand(['flue run', `workflow ${args.workflow}`, 'starting...']));
 	const child = startLocalProcess(
 		built.serverPath,
 		'workflow',
@@ -1362,7 +1362,6 @@ async function run(args: RunArgs) {
 		undefined,
 		built.cfg.root,
 	);
-	console.error(`[flue] Running workflow: ${args.workflow}`);
 	try {
 		await waitForLocalReady(
 			child,
@@ -1375,12 +1374,12 @@ async function run(args: RunArgs) {
 				requestId: `req_${crypto.randomUUID()}`,
 				payload: JSON.parse(args.payload),
 			},
-			(message) => console.error(`[flue] Run ID: ${message.runId}`),
+			(message) => row('run', message.runId),
 		);
 		if (result !== undefined && result !== null) console.log(JSON.stringify(result, null, 2));
-		console.error('[flue] Done.');
+		success('workflow completed');
 	} catch (err) {
-		console.error(`[flue] Workflow error: ${err instanceof Error ? err.message : String(err)}`);
+		cliError(`Workflow failed: ${err instanceof Error ? err.message : String(err)}`);
 		stopLocalProcess();
 		process.exit(1);
 	}
@@ -1392,6 +1391,7 @@ async function connectCommand(args: ConnectArgs) {
 	if (built.cfg.target === 'cloudflare') printCloudflareConnectUnsupported();
 	if (!built.serverPath)
 		throw new Error('[flue] Node local agent build did not produce an executable artifact.');
+	console.error(brand(['flue connect', `${args.agent}/${args.instanceId}`, 'starting...']));
 	const child = startLocalProcess(
 		built.serverPath,
 		'agent',
@@ -1408,21 +1408,18 @@ async function connectCommand(args: ConnectArgs) {
 				message.instanceId === args.instanceId,
 		);
 	} catch (err) {
-		console.error(`[flue] Connection error: ${err instanceof Error ? err.message : String(err)}`);
+		cliError(`Connection failed: ${err instanceof Error ? err.message : String(err)}`);
 		stopLocalProcess();
 		process.exit(1);
 	}
-	console.error(
-		`[flue] Connected to ${args.agent}/${args.instanceId}. Enter a prompt per line; Ctrl-D to exit.`,
-	);
+	success('connected');
+	note('enter one prompt per line; Ctrl+D to exit');
 	const input = createInterface({ input: process.stdin, crlfDelay: Infinity });
 	let closing = false;
 	child.once('exit', (code) => {
 		if (closing) return;
 		input.close();
-		console.error(
-			`[flue] Agent connection ended unexpectedly${code === null ? '.' : ` (code ${code}).`}`,
-		);
+		cliError(`Agent connection ended unexpectedly${code === null ? '.' : ` (code ${code}).`}`);
 		process.exitCode = 1;
 	});
 	for await (const line of input) {
@@ -1435,7 +1432,7 @@ async function connectCommand(args: ConnectArgs) {
 			});
 			if (result !== undefined && result !== null) console.log(JSON.stringify(result, null, 2));
 		} catch (err) {
-			console.error(`[flue] Agent error: ${err instanceof Error ? err.message : String(err)}`);
+			cliError(`Agent failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	}
 	closing = true;
@@ -1457,28 +1454,26 @@ function formatDuration(ms: number | undefined): string {
 function logsRenderPretty(event: FlueEvent): void {
 	const { type } = event;
 	if (type === 'run_start') {
-		console.error(`[flue] run:start    ${event.runId}  workflow=${event.workflowName}`);
+		console.error(`${dim('run:start')} ${event.runId}  workflow=${event.workflowName}`);
 		return;
 	}
 	if (type === 'run_end') {
 		const duration = formatDuration(event.durationMs);
 		if (event.isError) {
 			const err = event.error as { message?: string } | undefined;
-			console.error(
-				`[flue] run:end      ${event.runId}  ERROR  ${err?.message ?? ''}  (${duration})`,
-			);
+			console.error(`${dim('run:end')}   ${event.runId}  ERROR  ${err?.message ?? ''}  (${duration})`);
 		} else {
-			console.error(`[flue] run:end      ${event.runId}  ok  (${duration})`);
+			console.error(`${dim('run:end')}   ${event.runId}  ok  (${duration})`);
 		}
 		return;
 	}
 	if (type === 'operation_start') {
-		console.error(`[flue] op:start      ${event.operationKind}`);
+		console.error(`${dim('op:start')}  ${event.operationKind}`);
 		return;
 	}
 	if (type === 'operation') {
 		const duration = formatDuration(event.durationMs);
-		console.error(`[flue] op:done      ${event.operationKind}${duration ? `  (${duration})` : ''}`);
+		console.error(`${dim('op:done')}   ${event.operationKind}${duration ? `  (${duration})` : ''}`);
 		return;
 	}
 	logEvent(event);
@@ -1489,6 +1484,14 @@ function createLogsClient(args: LogsArgs) {
 		baseUrl: args.server,
 		headers: args.headers,
 	});
+}
+
+function getRunWorkflowName(run: RunRecord): string {
+	const record = run as RunRecord & {
+		workflowName?: string;
+		owner?: { workflowName?: string };
+	};
+	return record.workflowName ?? record.owner?.workflowName ?? 'unknown';
 }
 
 function logsEmitEvent(event: FlueEvent, format: LogsArgs['format']): void {
@@ -1508,6 +1511,9 @@ function logsEmitEvent(event: FlueEvent, format: LogsArgs['format']): void {
 
 async function logsCommand(args: LogsArgs): Promise<void> {
 	const client = createLogsClient(args);
+	if (args.format === 'pretty') {
+		console.error(brand(['flue logs', args.runId, args.follow === false ? 'replay' : 'stream']));
+	}
 
 	let shouldFollow: boolean;
 	if (args.follow === false) {
@@ -1520,16 +1526,14 @@ async function logsCommand(args: LogsArgs): Promise<void> {
 		try {
 			run = await client.runs.get(args.runId);
 		} catch (err) {
-			console.error(
-				`[flue] Failed to fetch run ${args.runId}: ${err instanceof Error ? err.message : String(err)}`,
-			);
+			cliError(`Failed to fetch run ${args.runId}: ${err instanceof Error ? err.message : String(err)}`);
 			process.exit(1);
 		}
 		// Run ids are opaque; surface the owning workflow from the run record.
 		if (args.format === 'pretty') {
-			console.error(
-				`[flue] run          ${args.runId}  workflow=${run.workflowName}  status=${run.status}`,
-			);
+			row('workflow', getRunWorkflowName(run));
+			row('status', run.status);
+			console.error('');
 		}
 		shouldFollow = args.follow ?? run.status === 'active';
 	}
@@ -1548,8 +1552,8 @@ async function logsCommand(args: LogsArgs): Promise<void> {
 				},
 			});
 		} catch (err) {
-			console.error(
-				`[flue] Failed to read events for run ${args.runId}: ${err instanceof Error ? err.message : String(err)}`,
+			cliError(
+				`Failed to read events for run ${args.runId}: ${err instanceof Error ? err.message : String(err)}`,
 			);
 			process.exit(1);
 		}
@@ -1609,9 +1613,7 @@ async function logsCommand(args: LogsArgs): Promise<void> {
 		}
 	} catch (err) {
 		if (!signalled) {
-			console.error(
-				`[flue] Stream interrupted: ${err instanceof Error ? err.message : String(err)}`,
-			);
+			cliError(`Stream interrupted: ${err instanceof Error ? err.message : String(err)}`);
 			exitCode = 1;
 		}
 	} finally {
@@ -1644,7 +1646,7 @@ function initCommand(args: InitArgs) {
 	const targetDir = args.explicitRoot ?? process.cwd();
 
 	if (!fs.existsSync(targetDir)) {
-		console.error(`[flue] Target directory does not exist: ${targetDir}`);
+		cliError(`Target directory does not exist: ${targetDir}`);
 		process.exit(1);
 	}
 
@@ -1655,15 +1657,13 @@ function initCommand(args: InitArgs) {
 	try {
 		existing = resolveConfigPath({ cwd: targetDir, configFile: undefined });
 	} catch (err) {
-		console.error(err instanceof Error ? err.message : String(err));
+		cliError(err instanceof Error ? err.message : String(err));
 		process.exit(1);
 	}
 
 	if (existing && !args.force) {
 		const rel = path.relative(process.cwd(), existing) || existing;
-		console.error(
-			`[flue] A Flue config already exists at ${rel}.\n  Re-run with --force to overwrite.`,
-		);
+		cliError(`A Flue config already exists at ${rel}.\n  Re-run with --force to overwrite.`);
 		process.exit(1);
 	}
 
@@ -1673,30 +1673,25 @@ function initCommand(args: InitArgs) {
 	try {
 		fs.writeFileSync(outPath, content);
 	} catch (err) {
-		console.error(
-			`[flue] Failed to write ${outPath}: ${err instanceof Error ? err.message : String(err)}`,
-		);
+		cliError(`Failed to write ${outPath}: ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(1);
 	}
 
 	const relOut = path.relative(process.cwd(), outPath) || outPath;
-	console.error(`[flue] Wrote ${relOut}`);
+	console.error(brand(['flue init', `target ${args.target}`, `wrote ${relOut}`]));
 
 	// If --force overwrote a non-`.ts` variant, the new flue.config.ts will
 	// take precedence (CONFIG_BASENAMES priority), but the old file still
 	// sits on disk. Surface that so the user isn't surprised later.
 	if (existing && path.basename(existing) !== 'flue.config.ts') {
 		const relExisting = path.relative(process.cwd(), existing) || existing;
-		console.error(
-			`[flue] Note: ${relExisting} is still on disk. ` +
-				`flue.config.ts now takes precedence; delete the old file if you no longer need it.`,
+		note(
+			`${relExisting} is still on disk. flue.config.ts now takes precedence; delete the old file if you no longer need it.`,
 		);
 	}
 
 	console.error('');
-	console.error('Next step:');
-	console.error('');
-	console.error('  fetch https://flueframework.com/start.md to create a new agent');
+	note('next: fetch https://flueframework.com/start.md to create a new agent');
 }
 
 // ─── `flue add` ─────────────────────────────────────────────────────────────
@@ -1798,15 +1793,14 @@ async function fetchBlueprintMarkdown(
 	try {
 		res = await fetch(url);
 	} catch (err) {
-		console.error(
-			`[flue] Failed to reach the blueprint registry at ${url}.\n` +
-				`  ${err instanceof Error ? err.message : String(err)}`,
+		cliError(
+			`Failed to reach the blueprint registry at ${url}.\n  ${err instanceof Error ? err.message : String(err)}`,
 		);
 		process.exit(1);
 	}
 	if (res.status === 404) return { notFound: true };
 	if (!res.ok) {
-		console.error(`[flue] Blueprint registry returned HTTP ${res.status} for ${url}.`);
+		cliError(`Blueprint registry returned HTTP ${res.status} for ${url}.`);
 		process.exit(1);
 	}
 	return { body: await res.text() };
@@ -1959,9 +1953,8 @@ function normalizeDocsPath(input: string): string {
 function docsCommand(args: DocsArgs): void {
 	const root = resolveDocsRoot();
 	if (!root) {
-		console.error(
-			'[flue] Could not locate the bundled documentation. ' +
-				'Your @flue/cli installation may be incomplete — try reinstalling it.',
+		cliError(
+			'Could not locate the bundled documentation. Your @flue/cli installation may be incomplete — try reinstalling it.',
 		);
 		process.exit(1);
 	}
@@ -1985,9 +1978,8 @@ function docsCommand(args: DocsArgs): void {
 		const target = normalizeDocsPath(args.value);
 		const page = pages.find((candidate) => candidate.path === target);
 		if (!page) {
-			console.error(
-				`[flue] Unknown docs page: ${args.value}\n` +
-					'Run `flue docs` to list available pages, or `flue docs search <query>` to find one.',
+			cliError(
+				`Unknown docs page: ${args.value}\nRun \`flue docs\` to list available pages, or \`flue docs search <query>\` to find one.`,
 			);
 			process.exit(1);
 		}
@@ -2058,9 +2050,8 @@ async function emitBlueprintMarkdown(
 ) {
 	const result = await fetchBlueprintMarkdown(opts.slug);
 	if ('notFound' in result) {
-		console.error(
-			`[flue] The blueprint registry did not have Markdown for ${opts.notFoundLabel}. ` +
-				`Your installed CLI may be out of sync with the registry — try updating @flue/cli.`,
+		cliError(
+			`The blueprint registry did not have Markdown for ${opts.notFoundLabel}. Your installed CLI may be out of sync with the registry — try updating @flue/cli.`,
 		);
 		process.exit(1);
 	}
@@ -2088,10 +2079,8 @@ async function blueprintCommand(args: BlueprintCommandArgs) {
 
 	const root = KIND_ROOTS.find((entry) => entry.kind === args.kind);
 	if (!root) {
-		console.error(
-			`[flue] Unknown blueprint kind "${args.kind}". Known kinds: ${
-				KIND_ROOTS.map((entry) => entry.kind).join(', ') || '(none)'
-			}`,
+		cliError(
+			`Unknown blueprint kind "${args.kind}". Known kinds: ${KIND_ROOTS.map((entry) => entry.kind).join(', ') || '(none)'}`,
 		);
 		process.exit(1);
 	}
@@ -2163,7 +2152,7 @@ async function main() {
 }
 
 void main().catch((err) => {
-	console.error(`[flue] ${err instanceof Error ? err.message : String(err)}`);
+	cliError(err instanceof Error ? err.message : String(err));
 	stopLocalProcess();
 	process.exit(1);
 });

--- a/packages/cli/src/lib/build-plugin-cloudflare.ts
+++ b/packages/cli/src/lib/build-plugin-cloudflare.ts
@@ -12,6 +12,7 @@ import {
 	generateBuiltModuleNormalizationSource,
 	workflowVarName,
 } from './generated-entry-normalization.ts';
+import { note } from './terminal.ts';
 import type { BuildContext, BuildPlugin, ViteCloudflareInputs } from './types.ts';
 
 export class CloudflarePlugin implements BuildPlugin {
@@ -580,7 +581,7 @@ export default {
 			path: userConfigPath,
 		} = await readUserWranglerConfig(ctx.root);
 		if (userConfigPath) {
-			console.log(`[flue] Merging with user wrangler config: ${userConfigPath}`);
+			note(`wrangler ${userConfigPath}`);
 		}
 		validateUserWranglerConfig({ config: userConfig, effectiveConfig });
 

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -6,6 +6,7 @@ import { cloudflare } from '@cloudflare/vite-plugin';
 import { packageUpSync } from 'package-up';
 import { CloudflarePlugin } from './build-plugin-cloudflare.ts';
 import { NodePlugin } from './build-plugin-node.ts';
+import { brandRows, section, success } from './terminal.ts';
 import type {
 	AgentInfo,
 	BuildContext,
@@ -48,15 +49,13 @@ async function buildApplication(options: BuildOptions): Promise<BuildResult> {
 	const root = path.resolve(options.root);
 	const output = path.resolve(options.output ?? path.join(root, 'dist'));
 	const plugin: BuildPlugin = resolvePlugin(options);
+	const verbose = options.log !== 'silent';
+	const rel = (filePath: string) => {
+		const relative = path.relative(root, filePath);
+		return relative && !relative.startsWith('..') && !path.isAbsolute(relative) ? relative : filePath;
+	};
 
 	const sourceRoot = path.resolve(options.sourceRoot);
-
-	console.log(`[flue] Building: ${root}`);
-	if (sourceRoot !== root) {
-		console.log(`[flue] Source root: ${sourceRoot}`);
-	}
-	console.log(`[flue] Output: ${output}`);
-	console.log(`[flue] Target: ${plugin.name}`);
 
 	const agents = discoverAgents(sourceRoot);
 	const workflows = discoverWorkflows(sourceRoot);
@@ -65,6 +64,23 @@ async function buildApplication(options: BuildOptions): Promise<BuildResult> {
 	const cloudflareEntry = discoverOptionalEntry(sourceRoot, 'cloudflare');
 	const dbEntry = discoverOptionalEntry(sourceRoot, 'db');
 
+	if (verbose) {
+		brandRows('flue build', [
+			['target', plugin.name],
+			['output', rel(output)],
+			['config', options.configFile ? rel(options.configFile) : undefined],
+			['env', options.envFile ? rel(options.envFile) : undefined],
+			['source', rel(sourceRoot)],
+			['app', appEntry ? rel(appEntry) : undefined],
+			['database', dbEntry ? rel(dbEntry) : undefined],
+			['cloudflare', cloudflareEntry && plugin.name === 'cloudflare' ? rel(cloudflareEntry) : undefined],
+		]);
+		section('agents', agents.map((agent) => agent.name));
+		section('workflows', workflows.map((workflow) => workflow.name));
+		section('channels', channels.map((channel) => channel.name));
+		console.error('');
+	}
+
 	if (agents.length === 0 && workflows.length === 0) {
 		throw new Error(
 			`[flue] No agent or workflow files found.\n\n` +
@@ -72,35 +88,6 @@ async function buildApplication(options: BuildOptions): Promise<BuildResult> {
 				`Add at least one agent or workflow file.`,
 		);
 	}
-
-	if (appEntry) {
-		console.log(`[flue] Custom app entry: ${path.relative(root, appEntry) || appEntry}`);
-	}
-	if (dbEntry) {
-		console.log(`[flue] Custom persistence: ${path.relative(root, dbEntry) || dbEntry}`);
-	}
-	if (cloudflareEntry && plugin.name === 'cloudflare') {
-		console.log(
-			`[flue] Custom Cloudflare entry: ${path.relative(root, cloudflareEntry) || cloudflareEntry}`,
-		);
-	}
-
-	if (agents.length > 0) {
-		console.log(`[flue] Found ${agents.length} agent(s): ${agents.map((a) => a.name).join(', ')}`);
-	}
-	if (workflows.length > 0) {
-		console.log(
-			`[flue] Found ${workflows.length} workflow(s): ${workflows.map((workflow) => workflow.name).join(', ')}`,
-		);
-	}
-	if (channels.length > 0) {
-		console.log(
-			`[flue] Found ${channels.length} channel(s): ${channels.map((channel) => channel.name).join(', ')}`,
-		);
-	}
-	console.log(
-		`[flue] AGENTS.md and workspace .agents/skills/ will be discovered at runtime; imported SKILL.md directories are packaged by Vite`,
-	);
 
 	fs.mkdirSync(output, { recursive: true });
 
@@ -156,7 +143,7 @@ async function buildApplication(options: BuildOptions): Promise<BuildResult> {
 					},
 				},
 			});
-			console.log(`[flue] Built: ${outPath}`);
+			if (verbose) success(`built ${rel(outPath)}`);
 			anyChanged = true;
 		} finally {
 			try {
@@ -192,7 +179,7 @@ async function buildApplication(options: BuildOptions): Promise<BuildResult> {
 			generatedChanged ||= changed;
 		}
 		if (options.mode === 'development') {
-			console.log(`[flue] Prepared Cloudflare Vite entry: ${entryPath}`);
+			if (verbose) success(`prepared ${rel(entryPath)}`);
 			return { changed: generatedChanged };
 		}
 		const generatedConfigPath = cloudflareViteConfigPath(root);
@@ -207,7 +194,7 @@ async function buildApplication(options: BuildOptions): Promise<BuildResult> {
 			});
 			await builder.buildApp();
 		});
-		console.log(`[flue] Built Cloudflare application: ${output}`);
+		if (verbose) success(`built ${rel(output)}`);
 		anyChanged = true;
 	}
 
@@ -221,13 +208,13 @@ async function buildApplication(options: BuildOptions): Promise<BuildResult> {
 			const changed = !fs.existsSync(filePath) || fs.readFileSync(filePath, 'utf-8') !== content;
 			if (changed) {
 				fs.writeFileSync(filePath, content, 'utf-8');
-				console.log(`[flue] Generated: ${filePath}`);
+				if (verbose) success(`generated ${rel(filePath)}`);
 				anyChanged = true;
 			}
 		}
 	}
 
-	console.log(`[flue] Build complete. Output: ${output}`);
+	if (verbose) success(`ready ${rel(output)}`);
 	return { changed: anyChanged };
 }
 

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -258,15 +258,15 @@ function resolvePlugin(options: BuildOptions): BuildPlugin {
 	}
 }
 
-function discoverAgents(sourceRoot: string): AgentInfo[] {
+export function discoverAgents(sourceRoot: string): AgentInfo[] {
 	return discoverModules(sourceRoot, 'agent');
 }
 
-function discoverWorkflows(sourceRoot: string): WorkflowInfo[] {
+export function discoverWorkflows(sourceRoot: string): WorkflowInfo[] {
 	return discoverModules(sourceRoot, 'workflow');
 }
 
-function discoverChannels(sourceRoot: string): ChannelInfo[] {
+export function discoverChannels(sourceRoot: string): ChannelInfo[] {
 	return discoverModules(sourceRoot, 'channel');
 }
 

--- a/packages/cli/src/lib/dev.ts
+++ b/packages/cli/src/lib/dev.ts
@@ -22,6 +22,7 @@ import {
 	viteInputDir,
 } from './build.ts';
 import { createEnvLoader, type EnvLoader, selectEnvFile } from './env.ts';
+import { blue, brandRows, dim, error, note, red, section, success } from './terminal.ts';
 import type { BuildOptions } from './types.ts';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -40,6 +41,7 @@ export interface DevOptions {
 	envFile?: string;
 	envLoader?: EnvLoader;
 	configFiles?: readonly string[];
+	configFile?: string;
 	onReady?: () => void;
 }
 
@@ -101,13 +103,11 @@ export async function dev(options: DevOptions): Promise<void> {
 		output,
 		target: options.target,
 		mode: options.target === 'cloudflare' ? 'development' : 'build',
+		log: 'silent',
+		configFile: options.configFile,
+		envFile: fs.existsSync(envFile) ? envFile : undefined,
 	};
 
-	console.error(`[flue] Starting dev server (target: ${options.target})`);
-	console.error(`[flue] Watching: ${root}`);
-	console.error(`[flue] Building...`);
-
-	const initialStart = Date.now();
 	try {
 		if (options.target === 'cloudflare') {
 			await envLoader.withApplied(() => build(buildOptions));
@@ -115,11 +115,8 @@ export async function dev(options: DevOptions): Promise<void> {
 			await build(buildOptions);
 		}
 	} catch (err) {
-		throw new Error(
-			`[flue] Initial build failed: ${err instanceof Error ? err.message : String(err)}`,
-		);
+		throw new Error(`Initial build failed: ${err instanceof Error ? err.message : String(err)}`);
 	}
-	console.error(`[flue] Built in ${Date.now() - initialStart}ms`);
 
 	if (options.target === 'cloudflare') envLoader.restore();
 	const reloader: DevReloader =
@@ -129,15 +126,26 @@ export async function dev(options: DevOptions): Promise<void> {
 
 	await reloader.start();
 
+	brandRows('flue dev', [
+		['target', options.target],
+		['server', reloader.url],
+		['config', options.configFile ? displayPath(root, options.configFile) : undefined],
+		['env', fs.existsSync(envFile) ? displayPath(root, envFile) : undefined],
+		['source', path.relative(root, sourceRoot) || '.'],
+		['output', path.relative(root, output) || '.'],
+	]);
+	section('agents', listModuleNames(sourceRoot, 'agents'));
+	section('workflows', listModuleNames(sourceRoot, 'workflows'));
+	section('channels', listModuleNames(sourceRoot, 'channels'));
+	console.error('');
 	if (reloader.url) {
-		console.error(`[flue] Server: ${reloader.url}`);
 		const exampleAgent = pickExampleAgentName(sourceRoot);
 		if (exampleAgent) {
-			console.error(`[flue] Try: curl -X POST ${reloader.url}/agents/${exampleAgent}/test-1 \\`);
-			console.error(`         -H 'Content-Type: application/json' -d '{}'`);
+			note(`connect with: flue connect ${exampleAgent} local`);
 		}
 	}
-	console.error(`[flue] Press Ctrl+C to stop\n`);
+	note('watching for changes; Ctrl+C to stop');
+	console.error('');
 	options.onReady?.();
 
 	// ─── Watch loop ──────────────────────────────────────────────────────────
@@ -160,13 +168,11 @@ export async function dev(options: DevOptions): Promise<void> {
 				try {
 					envLoader.apply();
 				} catch (err) {
-					console.error(
-						`[flue] Environment reload failed: ${err instanceof Error ? err.message : String(err)}`,
-					);
+					error(`Environment reload failed: ${err instanceof Error ? err.message : String(err)}`);
 					return;
 				}
 			}
-			console.error(`[flue] Change detected: ${relPath}`);
+			console.error(`${dim('changed')} ${relPath}`);
 			rebuilder.schedule(isEnvFile);
 		},
 	});
@@ -177,16 +183,14 @@ export async function dev(options: DevOptions): Promise<void> {
 	const shutdown = async (signal: string, exitCode: number) => {
 		if (shuttingDown) return;
 		shuttingDown = true;
-		console.error(`\n[flue] Received ${signal}, shutting down...`);
+		console.error(`\n${dim(signal)} shutting down`);
 		watcher.close();
 		try {
 			await reloader.stop();
 		} catch (err) {
-			console.error(
-				`[flue] Error during shutdown: ${err instanceof Error ? err.message : String(err)}`,
-			);
+			error(`Shutdown failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
-		console.error(`[flue] Stopped.`);
+		success('stopped');
 		process.exit(exitCode);
 	};
 
@@ -207,6 +211,11 @@ export async function dev(options: DevOptions): Promise<void> {
 
 	// Block forever until a signal handler exits the process.
 	await new Promise<void>(() => {});
+}
+
+function displayPath(root: string, filePath: string): string {
+	const relative = path.relative(root, filePath);
+	return relative && !relative.startsWith('..') && !path.isAbsolute(relative) ? relative : filePath;
 }
 
 // ─── Rebuilder ──────────────────────────────────────────────────────────────
@@ -239,15 +248,18 @@ function createRebuilder(
 	const runOnce = async (force: boolean) => {
 		running = true;
 		const start = Date.now();
-		console.error(`[flue] Rebuilding...`);
+		console.error(`${dim('rebuild')} started`);
 		try {
 			const { changed } = await rebuild();
 			await reloader.reload(changed || force);
-			console.error(`[flue] Reloaded in ${Date.now() - start}ms\n`);
+			success(`rebuilt in ${Date.now() - start}ms`);
+			console.error('');
 		} catch (err) {
 			// Don't exit the dev loop on a rebuild error — the user is editing
 			// code, they'll fix it and trigger another rebuild.
-			console.error(`[flue] Rebuild failed: ${err instanceof Error ? err.message : String(err)}\n`);
+			error(`Rebuild failed: ${err instanceof Error ? err.message : String(err)}`);
+			note('fix the error; dev is still watching');
+			console.error('');
 		} finally {
 			running = false;
 			if (queued) {
@@ -363,9 +375,7 @@ function createWatcher(options: WatcherOptions): WatcherHandle {
 		});
 		watchers.push(w);
 	} catch (err) {
-		console.error(
-			`[flue] Failed to watch ${root}: ${err instanceof Error ? err.message : String(err)}`,
-		);
+		error(`Failed to watch ${root}: ${err instanceof Error ? err.message : String(err)}`);
 	}
 
 	try {
@@ -469,7 +479,7 @@ class NodeReloader implements DevReloader {
 				) {
 					continue;
 				}
-				console.error(line);
+				console.error(formatChildLogLine(line));
 			}
 		};
 		child.stdout?.on('data', pipe);
@@ -479,9 +489,7 @@ class NodeReloader implements DevReloader {
 			if (this.child === child) {
 				this.child = null;
 				if (code !== 0 && code !== null) {
-					console.error(
-						`[flue] Node server exited unexpectedly (code=${code}, signal=${signal ?? 'none'})`,
-					);
+					error(`Node server exited unexpectedly (code=${code}, signal=${signal ?? 'none'})`);
 				}
 			}
 		});
@@ -527,6 +535,18 @@ class NodeReloader implements DevReloader {
 			}, 1_000);
 		});
 	}
+}
+
+function formatChildLogLine(line: string): string {
+	const flueStructured = line.match(/^\[flue\]\s+\[([^\]]+)\]\s*(.*)$/);
+	if (flueStructured) {
+		const code = flueStructured[1]?.replace(/_/g, ' ') ?? 'error';
+		const message = flueStructured[2] ?? '';
+		return `${red('flue')}: ${red(code)}: ${message}`;
+	}
+	const fluePlain = line.match(/^\[flue\]\s+(.*)$/);
+	if (fluePlain) return `${blue('flue')}: ${fluePlain[1] ?? ''}`;
+	return line;
 }
 
 // ─── Cloudflare reloader ────────────────────────────────────────────────────
@@ -612,5 +632,18 @@ function pickExampleAgentName(sourceRoot: string): string | null {
 		return null;
 	} catch {
 		return null;
+	}
+}
+
+function listModuleNames(sourceRoot: string, directory: 'agents' | 'workflows' | 'channels'): string[] {
+	try {
+		const modulesDir = path.join(sourceRoot, directory);
+		if (!fs.existsSync(modulesDir)) return [];
+		return fs
+			.readdirSync(modulesDir)
+			.map((entry) => entry.match(/^([a-zA-Z0-9_-]+)\.(ts|js|mts|mjs)$/)?.[1])
+			.filter((name): name is string => Boolean(name));
+	} catch {
+		return [];
 	}
 }

--- a/packages/cli/src/lib/dev.ts
+++ b/packages/cli/src/lib/dev.ts
@@ -19,6 +19,9 @@ import {
 	build,
 	cloudflareViteConfigPath,
 	createCloudflareViteConfig,
+	discoverAgents,
+	discoverChannels,
+	discoverWorkflows,
 	viteInputDir,
 } from './build.ts';
 import { createEnvLoader, type EnvLoader, selectEnvFile } from './env.ts';
@@ -134,9 +137,9 @@ export async function dev(options: DevOptions): Promise<void> {
 		['source', path.relative(root, sourceRoot) || '.'],
 		['output', path.relative(root, output) || '.'],
 	]);
-	section('agents', listModuleNames(sourceRoot, 'agents'));
-	section('workflows', listModuleNames(sourceRoot, 'workflows'));
-	section('channels', listModuleNames(sourceRoot, 'channels'));
+	section('agents', discoverAgents(sourceRoot).map((agent) => agent.name));
+	section('workflows', discoverWorkflows(sourceRoot).map((workflow) => workflow.name));
+	section('channels', discoverChannels(sourceRoot).map((channel) => channel.name));
 	console.error('');
 	if (reloader.url) {
 		const exampleAgent = pickExampleAgentName(sourceRoot);
@@ -622,28 +625,5 @@ function isSourceStructurePath(root: string, sourceRoot: string, relPath: string
 }
 
 function pickExampleAgentName(sourceRoot: string): string | null {
-	try {
-		const agentsDir = path.join(sourceRoot, 'agents');
-		if (!fs.existsSync(agentsDir)) return null;
-		for (const entry of fs.readdirSync(agentsDir)) {
-			const match = entry.match(/^([a-zA-Z0-9_-]+)\.(ts|js|mts|mjs)$/);
-			if (match?.[1]) return match[1];
-		}
-		return null;
-	} catch {
-		return null;
-	}
-}
-
-function listModuleNames(sourceRoot: string, directory: 'agents' | 'workflows' | 'channels'): string[] {
-	try {
-		const modulesDir = path.join(sourceRoot, directory);
-		if (!fs.existsSync(modulesDir)) return [];
-		return fs
-			.readdirSync(modulesDir)
-			.map((entry) => entry.match(/^([a-zA-Z0-9_-]+)\.(ts|js|mts|mjs)$/)?.[1])
-			.filter((name): name is string => Boolean(name));
-	} catch {
-		return [];
-	}
+	return discoverAgents(sourceRoot)[0]?.name ?? null;
 }

--- a/packages/cli/src/lib/terminal.ts
+++ b/packages/cli/src/lib/terminal.ts
@@ -1,0 +1,68 @@
+const BLUE = '\x1b[34m';
+const BOLD = '\x1b[1m';
+const DIM = '\x1b[2m';
+const RED = '\x1b[31m';
+const RESET = '\x1b[0m';
+
+function useColor(): boolean {
+	return Boolean(process.stderr.isTTY) && process.env.NO_COLOR === undefined;
+}
+
+function paint(code: string, text: string): string {
+	return useColor() ? `${code}${text}${RESET}` : text;
+}
+
+export function blue(text: string): string {
+	return paint(BLUE, text);
+}
+
+export function bold(text: string): string {
+	return paint(BOLD, text);
+}
+
+export function dim(text: string): string {
+	return paint(DIM, text);
+}
+
+export function red(text: string): string {
+	return paint(RED, text);
+}
+
+export function brand(lines: [string, string, string]): string {
+	const mark = [blue(' ▗ '), blue(' ▚ '), blue(' ▘ ')];
+	return lines.map((line, index) => `${mark[index]} ${line}`).join('\n');
+}
+
+export function brandRows(title: string, rows: readonly [string, string | undefined][]): void {
+	const visible = rows.filter((row): row is [string, string] => row[1] !== undefined && row[1] !== '');
+	const mark = [blue(' ▗ '), blue(' ▚ '), blue(' ▘ ')];
+	console.error(`${mark[0]} ${bold(title)}`);
+	visible.forEach(([label, value], index) => {
+		const prefix = mark[index + 1] ?? '   ';
+		console.error(`${prefix} ${dim(label.padEnd(10))}${value}`);
+	});
+}
+
+export function row(label: string, value: string | undefined): void {
+	if (!value) return;
+	console.error(`    ${dim(label.padEnd(10))}${value}`);
+}
+
+export function section(title: string, values: readonly string[]): void {
+	if (values.length === 0) return;
+	console.error('');
+	console.error(`    ${bold(title)}`);
+	for (const value of values) console.error(`      ${value}`);
+}
+
+export function note(message: string): void {
+	console.error(`    ${dim(message)}`);
+}
+
+export function error(message: string): void {
+	console.error(`${bold('Error')}: ${message}`);
+}
+
+export function success(message: string): void {
+	console.error(`${blue('done')} ${message}`);
+}

--- a/packages/cli/src/lib/types.ts
+++ b/packages/cli/src/lib/types.ts
@@ -143,4 +143,8 @@ export interface BuildOptions {
 	output?: string;
 	target?: 'node' | 'cloudflare';
 	mode?: 'build' | 'development';
+	/** Controls human build progress output. Defaults to `normal`. */
+	log?: 'normal' | 'silent';
+	configFile?: string;
+	envFile?: string;
 }

--- a/packages/cli/test/add.test.mjs
+++ b/packages/cli/test/add.test.mjs
@@ -21,8 +21,12 @@ function stripFrontmatter(source) {
 }
 
 async function runCli(args) {
+	const env = { ...process.env, FLUE_REGISTRY_URL: registryUrl };
+	for (const key of Object.keys(env)) {
+		if (key.startsWith('CODEX_')) delete env[key];
+	}
 	const child = spawn(process.execPath, [cli.pathname, ...args], {
-		env: { ...process.env, FLUE_REGISTRY_URL: registryUrl },
+		env,
 		stdio: ['ignore', 'pipe', 'pipe'],
 	});
 	let stdout = '';

--- a/packages/cli/test/config.test.mjs
+++ b/packages/cli/test/config.test.mjs
@@ -172,9 +172,9 @@ describe('flue build', () => {
 		const [exitCode] = await once(child, 'exit');
 
 		assert.equal(exitCode, 0, `flue build failed:\n\n${output}`);
-		assert.match(output, /Source root: .*\.flue/);
-		assert.match(output, /Found 1 agent\(s\): helper/);
-		assert.match(output, /Found 1 workflow\(s\): inner/);
+		assert.match(output, /source\s+\.flue/);
+		assert.match(output, /agents\s+helper/s);
+		assert.match(output, /workflows\s+inner/s);
 		assert.doesNotMatch(output, /stray/);
 		assert.doesNotMatch(output, /outer/);
 		assert.equal(fs.existsSync(path.join(root, 'dist', 'server.mjs')), true);

--- a/packages/cli/test/dev.test.mjs
+++ b/packages/cli/test/dev.test.mjs
@@ -48,7 +48,7 @@ test('restarts after discovered config changes and recovers after invalid config
 		await waitForServer(port);
 
 		fs.rmSync(path.join(root, 'flue.config.ts'));
-		await dev.waitForLog('Loaded config: flue.config.mjs');
+		await dev.waitForLog('config    flue.config.mjs');
 		await waitForServer(port);
 	} finally {
 		await dev.stop();

--- a/packages/cli/test/dev.test.mjs
+++ b/packages/cli/test/dev.test.mjs
@@ -20,6 +20,10 @@ test('restarts after discovered config changes and recovers after invalid config
 	const root = createFixtureRoot();
 	const port = await getAvailablePort();
 	writeWorkflow(root);
+	fs.writeFileSync(
+		path.join(root, 'workflows', 'daily.report.mjs'),
+		`export async function run() { return { ok: true }; }\n`,
+	);
 	fs.writeFileSync(path.join(root, '.config-helper.mjs'), `export default 'dist-one';\n`);
 	fs.writeFileSync(
 		path.join(root, 'flue.config.mjs'),
@@ -29,6 +33,7 @@ test('restarts after discovered config changes and recovers after invalid config
 	const dev = startDev(root, ['--port', String(port)]);
 	try {
 		await waitForServer(port, dev.logs);
+		await dev.waitForLog('daily.report');
 		assert.equal(fs.existsSync(path.join(root, 'dist-one', 'server.mjs')), true);
 
 		fs.writeFileSync(path.join(root, '.config-helper.mjs'), `export default 'dist-two';\n`);


### PR DESCRIPTION
This PR overhauls the look of the CLI and brings some of flue's branding (color and logo) into the terminal output. I also removed a bunch of logs that I thought weren't necessary to be printed.

<table>
<tr>
 <td><b>Before</b>
 <td><b>After</b>
<tr>
 <td><img width="1760" height="1472" alt="CleanShot 2026-06-16 at 15 57 41@2x" src="https://github.com/user-attachments/assets/618708b5-9dae-4ed8-8697-01b546faab3a" />
 <td><img width="1760" height="1472" alt="CleanShot 2026-06-16 at 15 51 59@2x" src="https://github.com/user-attachments/assets/a5c38a64-6983-46d5-95d9-4d5ace9930b7" />
<tr>
 <td><img width="1760" height="1472" alt="CleanShot 2026-06-16 at 15 57 49@2x" src="https://github.com/user-attachments/assets/73abad9c-d2d1-4104-9bb1-a5c9f7d2228b" />
 <td><img width="1760" height="1472" alt="CleanShot 2026-06-16 at 15 51 59@2x" src="https://github.com/user-attachments/assets/a8ff5ff1-d925-4334-a38d-59ca82482ab6" />
</table>

It lists all the agents and workflows in the project, so for most projects it should look somewhat similar to the flue repo itself.

cc @FredKSchott 