### PR TITLE
docs: Add installable Flue skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,8 @@ A single `review` task is enough review for most work. Additional reviews are al
 
 When writing new plans to disk, write them to `plans/` (gitignored intentionally) with a `YYYY-MM-DD` filename prefix.
 
+When updating Flue documentation under `apps/docs/src/content/docs/`, also check `skills/flue/README.md` and update any affected installable skill content under `skills/flue/`.
+
 ## Errors
 
 Throw structured error classes from `packages/runtime/src/errors.ts` rather than ad-hoc `new Error('[flue] ...')`. If no existing class fits, add one following the structured-constructor pattern: machine-readable fields in `details`, developer-only guidance (filesystem paths, setup mechanics) in `dev` — never in the caller-visible message. Consumers distinguish failures via `instanceof` checks against exported classes and structured fields; error message strings are not API, and tests should assert on class and structured data rather than message text.

--- a/skills/flue/README.md
+++ b/skills/flue/README.md
@@ -1,0 +1,23 @@
+# Maintaining The Flue Skill
+
+This skill is an agent-facing distillation of Flue documentation. Update it with an agent after documentation or runtime behavior changes; do not generate it by copying the docs tree.
+
+## Update Workflow
+
+1. Read the changed docs under `apps/docs/src/content/docs/`.
+2. Read nearby docs listed in `apps/docs/src/lib/docs-navigation.ts`.
+3. Read implementation source, tests, examples, or blueprints needed to verify behavior.
+4. Update only the affected files under `skills/flue/`.
+5. Keep runtime references flat under `references/`.
+6. List every reference file in `SKILL.md` with a one-line routing reason.
+7. Update `SOURCES.md` with local source paths and official docs URLs.
+8. Check the contract in `SPEC.md` before finishing.
+
+## Authoring Rules
+
+- Preserve Flue terminology exactly: workflow runs are workflow-only; direct prompts and `dispatch(...)` inputs are agent session operations.
+- Prefer dense tables, gotchas, and implementation checklists over copied prose.
+- Keep official docs links available in `SOURCES.md` so a consuming agent can fetch deeper or newer detail when available.
+- Add provider-specific files with flat names such as `channel-github.md`, `sandbox-cloudflare.md`, or `database-postgres.md`.
+- Do not add nested reference directories or broad catch-all files such as `channels.md`.
+

--- a/skills/flue/SKILL.md
+++ b/skills/flue/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: flue
+description: Use when building, debugging, reviewing, or documenting Flue agents, workflows, channels, skills, tools, sandboxes, targets, routing, persistence, observability, or CLI usage; provides agent-focused Flue implementation guidance with links to official docs.
+---
+
+# Flue
+
+Use this skill to answer or implement Flue work from a coding-agent perspective. Start with the routing table, open only the references needed for the request, and consult `SOURCES.md` when exact docs, API references, or fresher public documentation are needed.
+
+Never describe direct HTTP/WebSocket agent prompts or `dispatch(...)` inputs as workflow runs. Runs are workflow-only.
+
+## Reference Router
+
+| Topic | Open when... | Reference |
+| --- | --- | --- |
+| Terminology | You need exact Flue names or must avoid confusing agents, instances, harnesses, sessions, operations, turns, workflows, and runs. | `references/terminology.md` |
+| Project layout | You need source-root discovery, generated output, `.flue/` vs `src/`, or file-based entrypoint rules. | `references/project-layout.md` |
+| Agent sessions | You are creating addressable agents, initializing harnesses, handling direct prompts, using `dispatch(...)`, or choosing IDs and sessions. | `references/agent-sessions-operations.md` |
+| Workflow runs | You are creating, invoking, inspecting, or recovering finite workflow runs. | `references/workflow-runs.md` |
+| Skills, tools, subagents | You are deciding between reusable instructions, executable capabilities, sandbox access, MCP tools, or delegated agent profiles. | `references/skill-tool-subagent.md` |
+| CLI and build/dev | You need `flue dev`, `build`, `run`, `connect`, `logs`, `add`, `update`, `docs`, config overrides, or local command behavior. | `references/cli-build-dev.md` |
+| HTTP routing | You are composing `app.ts`, mounting `flue()`, protecting routes, exposing agents/workflows, or prefixing APIs. | `references/routing-http.md` |
+| Node target | You are building or debugging the Node.js server, `local()` sandbox, Node persistence, environment loading, or restart behavior. | `references/target-node.md` |
+| Cloudflare target | You are building or debugging Workers, generated Durable Objects, migrations, Workers AI, Cloudflare Sandbox, Shell, or `cloudflare.ts`. | `references/target-cloudflare.md` |
+| Channel model | You are adding or reviewing any provider HTTP ingress against Flue's stateless channel ownership model. | `references/channel-model.md` |
+| GitHub channel | You are implementing or debugging `@flue/github`, GitHub webhooks, Octokit tools, delivery IDs, or issue/PR conversation keys. | `references/channel-github.md` |
+| Slack channel | You are implementing or debugging `@flue/slack`, Events API, interactions, slash commands, Web API tools, or thread conversation keys. | `references/channel-slack.md` |
+| Discord channel | You are implementing or debugging `@flue/discord`, interaction responses, REST tools, deadlines, or Discord destination keys. | `references/channel-discord.md` |
+| Teams channel | You are implementing or debugging `@flue/teams`, Bot Connector activities, Teams auth, or conversation-bound reply tools. | `references/channel-teams.md` |
+| Resend channel | You are implementing or debugging `@flue/resend`, inbound email webhooks, message retrieval, or email instance IDs. | `references/channel-resend.md` |
+| Sandbox model | You are choosing between virtual, local, and remote sandboxes or separating workspace persistence from session persistence. | `references/sandbox-model.md` |
+| Data persistence | You are configuring `db.ts`, SQLite, Postgres, Cloudflare SQLite, run records, or session durability. | `references/data-persistence.md` |
+| Observability and errors | You need `flue logs`, `observe(...)`, event privacy, workflow run inspection, or structured Flue error conventions. | `references/observability-errors.md` |
+| Testing conventions | You are adding or reviewing Flue tests and need repository-specific testing posture and naming rules. | `references/testing-conventions.md` |
+
+## Operating Rules
+
+1. Prefer current source and docs over memory when behavior matters.
+2. Use `SOURCES.md` for official docs URLs and local source ownership.
+3. Keep application-owned authorization, credentials, tenant identity, and provider destinations in trusted code, not model-selected arguments.
+4. When delegating with `task`, include a notice that the subagent must not spawn its own subagents.
+

--- a/skills/flue/SOURCES.md
+++ b/skills/flue/SOURCES.md
@@ -1,0 +1,48 @@
+# Flue Skill Sources
+
+This file maps skill references to canonical Flue docs, local source, and official public URLs. Use these sources to verify behavior before updating runtime guidance.
+
+## Source Inventory
+
+| Reference | Local docs and source | Official docs |
+| --- | --- | --- |
+| `references/terminology.md` | `AGENTS.md`; `apps/docs/src/content/docs/concepts/agents.mdx`; `apps/docs/src/content/docs/concepts/durable-execution.md` | https://flueframework.com/docs/concepts/agents/ |
+| `references/project-layout.md` | `apps/docs/src/content/docs/guide/project-layout.md`; `apps/docs/src/content/docs/reference/configuration.md`; `packages/cli/src/lib/config.ts`; `packages/cli/src/lib/config-paths.ts` | https://flueframework.com/docs/guide/project-layout/ |
+| `references/agent-sessions-operations.md` | `apps/docs/src/content/docs/guide/building-agents.md`; `apps/docs/src/content/docs/api/agent-api.md`; `packages/runtime/src/context.ts`; `packages/runtime/test/session-operations.test.ts` | https://flueframework.com/docs/guide/building-agents/ |
+| `references/workflow-runs.md` | `apps/docs/src/content/docs/guide/workflows.md`; `apps/docs/src/content/docs/sdk/runs.md`; `packages/runtime/test/routing.test.ts` | https://flueframework.com/docs/guide/workflows/ |
+| `references/skill-tool-subagent.md` | `apps/docs/src/content/docs/guide/skills.md`; `apps/docs/src/content/docs/guide/tools.md`; `apps/docs/src/content/docs/guide/subagents.md`; `packages/runtime/src/skill-frontmatter.ts`; `packages/runtime/test/session-skills.test.ts` | https://flueframework.com/docs/guide/skills/ |
+| `references/cli-build-dev.md` | `packages/cli/bin/flue.ts`; `apps/docs/src/content/docs/cli/*.md`; `apps/docs/src/content/docs/reference/configuration.md` | https://flueframework.com/docs/cli/overview/ |
+| `references/routing-http.md` | `apps/docs/src/content/docs/guide/routing.md`; `apps/docs/src/content/docs/api/routing-api.md`; `packages/runtime/test/routing.test.ts` | https://flueframework.com/docs/guide/routing/ |
+| `references/target-node.md` | `apps/docs/src/content/docs/guide/targets/node.md`; `apps/docs/src/content/docs/ecosystem/deploy/node.md`; `packages/runtime/src/node/*` | https://flueframework.com/docs/guide/targets/node/ |
+| `references/target-cloudflare.md` | `apps/docs/src/content/docs/guide/targets/cloudflare.md`; `apps/docs/src/content/docs/ecosystem/deploy/cloudflare.md`; `packages/runtime/src/cloudflare/*`; `packages/cli/src/lib/build-plugin-cloudflare.ts` | https://flueframework.com/docs/guide/targets/cloudflare/ |
+| `references/channel-model.md` | `apps/docs/src/content/docs/guide/channels.md`; `apps/docs/src/content/docs/api/*-channel.md`; `blueprints/channel.md` | https://flueframework.com/docs/guide/channels/ |
+| `references/channel-github.md` | `apps/docs/src/content/docs/ecosystem/channels/github.md`; `apps/docs/src/content/docs/api/github-channel.md`; `packages/github/` | https://flueframework.com/docs/ecosystem/channels/github/ |
+| `references/channel-slack.md` | `apps/docs/src/content/docs/ecosystem/channels/slack.md`; `apps/docs/src/content/docs/api/slack-channel.md`; `packages/slack/` | https://flueframework.com/docs/ecosystem/channels/slack/ |
+| `references/channel-discord.md` | `apps/docs/src/content/docs/ecosystem/channels/discord.md`; `apps/docs/src/content/docs/api/discord-channel.md`; `packages/discord/` | https://flueframework.com/docs/ecosystem/channels/discord/ |
+| `references/channel-teams.md` | `apps/docs/src/content/docs/ecosystem/channels/teams.md`; `apps/docs/src/content/docs/api/teams-channel.md`; `packages/teams/` | https://flueframework.com/docs/ecosystem/channels/teams/ |
+| `references/channel-resend.md` | `apps/docs/src/content/docs/ecosystem/channels/resend.md`; `apps/docs/src/content/docs/api/resend-channel.md`; `packages/resend/` | https://flueframework.com/docs/ecosystem/channels/resend/ |
+| `references/sandbox-model.md` | `apps/docs/src/content/docs/guide/sandboxes.md`; `apps/docs/src/content/docs/api/sandbox-api.md`; `apps/docs/src/content/docs/ecosystem/sandboxes/*.md` | https://flueframework.com/docs/guide/sandboxes/ |
+| `references/data-persistence.md` | `apps/docs/src/content/docs/guide/database.md`; `apps/docs/src/content/docs/api/data-persistence-api.md`; `packages/postgres/`; `packages/runtime/src/adapter*` | https://flueframework.com/docs/guide/database/ |
+| `references/observability-errors.md` | `apps/docs/src/content/docs/guide/observability.md`; `apps/docs/src/content/docs/api/events-reference.md`; `apps/docs/src/content/docs/api/errors-reference.md`; `packages/runtime/src/errors.ts` | https://flueframework.com/docs/guide/observability/ |
+| `references/testing-conventions.md` | `AGENTS.md`; active tests under `packages/*/test/`; package scripts in `package.json` | https://flueframework.com/docs/ |
+
+## Adopted Decisions
+
+- Adopted: Use a top-level `skills/flue/` source artifact for the installable skill.
+- Adopted: Keep the skill authored by agents from docs/source, not generated from the full docs tree.
+- Adopted: Keep runtime references flat and specifically named.
+- Adopted: Include official docs URLs in this source map for deeper verification.
+- Rejected: Copying all docs pages into `references/`.
+- Rejected: Nested provider directories such as `references/channels/github.md`.
+- Rejected: Broad runtime buckets such as `channels.md`.
+
+## Coverage Notes
+
+- Initial provider-specific channel coverage includes GitHub, Slack, Discord, Teams, and Resend because their ecosystem guides contain concrete protocol, credential, deadline, and tool-binding behavior.
+- Other first-party channels should get `channel-[name].md` only when the reference can contain meaningful provider-specific guidance. Until then, use `channel-model.md` plus the official docs URL.
+- Sandbox provider-specific files should follow the same rule, such as `sandbox-cloudflare.md` or `sandbox-e2b.md`, when the shared sandbox model is not enough.
+
+## Stopping Rationale
+
+The first version covers the core Flue docs surfaces and representative provider-specific channel references without mirroring the full docs tree. Additional provider files should be added as docs work creates concrete agent-facing guidance.
+

--- a/skills/flue/SPEC.md
+++ b/skills/flue/SPEC.md
@@ -1,0 +1,96 @@
+# Flue Skill Specification
+
+## Intent
+
+The Flue skill gives coding agents a compact, implementation-focused map of Flue's documented behavior. It converts the public docs and repository conventions into routed guidance that helps agents build, debug, review, and document Flue projects without rereading the whole docs site.
+
+## Scope
+
+In scope:
+
+- Flue terminology, source layout, agents, workflows, sessions, operations, runs, routing, CLI commands, targets, channels, sandboxes, persistence, observability, and repository testing conventions.
+- Provider-specific channel guidance when the docs provide concrete setup, protocol, runtime, or failure behavior.
+- Links to official docs and local source paths for deeper verification.
+
+Out of scope:
+
+- Copying the full documentation corpus into the skill.
+- Replacing official API references or provider documentation.
+- Adding executable update scripts for the authored skill content.
+- Capturing secrets, private customer data, or non-public deployment URLs.
+
+## Users And Trigger Context
+
+- Primary users: coding agents implementing, reviewing, debugging, or documenting Flue work.
+- Common user requests: create a Flue agent, write a workflow, add a channel, choose a sandbox, configure a target, inspect runs, fix persistence, or update docs.
+- Should not trigger for: unrelated agent frameworks, generic TypeScript questions, or provider SDK work that does not touch Flue.
+
+## Runtime Contract
+
+- `SKILL.md` must provide a complete flat reference inventory and route every reference with a one-line reason.
+- Runtime references must be direct children of `references/`.
+- Broad shared files must answer a concrete decision, such as `channel-model.md`; provider-specific files use flat names such as `channel-github.md`.
+- The skill must preserve the workflow-only meaning of runs.
+- The skill must not invent behavior beyond docs, source, tests, examples, or blueprints.
+
+## Source And Evidence Model
+
+Authoritative sources:
+
+- Public docs under `apps/docs/src/content/docs/`.
+- Docs navigation under `apps/docs/src/lib/docs-navigation.ts`.
+- Runtime, CLI, SDK, and provider package source under `packages/`.
+- Active tests under `<package>/test/`.
+- Repository instructions in `AGENTS.md`.
+
+Useful improvement sources:
+
+- Changelog entries and release notes.
+- Blueprints under `blueprints/`.
+- Examples under `examples/`.
+- Review feedback that identifies a concrete correctness or durability risk.
+
+Data that must not be stored:
+
+- secrets, tokens, private keys, webhook raw bodies, provider response URLs, customer data, private URLs, or private identifiers not needed for reproduction.
+
+## Reference Architecture
+
+- `SKILL.md` contains the runtime router and universal guardrails.
+- `references/` contains flat, runtime-loadable lookup files.
+- `SOURCES.md` contains provenance, official docs URLs, local source ownership, decisions, and gaps.
+- `README.md` contains the portable agentic maintenance process.
+- No `scripts/` or generated runtime files are part of this skill.
+
+## Validation
+
+Lightweight validation:
+
+- Confirm `SKILL.md` frontmatter name is `flue` and matches the directory.
+- Confirm every `references/*.md` file is listed in `SKILL.md`.
+- Confirm every reference has source ownership in `SOURCES.md`.
+- Confirm no nested files exist under `references/`.
+
+Deeper validation:
+
+- Ask the skill to answer representative Flue implementation questions and verify against official docs/source.
+- Check provider-specific files against their package docs and API references after channel docs change.
+
+Acceptance gates:
+
+- No copied full docs pages.
+- No vague plural category buckets such as `channels.md` or nested `references/channels/github.md`.
+- Official docs links remain available in `SOURCES.md`.
+
+## Known Limitations
+
+- This skill is curated and may omit details that are already better served by the official docs or API reference.
+- Provider-specific references are added only when they contain useful behavior beyond the shared model.
+- The skill does not guarantee the public docs URL is reachable from every runtime environment.
+
+## Maintenance Notes
+
+- Update `SKILL.md` when adding, removing, or renaming a reference.
+- Update `SOURCES.md` whenever source ownership, official docs URLs, or known gaps change.
+- Update only affected references when docs change; do not mirror the docs tree.
+

--- a/skills/flue/references/agent-sessions-operations.md
+++ b/skills/flue/references/agent-sessions-operations.md
@@ -1,0 +1,75 @@
+# Agent Sessions And Operations
+
+Use this when creating continuing agents, direct prompts, dispatched input, sessions, or operation-level calls.
+
+## Created Agent
+
+```ts
+import { createAgent } from '@flue/runtime';
+
+export default createAgent(({ id }) => ({
+  model: 'anthropic/claude-haiku-4-5',
+  instructions: `Help with ticket ${id}.`,
+}));
+```
+
+- Filename gives the discovered agent name.
+- `id` selects one continuing agent instance.
+- Application code decides what `id` means and must authorize caller access to it.
+- Conversation history belongs to the session store; business data belongs to the application.
+
+## Public Direct Prompt
+
+Export `route` from an agent module to expose:
+
+- `POST /agents/<name>/<id>` for prompts.
+- `GET /agents/<name>/<id>` for event streaming.
+
+Use the route handler to authenticate and authorize the selected `id`.
+
+## Dispatch
+
+Use `dispatch(agent, { id, input })` when an accepted application or provider event should enter a continuing agent session asynchronously.
+
+```ts
+await dispatch(supportAssistant, {
+  id: event.ticketId,
+  input: {
+    type: 'support.comment.created',
+    commentId: event.commentId,
+    text: event.text,
+  },
+});
+```
+
+- Application code chooses the agent and instance ID.
+- Dispatched input is an agent session operation, not a workflow run.
+- Preserve delivery IDs in input when useful for tracing.
+- Claim delivery IDs in application storage before dispatch when duplicate admission is unacceptable.
+
+## Harness And Session
+
+Inside workflows or application-controlled execution:
+
+```ts
+const harness = await init(agent);
+const session = await harness.session();
+const response = await session.prompt('Summarize this ticket.');
+```
+
+- Use `harness` as the variable name for `init(...)`.
+- Use named sessions for parallel or separate conversation branches.
+- A session runs one active operation at a time.
+- Use structured results when application code depends on fields rather than prose.
+
+## Operation Choices
+
+| Need | Use |
+| --- | --- |
+| Send text or images to the agent | `session.prompt(...)` |
+| Invoke a registered skill | `session.skill(...)` |
+| Delegate to a child session or subagent | `session.task(...)` |
+| Run command output into session context | `session.shell(...)` |
+| Stage or collect workspace files outside conversation | `harness.fs` |
+| Prepare workspace without adding conversation messages | `harness.shell(...)` |
+

--- a/skills/flue/references/channel-discord.md
+++ b/skills/flue/references/channel-discord.md
@@ -1,0 +1,41 @@
+# Discord Channel
+
+Use this for `@flue/discord`, HTTP interactions, response deadlines, REST tools, and Discord destination keys.
+
+## Setup
+
+- Run `flue add channel discord`.
+- Use `@flue/discord` for verified HTTP interactions.
+- Use project-owned `@discordjs/rest` for outbound REST calls.
+- Required environment:
+  - `DISCORD_PUBLIC_KEY`
+  - `DISCORD_BOT_TOKEN`
+- Configure Interactions Endpoint URL: `https://example.com/channels/discord/interactions`.
+
+Discord Gateway is a persistent WebSocket transport and is outside the Flue channel model.
+
+## Interactions
+
+- Supported route: `/channels/discord/interactions`.
+- Signed PING requests are answered with PONG internally.
+- `interaction` is Discord's provider-native API v10 object.
+- Numeric `interaction.type` discriminates commands, autocomplete, components, and modal submissions.
+- Preserve and branch on Discord's native fields.
+- Authenticated future numeric types can still arrive at runtime; tolerate unfamiliar values.
+
+## Deadlines And Tokens
+
+- Every non-PING HTTP interaction requires a valid interaction response.
+- Discord invalidates the interaction token if the initial response is not sent within three seconds.
+- Return type `4` for immediate response or type `5` for deferred response.
+- Interaction tokens remain valid for follow-up operations for up to 15 minutes.
+- Keep `interaction.token` out of dispatch input, model context, logs, and durable session history.
+
+## Destination And Tools
+
+- Derive a destination from native guild, channel, channel type, and context fields.
+- Some valid interactions omit a durable channel.
+- Private-channel interactions may be acknowledged with their token but do not grant arbitrary bot message access.
+- Use `channel.conversationKey(ref)` for destinations that should continue one agent instance.
+- Bind REST tools with trusted destination and bot token; model chooses message content only.
+

--- a/skills/flue/references/channel-github.md
+++ b/skills/flue/references/channel-github.md
@@ -1,0 +1,39 @@
+# GitHub Channel
+
+Use this for `@flue/github`, signed webhooks, Octokit tools, and issue or pull-request conversation keys.
+
+## Setup
+
+- Run `flue add channel github`.
+- Install/use `@flue/github` for verified ingress.
+- Use official `@octokit/rest` for outbound API calls.
+- Required environment:
+  - `GITHUB_WEBHOOK_SECRET`
+  - `GITHUB_TOKEN`
+- Configure webhook URL: `https://example.com/channels/github/webhook`.
+- Use `application/json`; form-encoded deliveries are not accepted.
+
+## Handler Notes
+
+- Export `channel = createGitHubChannel({ webhookSecret, webhook })`.
+- `delivery.name` is the `X-GitHub-Event` value and narrows `delivery.payload`.
+- Payloads preserve GitHub field names and nesting.
+- GitHub `ping` is acknowledged internally and does not reach the callback.
+- There is no fixed supported-event list; subscribe in GitHub and branch in application code.
+
+## Conversation And Tools
+
+- Use `channel.conversationKey(issueRef)` for repository plus issue or pull request number.
+- Pull requests use their issue number for issue comments.
+- Bind outbound tools with `channel.parseConversationKey(id)` in trusted code.
+- The model should choose the comment body only; trusted code binds owner, repo, issue number, and token.
+- The channel-agent import cycle is acceptable when imported bindings are read only inside deferred callbacks or initializers.
+
+## Delivery Behavior
+
+- GitHub expects a `2xx` response within ten seconds.
+- The package does not enforce a handler deadline; admit durable work quickly.
+- GitHub does not auto-retry, but failed deliveries can be manually redelivered with the same delivery ID.
+- Claim `delivery.deliveryId` in application storage before dispatch when duplicate admission matters.
+- Octokit REST Fetch paths used by examples are tested in workerd with `nodejs_compat`; verify additional SDK methods.
+

--- a/skills/flue/references/channel-model.md
+++ b/skills/flue/references/channel-model.md
@@ -1,0 +1,50 @@
+# Channel Model
+
+Use this when adding or reviewing any provider HTTP ingress.
+
+## Ownership Boundary
+
+| Concern | Owner |
+| --- | --- |
+| Signature verification, request authentication, protocol handshakes, parsing | Channel package |
+| Route namespace under `/channels/<name>/...` | Flue |
+| Provider SDK client, OAuth, tokens, outbound calls | Application |
+| Agent tools, authorization policy, deduplication, business persistence | Application |
+
+Channels are inbound HTTP integrations. They are not universal provider clients and do not replace provider SDKs.
+
+## File And Route Rules
+
+- Each immediate `channels/<name>.ts` file exports one named `channel`.
+- Filename defines route namespace.
+- Provider package defines one or more fixed non-empty suffixes.
+- `/channels/<name>` itself is not an endpoint.
+- `app.ts` can prefix all Flue routes but cannot relocate one channel independently.
+
+## Handler Contract
+
+- Callback runs only after the channel package verifies and parses the request.
+- Callback receives provider-native typed data and the Hono context.
+- Return nothing for empty success when appropriate.
+- Return Hono/Fetch responses for explicit status, headers, or body.
+- Omitted optional callbacks omit their routes.
+- Provider callbacks may have deadlines; admit durable work promptly.
+
+## Delivering To Agents
+
+Use `dispatch(...)` for provider events that should continue an agent session.
+
+- Choose agent and instance ID in trusted application code.
+- Use provider thread, issue, ticket, channel, or message identity as the conversation boundary when appropriate.
+- Conversation keys are identifiers, not authorization capabilities.
+- If caller-selected IDs are exposed elsewhere, authorize before using them for provider destinations or tools.
+- Dispatched provider events are agent session operations, not workflow runs.
+
+## Retry And Secret Handling
+
+- Channel packages are stateless and do not deduplicate.
+- Providers may retry, redeliver, or reorder events.
+- Claim provider delivery IDs in application storage before external effects when duplicates matter.
+- Keep credentials, raw bodies, response URLs, interaction tokens, and short-lived capabilities out of model context, dispatched input, logs, and durable session history.
+- Validate target runtime behavior for any provider SDK path used on Cloudflare.
+

--- a/skills/flue/references/channel-resend.md
+++ b/skills/flue/references/channel-resend.md
@@ -1,0 +1,48 @@
+# Resend Channel
+
+Use this for `@flue/resend`, verified webhooks, inbound email retrieval, and message-scoped agent instances.
+
+## Setup
+
+- Run `flue add channel resend`.
+- Use `@flue/resend` for verified ingress.
+- Use official `resend` SDK for outbound API and email retrieval.
+- Required environment:
+  - `RESEND_WEBHOOK_SECRET`
+  - `RESEND_API_KEY`
+- Configure webhook URL: `https://example.com/channels/resend/webhook`.
+- Webhook secret and outbound API key are separate credentials.
+
+The SDK declarations may require `@types/node` and `@types/react` as development dependencies; these add no Node or React runtime code to Worker bundles.
+
+## Webhook Behavior
+
+- `createResendChannel({ client, webhookSecret, webhook })` verifies exact request body and Svix headers.
+- Returning nothing produces empty `200`.
+- JSON-compatible values become response bodies.
+- Hono/Fetch responses pass through.
+- Resend retries every status other than `200`; return non-`200` only when redelivery is intentional.
+- Events preserve official provider-native fields, including newer event types.
+- `switch (event.type)` narrows modeled variants; keep a default branch for SDK-newer events.
+
+## Inbound Email
+
+- `email.received` includes routing metadata and attachment descriptors.
+- Retrieve full body, headers, and current attachment metadata later through `client.emails.receiving.get(emailId)`.
+- Use attachment APIs for signed download URLs only when attachment content is needed.
+- Decide separately what email content may enter model context or durable storage.
+
+## Instance IDs And Tools
+
+- Use an application convention such as `resend-email:${encodeURIComponent(emailId)}` for one inbound message.
+- Bind `retrieveReceivedEmail(emailId)` in trusted code so the model can retrieve only the email already bound to the agent.
+- Outbound send, forward, or reply tools should bind credentials, sender identity, recipients, and message policy outside model-selected arguments.
+- The package does not expose a conversation helper because Resend `message_id` identifies one message rather than a stable thread root.
+
+## Delivery
+
+- Resend delivery is at least once and ordering is not guaranteed.
+- `delivery.id` comes from `svix-id` and is useful for deduplication.
+- Claim delivery IDs in application storage before dispatch when duplicate admission is unacceptable.
+- The channel does not register webhooks, manage receiving domains, store credentials, deduplicate, restore ordering, persist messages, retrieve bodies automatically, or send replies.
+

--- a/skills/flue/references/channel-slack.md
+++ b/skills/flue/references/channel-slack.md
@@ -1,0 +1,46 @@
+# Slack Channel
+
+Use this for `@flue/slack`, Slack Events API, interactions, slash commands, and Web API tools.
+
+## Setup
+
+- Run `flue add channel slack`.
+- Use `@flue/slack` for verified ingress.
+- Use Slack's official `@slack/web-api` client for outbound calls.
+- Required environment:
+  - `SLACK_SIGNING_SECRET`
+  - `SLACK_BOT_TOKEN`
+
+## Surfaces
+
+| Slack surface | Route |
+| --- | --- |
+| Event Subscriptions | `/channels/slack/events` |
+| Interactivity | `/channels/slack/interactions` |
+| Slash commands | `/channels/slack/commands` |
+
+Add only the callbacks the application handles. Omitted callbacks omit routes. URL verification is answered internally after signature verification.
+
+## Events
+
+- `payload` is Slack's outer Events API delivery.
+- For `event_callback`, `payload.event` uses Slack's event union.
+- Switch on `payload.event.type`; message subtypes remain under `payload.event.subtype`.
+- The channel does not filter bot messages, subtypes, or event families.
+- `app_rate_limited` notifications reach the callback.
+- Workspace and enterprise identity stay in payload; enforce allowlists in application code when needed.
+
+## Interactions And Commands
+
+- Payloads preserve Slack snake_case wire fields.
+- `trigger_id`, `response_url`, and view `response_urls` are short-lived capabilities.
+- Keep those capabilities in immediate trusted request handling, not model context, dispatch input, logs, or durable session history.
+- Slack expects prompt acknowledgements; dispatch durable work and return quickly.
+
+## Thread Tools
+
+- Export a Web API `client`.
+- Define tools such as `replyInThread(ref)` with channel and thread bound in trusted code.
+- Use `channel.conversationKey({ teamId, channelId, threadTs })` for thread-scoped agent instances.
+- The model should choose message text, not Slack destination or token.
+

--- a/skills/flue/references/channel-teams.md
+++ b/skills/flue/references/channel-teams.md
@@ -1,0 +1,47 @@
+# Microsoft Teams Channel
+
+Use this for `@flue/teams`, Bot Connector activities, Teams authentication, and conversation-bound reply tools.
+
+## Setup
+
+- Run `flue add channel teams`.
+- Use `@flue/teams` for authenticated Bot Connector ingress.
+- Use the generated Fetch Bot Connector client for outbound messages.
+- Required environment:
+  - `TEAMS_APP_ID`
+  - `TEAMS_TENANT_ID`
+  - `TEAMS_APP_PASSWORD`
+- Configure Azure Bot messaging endpoint: `https://example.com/channels/teams/activities`.
+
+The blueprint uses documented OAuth and Bot Connector REST protocols through Fetch so the integration can run on Node and Cloudflare Workers.
+
+## Activities
+
+- Route: `/channels/teams/activities`.
+- Callback receives provider-native Bot Framework `Activity`.
+- Switch on `activity.type`, such as `message`, `conversationUpdate`, `invoke`, and `messageReaction`.
+- Use `channel.destination(activity)` to derive canonical reply identity.
+- `invoke` activities expect a JSON acknowledgement body.
+- Azure Bot Service retries on non-2xx responses; return 2xx after work is safely admitted.
+
+## Authentication
+
+`@flue/teams` verifies:
+
+- Microsoft OpenID signing key and `RS256` signature.
+- Issuer, application audience, and expiration.
+- Signing key `msteams` endorsement.
+- Activity `serviceUrl` against signed token claim.
+- Host conversation and channel tenant against `TEAMS_TENANT_ID`.
+
+Sovereign deployments can provide documented OpenID metadata URL, token issuer, and OAuth authority.
+
+## Conversation And Tools
+
+- Use `channel.conversationKey(channel.destination(activity))` for conversation-scoped agent IDs.
+- Bind reply tools with `channel.parseConversationKey(id)`.
+- Trusted code binds tenant, Connector service URL, conversation, bot account, and thread.
+- The model selects only message text.
+- Conversation keys validate syntax, not authorization; keep the agent dispatch-only or authorize caller-selected IDs separately.
+- Claim activity IDs in application storage before dispatch when duplicate admission matters.
+

--- a/skills/flue/references/cli-build-dev.md
+++ b/skills/flue/references/cli-build-dev.md
@@ -1,0 +1,40 @@
+# CLI, Build, And Dev
+
+Use this for command behavior and local workflows.
+
+## Core Commands
+
+| Command | Use |
+| --- | --- |
+| `flue dev` | Watch-mode dev server. |
+| `flue build` | Build deployable artifact to output directory. |
+| `flue run <workflow>` | Build and invoke one workflow locally. |
+| `flue connect <agent> <instance-id>` | Build and open an interactive local connection to an agent instance. |
+| `flue logs <runId>` | Tail or replay workflow run events from a running Flue server. |
+| `flue init --target <node|cloudflare>` | Scaffold `flue.config.*`. |
+| `flue add <kind> <name|url>` | Fetch a blueprint implementation guide. |
+| `flue update <kind> <name|url>` | Fetch an updated blueprint implementation guide. |
+| `flue docs` | List docs pages. |
+| `flue docs read <path>` | Print one docs page as markdown. |
+| `flue docs search <query>` | Search docs and return JSON results. |
+
+## Configuration Inputs
+
+- `flue.config.ts` accepts `target`, `root`, and `output`.
+- CLI flags override config values.
+- `root` controls source discovery.
+- `output` defaults to `<root>/dist`.
+- `--env <path>` selects one alternate `.env`-format file for build/dev/run/connect.
+- Without `--env`, commands load `<project>/.env` when present; shell values win.
+
+## Target Defaults
+
+| Target | Dev behavior |
+| --- | --- |
+| Node | Generated server; `flue dev --target node` defaults to port `3583`; production server defaults to `PORT` or `3000`. |
+| Cloudflare | Worker-oriented build and dev flow; requires valid Wrangler configuration for deployment. |
+
+## Agent-Oriented Docs Access
+
+Use `flue docs search` and `flue docs read` when a consuming agent needs exact current documentation. The installable Flue skill should route and summarize; the docs command should provide page-level detail.
+

--- a/skills/flue/references/data-persistence.md
+++ b/skills/flue/references/data-persistence.md
@@ -1,0 +1,46 @@
+# Data Persistence
+
+Use this for `db.ts`, adapter choice, and what Flue stores.
+
+## Node Persistence
+
+Add source-root `db.ts` when Node state should survive restart:
+
+```ts
+import { sqlite } from '@flue/runtime/node';
+
+export default sqlite('./data/flue.db');
+```
+
+| Adapter | Use |
+| --- | --- |
+| No `db.ts` | In-memory SQLite; state lost on process exit. |
+| `sqlite('./file.db')` | Local development, single-host deployment, small services. |
+| `@flue/postgres` | Multi-replica Node deployment or host replacement recovery. |
+| Custom `PersistenceAdapter` | Another database backend or hosting strategy. |
+
+Postgres `migrate()` runs automatically when the generated Node server starts.
+
+## Cloudflare Persistence
+
+- No `db.ts`.
+- Generated agent and workflow Durable Objects use SQLite automatically.
+- Run indexing lives in generated `FlueRegistry`.
+- Cloudflare build rejects a source-root `db.ts`.
+
+## Stored Vs Not Stored
+
+| Stored by Flue | Not stored by Flue |
+| --- | --- |
+| Agent session messages and compaction state | Sandbox files and installed dependencies |
+| Accepted direct prompts and `dispatch(...)` submissions | External API side effects |
+| Workflow-run records and persisted events | Business data unless application tools store it |
+| Run indexing for `/runs` and `listRuns()` | Provider credentials or secrets |
+
+## Design Checks
+
+- Keep customer records, payments, tickets, and durable business entities in the application database.
+- Treat external effects as application-owned and make them idempotent when provider retries are possible.
+- Do not assume persisted session history means workspace files are durable.
+- Do not assume a durable sandbox preserves conversation state.
+

--- a/skills/flue/references/observability-errors.md
+++ b/skills/flue/references/observability-errors.md
@@ -1,0 +1,55 @@
+# Observability And Errors
+
+Use this when inspecting work, exporting telemetry, or handling Flue errors.
+
+## Workflow Run Inspection
+
+- Each workflow invocation has a `runId`.
+- `flue logs <runId> --server <url>` inspects workflow runs.
+- `flue logs` does not inspect direct agent prompts or dispatched agent input.
+- Use workflow `log.info`, `log.warn`, and `log.error` for application-specific facts.
+- Logs accept structured attributes for search and aggregation.
+
+## Observe Application Activity
+
+Register `observe(...)` in `app.ts` to monitor workflows and continuing agents handled by that running application context.
+
+```ts
+observe((event) => {
+  if (event.type === 'run_end' && event.isError) {
+    console.error('Workflow failed', event.runId, event.error);
+  }
+});
+```
+
+- Branch on `event.type`.
+- Treat events as read-only.
+- Return immediately for events you do not consume.
+- Keep callbacks lightweight; returned promises are observed for rejection but not awaited.
+- In distributed deployments, each context observes only activity it handles.
+
+## Event Boundaries
+
+| Boundary | Meaning |
+| --- | --- |
+| Workflow run | Finite workflow invocation and its persisted run history. |
+| Operation | Prompt, skill, task, shell, or compact call inside agent activity. |
+| Turn | One nested model round trip. |
+
+Streaming deltas are best-effort live progress. `message_end` is the authoritative completed assistant message.
+
+## Privacy
+
+Events can contain payloads, prompts, model messages, logs, tool values, errors, and application metadata. Flue omits recognized image bytes, but arbitrary payloads and logs still need application-owned sanitization.
+
+Start with outcome-oriented signals: failed workflows, explicit application error logs, slow operations, and completed usage. Do not alert on every nested model/tool error when the agent can recover.
+
+## Error Conventions In This Repo
+
+- Throw structured error classes from `packages/runtime/src/errors.ts`.
+- Do not add ad-hoc `new Error('[flue] ...')` in runtime code.
+- Put machine-readable fields in `details`.
+- Put developer-only setup mechanics, paths, and guidance in `dev`.
+- Caller-visible messages are not API.
+- Tests should assert on error class and structured data, not message text.
+

--- a/skills/flue/references/project-layout.md
+++ b/skills/flue/references/project-layout.md
@@ -1,0 +1,42 @@
+# Project Layout
+
+Use this when deciding where Flue discovers authored source and what gets generated.
+
+## Discovery Order
+
+Flue chooses one source directory relative to the project root:
+
+1. `<root>/.flue/`
+2. `<root>/src/`
+3. `<root>/`
+
+The first matching directory wins. Flue does not merge layouts. If `.flue/` exists, bare `src/`, `agents/`, `workflows/`, and `channels/` outside `.flue/` are ignored for discovery.
+
+## Discovered Entrypoints
+
+| Path | Rule |
+| --- | --- |
+| `app.ts` | Optional Hono app that composes application routes and mounts `flue()`. |
+| `cloudflare.ts` | Optional Cloudflare-only Worker extensions, named exports, and non-HTTP handlers. |
+| `agents/` | Immediate files define addressable agents. Filename becomes agent name. Nested files are support modules only. |
+| `workflows/` | Immediate files define workflows. Filename becomes workflow name. Nested files are support modules only. |
+| `channels/` | Immediate files export one named `channel`. Filename becomes immutable route namespace under `/channels/<name>/...`. |
+| `db.ts` | Node-only persistence adapter. Rejected on Cloudflare. |
+
+Prefer lower-kebab-case filenames for discovered agents, workflows, and channels.
+
+## Generated Output
+
+- `dist/` is generated output by default and is not authored source.
+- Change output with `output` in `flue.config.ts`.
+- Change project root with `root` in `flue.config.ts` or CLI `--root`.
+- Build target is `target: 'node' | 'cloudflare'` or CLI `--target`.
+
+## Common Mistakes
+
+| Symptom | Check |
+| --- | --- |
+| Agent or workflow is not discovered | Is it nested? Is another source root winning? Does `.flue/` exist? |
+| Channel route is not at expected path | Channel filename defines namespace; package defines non-empty suffix; `app.ts` prefix applies to all Flue routes. |
+| Cloudflare build rejects `db.ts` | Cloudflare uses generated Durable Object SQLite; remove `db.ts`. |
+

--- a/skills/flue/references/routing-http.md
+++ b/skills/flue/references/routing-http.md
@@ -1,0 +1,51 @@
+# HTTP Routing
+
+Use this when composing Flue routes with application-owned HTTP behavior.
+
+## `app.ts`
+
+Without `app.ts`, Flue generates an application mounted at `/`. With `app.ts`, export a Hono app and mount Flue explicitly:
+
+```ts
+import { flue } from '@flue/runtime/routing';
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+app.get('/health', (c) => c.json({ ok: true }));
+app.route('/', flue());
+
+export default app;
+```
+
+Use `app.ts` for authentication, route prefixes, custom webhooks, health checks, and middleware.
+
+## Published Flue Route Families
+
+| Export | Route family |
+| --- | --- |
+| Agent `route` | `POST /agents/:name/:id` and `GET /agents/:name/:id` |
+| Workflow `route` | `POST /workflows/:name` |
+| Channel `channel` | `/channels/:name/<provider-suffix>` |
+| Run routes | `GET /runs/:runId` and `GET /runs/:runId?meta` |
+
+Mounting `flue()` does not expose every agent or workflow. Agent and workflow modules opt in with their own `route` exports. Run routes are registered beneath the mount path and must be protected by middleware.
+
+## Prefixing
+
+```ts
+app.route('/api', flue());
+```
+
+This moves all Flue routes beneath `/api`, including agents, workflows, runs, and channels. SDK `baseUrl` must include the prefix.
+
+Discovered channel filenames and provider suffixes are fixed below the mount. Use an application-owned Hono route outside `channels/` when one provider needs complete custom path control.
+
+## Authorization Checklist
+
+- Authenticate broad route families with Hono middleware.
+- Authorize selected agent instance IDs in agent route middleware.
+- Protect `/runs/*`; run IDs can disclose sensitive work.
+- If run existence must stay hidden, return the same `404` shape for unauthorized and unknown runs.
+- For custom provider routes, verify the provider request before dispatching to an agent.
+

--- a/skills/flue/references/sandbox-model.md
+++ b/skills/flue/references/sandbox-model.md
@@ -1,0 +1,51 @@
+# Sandbox Model
+
+Use this when choosing or explaining agent workspace access.
+
+## Sandbox Choices
+
+| Sandbox | Use when |
+| --- | --- |
+| Virtual sandbox | The application can provide needed files and only lightweight workspace work is required. |
+| Node `local()` | Trusted Node.js agent should operate directly on host files and shell. |
+| Remote sandbox | Work needs isolation, tenant-specific workspace, Linux tooling, provider-managed lifecycle, or durable files. |
+| Cloudflare Sandbox | Cloudflare-deployed agent needs container-backed Linux shell, git, packages, or native commands. |
+| Cloudflare Shell / Codemode | Cloudflare agent needs durable structured code operations, not arbitrary Linux shell. |
+
+## Virtual Sandbox
+
+- Default when no `sandbox` is configured.
+- In-memory workspace powered by `just-bash`.
+- Starts without application files or host filesystem.
+- Files do not persist beyond in-memory lifetime.
+- Suitable for staged documents and lightweight file/command work.
+- Not a network isolation boundary.
+
+## Node `local()`
+
+- Direct host filesystem and shell access.
+- Node target only.
+- Good for trusted dev tools, disposable CI, and self-hosted automation.
+- Not isolation from model-directed commands.
+- Expose environment variables narrowly through `local({ env })`.
+
+## Remote Sandbox
+
+Application owns:
+
+- workspace selection per agent instance or workflow;
+- credentials and network access;
+- reuse policy;
+- deletion and expiry;
+- mapping between session history and workspace lifecycle.
+
+## Persistence Separation
+
+| Question | Controlled by |
+| --- | --- |
+| Does conversation history continue later? | Session persistence via `db.ts`, target default, or Durable Object SQLite. |
+| Do files and installed packages remain? | Sandbox/workspace lifecycle. |
+| What can commands or tools access? | Sandbox environment, tools, and application authorization. |
+
+A persisted session does not make the virtual sandbox durable. A durable remote workspace does not preserve conversation history by itself.
+

--- a/skills/flue/references/skill-tool-subagent.md
+++ b/skills/flue/references/skill-tool-subagent.md
@@ -1,0 +1,49 @@
+# Skills, Tools, And Subagents
+
+Use this when deciding what capability to add to an agent.
+
+## Decision Table
+
+| Need | Use |
+| --- | --- |
+| Reusable instructions, checklist, or process | Agent Skill |
+| Application code action or data lookup | Tool |
+| Filesystem or command workspace | Sandbox |
+| Focused delegated reasoning role | Subagent profile |
+| Remote tool server | MCP tools through `connectMcpServer(...)` |
+
+Skills guide work; they do not add executable capabilities. Tools execute application code. Sandboxes provide file and command access.
+
+## Skills In Flue
+
+- Imported skills use `import review from '../skills/review/SKILL.md' with { type: 'skill' }`.
+- Passing imported references in `skills` makes them available to the agent.
+- Workspace-discovered skills are loaded from `<cwd>/.agents/skills/<name>/`.
+- Imported and workspace skills cannot share the same declared name.
+- Skill frontmatter `name` must match the directory name, be lower-case hyphenated, and be at most 64 characters.
+- Supporting files beside `SKILL.md` are packaged for imported skills; do not store secrets there.
+
+Invoke a skill manually with `session.skill('name', { args, result })` when application logic needs it.
+
+## Tools
+
+- Define tools with `defineTool(...)`.
+- Use action-oriented names like `lookup_order_status`.
+- Validate model-selected arguments with Valibot or JSON Schema.
+- Bind credentials, tenants, repository IDs, ticket IDs, and destinations in trusted code.
+- The model should choose content or narrow values, not authority boundaries.
+- Per-call tools can be supplied through `session.prompt`, `session.skill`, or `session.task` options.
+
+## Subagents
+
+- A subagent is a named `defineAgentProfile(...)` declared on a parent agent.
+- It runs in a separate child session.
+- It is not addressable at `/agents/<name>/<id>`.
+- The profile `description` should tell the parent when to delegate.
+- `instructions`, `tools`, `skills`, and `subagents` are profile-owned; omitted means none.
+- `model`, `thinkingLevel`, and `compaction` inherit as defaults.
+- `durability` on a subagent profile is rejected.
+- A `task()` call without `agent` reuses the parent's full configuration in a fresh context.
+
+When asking a subagent to review or implement work, include a notice that it must not spawn its own subagents.
+

--- a/skills/flue/references/target-cloudflare.md
+++ b/skills/flue/references/target-cloudflare.md
@@ -1,0 +1,63 @@
+# Cloudflare Target
+
+Use this for Workers, generated Durable Objects, migrations, Cloudflare sandboxes, and Cloudflare extensions.
+
+## Generated Durable Objects
+
+Flue generates a Durable Object class and Wrangler binding for each discovered agent and workflow:
+
+```txt
+src/agents/support-chat.ts -> FlueSupportChatAgent, env.FLUE_SUPPORT_CHAT_AGENT
+src/workflows/translate.ts -> FlueTranslateWorkflow, env.FLUE_TRANSLATE_WORKFLOW
+```
+
+- Agent session state, accepted submissions, and workflow run history are stored in Durable Object SQLite.
+- `FlueRegistry` indexes workflow runs across the deployment.
+- Cloudflare builds reject source-root `db.ts`.
+- Do not hand-author Flue generated `FLUE_*` bindings in `wrangler.jsonc`.
+
+## Wrangler Requirements
+
+`wrangler.jsonc` must include:
+
+- `nodejs_compat` in `compatibility_flags`.
+- Durable Object migrations for every generated Flue class.
+- `FlueRegistry` in the initial migration.
+
+Use `new_sqlite_classes` for generated Flue classes. Append migrations for added, renamed, or deleted classes. Do not rewrite deployed migration history.
+
+## Durable Execution
+
+- Direct HTTP prompts and `dispatch(...)` inputs enter the same durable per-agent-instance queue.
+- The submitting connection observes work but does not own it.
+- Disconnect after admission does not necessarily stop backend work.
+- Events are durably stored and replayable by offset.
+- Recovery requeues only when Flue can prove input was not applied; uncertain model/tool work is recorded as interrupted rather than blindly repeated.
+
+## Workers AI
+
+Use `cloudflare/...` model specifiers on the Cloudflare target without provider API keys:
+
+```ts
+model: 'cloudflare/@cf/meta/llama-3.1-8b-instruct'
+```
+
+Flue enables AI Gateway by default for `cloudflare/...` models. Re-register the `cloudflare` provider in `app.ts` when customizing gateway behavior.
+
+## Cloudflare Sandbox And Shell
+
+| Need | Use |
+| --- | --- |
+| Full Linux container with shell commands, git, package installation, native binaries | Cloudflare Sandbox plus `cloudflareSandbox(...)` |
+| Durable Workspace with structured code operations but not arbitrary Linux shell | Cloudflare Shell / Codemode generated adapter |
+| Prompt-and-response or lightweight workspace work | Default virtual sandbox |
+
+Cloudflare Shell adapters are imported from the generated sandbox adapter file, not from `@flue/runtime/cloudflare`.
+
+## Extension Points
+
+- Export `cloudflare = extend({ base, wrap })` from an agent or workflow module to add module-local Durable Object behavior.
+- Do not override Flue-owned `fetch()`, `onRequest()`, `onFiberRecovered()`, or `alarm()`.
+- Use `cloudflare.ts` for Worker-level named exports and non-HTTP handlers.
+- Do not define a default `fetch` in `cloudflare.ts`; HTTP composition belongs in `app.ts`.
+

--- a/skills/flue/references/target-node.md
+++ b/skills/flue/references/target-node.md
@@ -1,0 +1,47 @@
+# Node Target
+
+Use this for Node.js build, runtime, sandbox, persistence, and restart behavior.
+
+## Generated Server
+
+- Build with `flue build --target node`.
+- Start the generated server with `node dist/server.mjs`.
+- Default production port is `3000`; set `PORT` to change it.
+- `flue dev --target node` defaults to port `3583` and reloads on changes.
+- Application dependencies are externalized. Deploy the built artifact alongside `node_modules` or inside a container that installs dependencies.
+
+## State
+
+| Setup | Behavior |
+| --- | --- |
+| No `db.ts` | Process-local in-memory SQLite; state disappears on exit. |
+| `db.ts` with `sqlite('./file.db')` | State survives process restart on the same host. |
+| `db.ts` with `@flue/postgres` | State can survive host replacement and be shared across replicas. |
+
+With a durable adapter, direct prompts and `dispatch(...)` inputs enter the same SQL-backed per-instance queue and are processed in accepted order.
+
+## Restart Caveat
+
+Node does not have Cloudflare's automatic Durable Object wake or Fiber recovery. Startup reconciliation covers agent submissions. Interrupted workflow runs may remain listed as active with open streams even when their persisted events are readable. Use `flue logs --no-follow` to inspect persisted events after a crash.
+
+## `local()` Sandbox
+
+```ts
+import { local } from '@flue/runtime/node';
+
+export default createAgent(() => ({
+  sandbox: local(),
+}));
+```
+
+- Node is the only target with the built-in `local()` factory.
+- It exposes the host filesystem and shell to model-directed work.
+- It is useful for trusted development tools, CI tasks, and self-hosted automation.
+- It is not an isolation boundary.
+- Only shell-essential environment variables are exposed by default.
+- Pass narrow `env` values explicitly; avoid `env: { ...process.env }` except in trusted environments.
+
+## Environment
+
+CLI commands load project `.env` during build/dev/run/connect. The built server does not load `.env`; provide environment variables when starting the process.
+

--- a/skills/flue/references/terminology.md
+++ b/skills/flue/references/terminology.md
@@ -1,0 +1,35 @@
+# Terminology
+
+Use these names consistently. Do not rotate synonyms in implementation docs, tests, or generated code comments.
+
+| Term | Meaning |
+| --- | --- |
+| Agent profile | One reusable `defineAgentProfile(...)` value. |
+| Created agent | One runtime initializer returned from `createAgent(...)`. |
+| Agent module | `agents/<name>.ts`; default-exports a created agent and may export `route`, `description`, or target extensions. |
+| Agent instance | URL-selected `<id>` for one created agent; passed to `createAgent(({ id }))`. |
+| Harness | Runtime-initialized agent environment returned by `init(agent)`. Use `harness` as the variable name. |
+| Session | One `harness.session(name?)`; default name is `"default"`. |
+| Operation | One `session.prompt`, `session.skill`, `session.task`, `session.shell`, or related bounded call. |
+| Turn | One LLM round trip inside an operation. |
+| Workflow | `workflows/<name>.ts`; exports `run(...)`. |
+| Workflow run | One invocation of a workflow with `ctx.id === runId`. |
+
+## Non-Negotiable Distinctions
+
+- Runs are workflow-only.
+- Direct HTTP/WebSocket prompts to an agent instance are operations in persistent sessions, not runs.
+- `dispatch(...)` delivers asynchronous input to an agent session and is identified by `dispatchId`, not `runId`.
+- `/runs`, `flue logs`, and SDK `client.runs.*` inspect workflow runs only.
+- Agents have names; agent instances have IDs; harnesses and sessions have names; operations have generated IDs.
+- A subagent is an agent profile used for delegated work, not a separately addressable agent endpoint.
+
+## Preferred Wording
+
+| Say | Avoid |
+| --- | --- |
+| "Initialize the agent and get a harness." | "Start a run for the agent." |
+| "Dispatch input to the agent instance." | "Create a run from the webhook." |
+| "Inspect the workflow run with `flue logs`." | "Inspect the prompt with `flue logs`." |
+| "Open a session on the harness." | "Open an agent run session." |
+

--- a/skills/flue/references/testing-conventions.md
+++ b/skills/flue/references/testing-conventions.md
@@ -1,0 +1,42 @@
+# Testing Conventions
+
+Use this when adding or reviewing tests in this repository.
+
+## Test Location
+
+- Use `<package>/test/` for the active suite.
+- Do not add tests to `<package>/test-legacy/`.
+- Do not treat archived tests as source of truth when designing active coverage.
+
+## Coverage Judgment
+
+Add tests when they protect a durable contract or meaningful failure mode. Do not add a regression test for every change. Skip tests for incidental implementation details, rare edge cases, or behavior that remains naturally protected by surrounding design.
+
+Prefer the highest practical public interface:
+
+- user-facing behavior for public APIs;
+- explicit consumer-facing behavior for stable internal subsystem boundaries.
+
+Avoid directly testing private helpers when the behavior is already exercised through a meaningful interface.
+
+## Test Shape
+
+- Use `describe('someFunction()')` or `describe('SomeManager')`.
+- Test names use `it('X when Y')`.
+- Prefer explicit, self-contained `it()` blocks.
+- Copy-paste in tests is acceptable when it keeps behavior readable.
+- Avoid `it.each()` unless cases are genuinely linear and clearer as a table.
+- Avoid complex helpers that hide behavior-relevant inputs or expectations.
+
+## Mocks
+
+- Avoid broad mocks of whole files, packages, or modules.
+- Prefer real lightweight boundaries, small explicit fakes for injected interfaces, or narrow transport fixtures.
+- If broad mocking is unavoidable, document it as temporary and note the design smell.
+
+## Validation Commands
+
+- Runtime type changes: run `pnpm run check:types` in `packages/runtime/`.
+- Build runtime before CLI or examples when changes cross package boundaries.
+- Use package-local build, typecheck, and test scripts when the change is scoped.
+

--- a/skills/flue/references/workflow-runs.md
+++ b/skills/flue/references/workflow-runs.md
@@ -1,0 +1,57 @@
+# Workflow Runs
+
+Use this when implementing finite units of work, inspecting runs, or choosing between workflow and agent semantics.
+
+## Workflow Shape
+
+```ts
+import { createAgent, type FlueContext } from '@flue/runtime';
+
+const summarizer = createAgent(() => ({
+  model: 'anthropic/claude-haiku-4-5',
+  instructions: 'Summarize the supplied document.',
+}));
+
+export async function run({ init, payload }: FlueContext<{ text: string }>) {
+  const harness = await init(summarizer);
+  const session = await harness.session();
+  const response = await session.prompt(payload.text);
+
+  return { summary: response.text };
+}
+```
+
+- Filename gives the workflow name.
+- Each invocation creates one workflow run with `ctx.id === runId`.
+- Return value becomes the completed workflow result.
+- Use `init(agent)` and session operations for model-backed work so events, tools, skills, sandbox, and model resolution are preserved.
+
+## Invocation Surfaces
+
+| Surface | Use |
+| --- | --- |
+| `flue run <workflow>` | Local or CI one-shot execution. |
+| `POST /workflows/<name>` | HTTP admission when workflow exports `route`. |
+| `?wait=result` | Wait for completed HTTP result in the request. |
+| `flue logs <runId>` | Inspect or follow a workflow run. |
+| `GET /runs/<runId>` | Stream run events. |
+| `GET /runs/<runId>?meta` | Read run record metadata. |
+
+Do not import a workflow module and call `run(...)` directly from `app.ts`, `cloudflare.ts`, a scheduler, or a queue handler when you need a real run. Invoke the mounted workflow route or extract shared pure logic.
+
+## Run Boundaries
+
+- Only workflows create workflow runs.
+- Direct prompts and `dispatch(...)` input are continuing agent operations.
+- Run listing can expose payloads, results, logs, and model activity; protect run routes.
+- Per-workflow route middleware protects that workflow's run views.
+- Shared `/runs/*` middleware in `app.ts` can protect every run.
+
+## Recovery Notes
+
+| Target | Behavior |
+| --- | --- |
+| Node without durable `db.ts` | In-memory state is lost on process exit. |
+| Node with durable adapter | Accepted agent submissions can reconcile after restart; interrupted workflow runs may remain active and streams open. |
+| Cloudflare | Durable Objects and Fiber recovery handle admitted work more conservatively and can terminalize interrupted runs. |
+


### PR DESCRIPTION
This adds a proof-of-concept installable Flue skill under `skills/flue/`. The idea is to make the docs consumable by agents as a curated router plus flat reference files, rather than bundling the whole docs tree or asking an agent to rediscover the same terminology and implementation boundaries every time.

This was generated with Codex using Sentry's `skill-writer` skill from the `getsentry/skills` repo. It may not be the final shape you want, but I figured it could be useful as a concrete starting point for agent-facing Flue documentation.