### PR TITLE
Keep Cloudflare Sandbox cancellation local

### DIFF
--- a/packages/runtime/src/cloudflare/cf-sandbox.ts
+++ b/packages/runtime/src/cloudflare/cf-sandbox.ts
@@ -19,7 +19,6 @@ export interface CloudflareSandboxStub {
 			cwd?: string;
 			env?: Record<string, string>;
 			timeout?: number;
-			signal?: AbortSignal;
 		},
 	): Promise<{ success: boolean; stdout: string; stderr: string; exitCode?: number }>;
 	readFile(path: string, options?: { encoding?: string }): Promise<{ content: string }>;
@@ -159,12 +158,14 @@ export function cfSandboxToSessionEnv(
 			const externalSignal = execOpts?.signal;
 			if (externalSignal?.aborted) throw abortErrorFor(externalSignal);
 
+			// Cloudflare Sandbox does not currently accept AbortSignal across the
+			// getSandbox(...).exec(...) RPC boundary. Keep cancellation local while
+			// forwarding cloneable execution options to the sandbox.
 			const result = await sandbox.exec(command, {
 				cwd: execOpts?.cwd,
 				env: execOpts?.env,
 				// The Cloudflare sandbox `timeout` option is in milliseconds.
 				timeout: execOpts?.timeoutMs,
-				signal: externalSignal,
 			});
 
 			if (externalSignal?.aborted) throw abortErrorFor(externalSignal);

--- a/packages/runtime/test/cloudflare-context.test.ts
+++ b/packages/runtime/test/cloudflare-context.test.ts
@@ -120,7 +120,7 @@ describe('cloudflareSandbox()', () => {
 		});
 	});
 
-	it('forwards command cwd env and millisecond timeout when a wrapped command executes', async () => {
+	it('forwards cloneable command options when a wrapped command executes', async () => {
 		const exec = vi.fn(async () => ({ stdout: 'done', stderr: 'warning', exitCode: 3 }));
 		const env = await cloudflareSandbox({ exec } as unknown as CloudflareSandboxStub, {
 			cwd: '/workspace/project',
@@ -140,7 +140,6 @@ describe('cloudflareSandbox()', () => {
 			cwd: '/workspace/check',
 			env: { NODE_ENV: 'test' },
 			timeout: 12_000,
-			signal,
 		});
 	});
 
@@ -219,7 +218,7 @@ describe('cloudflareSandbox()', () => {
 		expect(deleteFile).toHaveBeenCalledWith('/workspace/project/tmp');
 	});
 
-	it('forwards a signal and rejects when a Cloudflare sandbox is aborted in flight', async () => {
+	it('keeps cancellation local when a Cloudflare sandbox command is aborted in flight', async () => {
 		let markStarted: () => void = () => {};
 		const started = new Promise<void>((resolve) => {
 			markStarted = resolve;
@@ -251,7 +250,6 @@ describe('cloudflareSandbox()', () => {
 			cwd: '/workspace/project',
 			env: undefined,
 			timeout: undefined,
-			signal: controller.signal,
 		});
 	});
 });


### PR DESCRIPTION
Flue's `cloudflareSandbox()` adapter forwarded the operation `AbortSignal` into `@cloudflare/sandbox`'s `getSandbox(...).exec(...)`. That call crosses a Durable Object RPC boundary where options are structured-cloned and `AbortSignal` is not cloneable, so every sandbox-backed shell call (`harness.shell()`, `session.shell()`, and the model's `bash` tool) threw before running:

    DataCloneError: AbortSignal serialization is not enabled.

Stop sending the signal across that boundary. Only cloneable options (`cwd`, `env`, native `timeout`) reach the sandbox. Flue keeps its local pre/post abort checks, so an already-aborted call still rejects up front and an in-flight abort still surfaces as `AbortError` once the remote command returns. This matches Flue's `SandboxApi` contract, where `signal` is optional and `timeoutMs` is the portable cancellation mechanism.

Shortcoming: a long-running command can't be cancelled mid-flight and runs until it finishes or hits its `timeout`. That never worked on this path anyway (it threw); real remote cancellation needs a cloneable protocol in the Sandbox SDK, which is out of scope here.
