### PR TITLE
Update flue connect + cloudflare error message to be more helpful

### DIFF
--- a/packages/cli/bin/flue.ts
+++ b/packages/cli/bin/flue.ts
@@ -412,7 +412,7 @@ function printCloudflareRunUnsupported(workflow: string, payload: string): never
 function printCloudflareConnectUnsupported(): never {
 	console.error(
 		'`flue connect --target cloudflare` is not supported.\n\n' +
-			'`flue connect` currently starts a local Node.js process; Cloudflare connections require a Workers runtime.',
+			'Use `flue connect <agent-name> local --target node` instead.',
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
I ran into this error because my hello-world example had been built with `target: "cloudflare"` in flue.config.ts but had `flue connect my-agent local` in the package.json – which didn't work

I didn't really know how to proceed based on the error.