### PR TITLE
runtime: add Nebius Token Factory provider

### DIFF
--- a/apps/docs/src/content/docs/api/provider-api.md
+++ b/apps/docs/src/content/docs/api/provider-api.md
@@ -1,7 +1,7 @@
 ---
 title: Provider API
 description: Register custom model providers and override built-in provider transport.
-lastReviewedAt: 2026-05-31
+lastReviewedAt: 2026-06-17
 ---
 
 The provider API configures model connection paths at runtime. Import ordinary provider APIs from `@flue/runtime`. For model selection, authentication setup, and Workers AI examples, see [Models & Providers](/docs/guide/models/).
@@ -25,7 +25,7 @@ function registerProvider(providerId: string, registration: ProviderRegistration
 
 Registers a model provider keyed by the provider ID used in model specifiers. The provider ID is the prefix used in model specifiers, such as `anthropic` in `anthropic/claude-sonnet-4-6`.
 
-When the provider ID is a catalog provider, models resolve from the catalog — preserving metadata such as cost, context window, and wire protocol — with this call's options layered on top. That makes routing a built-in provider through a gateway one call:
+When the provider ID is a catalog provider, models resolve from the catalog — preserving metadata such as cost, context window, and wire protocol — with this call's options layered on top. Flue-bundled providers that are not in Pi's catalog, such as `nebius`, keep their built-in protocol and endpoint defaults when you override only authentication or headers. That makes routing a built-in provider through a gateway one call:
 
 ```ts
 registerProvider('anthropic', {
@@ -34,7 +34,7 @@ registerProvider('anthropic', {
 });
 ```
 
-Provider IDs the catalog doesn't know are registered from scratch and must supply `api` and `baseUrl`. For example, registering `ollama` makes model specifiers such as `ollama/llama3.1:8b` available to agents and operations:
+Provider IDs that neither Pi's catalog nor Flue's built-in provider defaults know are registered from scratch and must supply `api` and `baseUrl`. For example, registering `ollama` makes model specifiers such as `ollama/llama3.1:8b` available to agents and operations:
 
 ```ts
 registerProvider('ollama', {
@@ -43,7 +43,7 @@ registerProvider('ollama', {
 });
 ```
 
-Each call replaces the provider ID's previous registration; calls do not accumulate. The effective settings are always the catalog defaults (when the ID is known) plus the latest call's options.
+Each call replaces the provider ID's previous registration; calls do not accumulate. The effective settings are always the built-in defaults (when the ID is known through Pi's catalog or Flue's provider defaults) plus the latest call's options.
 
 ### `ProviderRegistration`
 
@@ -74,16 +74,16 @@ interface HttpProviderRegistration {
 }
 ```
 
-| Property         | Purpose                                                                                                                                                                            |
-| ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `api`            | Wire protocol used for requests. Use a Pi-provided API slug or register one with `registerApiProvider()`. Required for non-catalog provider IDs; defaults to the catalog protocol. |
-| `baseUrl`        | Endpoint root, such as `https://api.anthropic.com/v1`. Required for non-catalog provider IDs; defaults to the catalog endpoint.                                                    |
-| `apiKey`         | Optional API key. When omitted, the underlying provider integration may use its normal environment-variable lookup.                                                                |
-| `headers`        | Headers sent on outgoing requests. Merged per key over the catalog model's headers when the provider ID hydrates from the catalog; the registration's values win on conflict.      |
-| `contextWindow`  | Default context-window size for models resolved through this registration. Falls back to the catalog value for catalog models, then to `0`, meaning unknown.                       |
-| `maxTokens`      | Default output-token limit for models resolved through this registration. Falls back to the catalog value for catalog models, then to `0`.                                         |
-| `models`         | Per-model `contextWindow` and `maxTokens` overrides keyed by model ID. Per-model values override provider-level defaults.                                                          |
-| `storeResponses` | Send `store: true` for OpenAI Responses API providers. Enable only when your application accepts the provider's retention policy.                                                  |
+| Property         | Purpose                                                                                                                                                                                                                   |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `api`            | Wire protocol used for requests. Use a Pi-provided API slug or register one with `registerApiProvider()`. Required for provider IDs with no catalog or Flue-bundled default; otherwise defaults to the built-in protocol. |
+| `baseUrl`        | Endpoint root, such as `https://api.anthropic.com/v1`. Required for provider IDs with no catalog or Flue-bundled default; otherwise defaults to the built-in endpoint.                                                    |
+| `apiKey`         | Optional API key. When omitted, the underlying provider integration may use its normal environment-variable lookup.                                                                                                       |
+| `headers`        | Headers sent on outgoing requests. Merged per key over the catalog model's headers when the provider ID hydrates from the catalog; the registration's values win on conflict.                                             |
+| `contextWindow`  | Default context-window size for models resolved through this registration. Falls back to the catalog value for catalog models, then to `0`, meaning unknown.                                                              |
+| `maxTokens`      | Default output-token limit for models resolved through this registration. Falls back to the catalog value for catalog models, then to `0`.                                                                                |
+| `models`         | Per-model `contextWindow` and `maxTokens` overrides keyed by model ID. Per-model values override provider-level defaults.                                                                                                 |
+| `storeResponses` | Send `store: true` for OpenAI Responses API providers. Enable only when your application accepts the provider's retention policy.                                                                                         |
 
 Registering a non-catalog provider ID without `api` and `baseUrl` throws a `ProviderRegistrationError`.
 

--- a/apps/docs/src/content/docs/guide/models.md
+++ b/apps/docs/src/content/docs/guide/models.md
@@ -1,7 +1,7 @@
 ---
 title: LLM (Models & Providers)
 description: Select models, configure providers, and tune reasoning behavior in Flue agents.
-lastReviewedAt: 2026-05-29
+lastReviewedAt: 2026-06-17
 ---
 
 Models determine what kind of work an agent can perform. Providers determine how your application reaches those models, authenticates its requests, and applies any transport-specific configuration.
@@ -10,15 +10,16 @@ This guide covers model selection and provider setup. For configuring addressabl
 
 ## Model specifier
 
-A model specifier is the unique string Flue uses to refer to a specific model across providers. It combines a provider ID, such as `anthropic`, `cloudflare`, `openai`, or `openrouter`, with a model ID recognized by that provider:
+A model specifier is the unique string Flue uses to refer to a specific model across providers. It combines a provider ID, such as `anthropic`, `cloudflare`, `nebius`, `openai`, or `openrouter`, with a model ID recognized by that provider:
 
-| Model specifier                       | Provider ID  | Model ID                   |
-| ------------------------------------- | ------------ | -------------------------- |
-| `anthropic/claude-sonnet-4-6`         | `anthropic`  | `claude-sonnet-4-6`        |
-| `openai/gpt-5.5`                      | `openai`     | `gpt-5.5`                  |
-| `openrouter/moonshotai/kimi-k2.6`     | `openrouter` | `moonshotai/kimi-k2.6`     |
-| `cloudflare/@cf/moonshotai/kimi-k2.6` | `cloudflare` | `@cf/moonshotai/kimi-k2.6` |
-| `cloudflare/openai/gpt-5.5`           | `cloudflare` | `openai/gpt-5.5`           |
+| Model specifier                                 | Provider ID  | Model ID                                 |
+| ----------------------------------------------- | ------------ | ---------------------------------------- |
+| `anthropic/claude-sonnet-4-6`                   | `anthropic`  | `claude-sonnet-4-6`                      |
+| `openai/gpt-5.5`                                | `openai`     | `gpt-5.5`                                |
+| `openrouter/moonshotai/kimi-k2.6`               | `openrouter` | `moonshotai/kimi-k2.6`                   |
+| `nebius/meta-llama/Meta-Llama-3.1-70B-Instruct` | `nebius`     | `meta-llama/Meta-Llama-3.1-70B-Instruct` |
+| `cloudflare/@cf/moonshotai/kimi-k2.6`           | `cloudflare` | `@cf/moonshotai/kimi-k2.6`               |
+| `cloudflare/openai/gpt-5.5`                     | `cloudflare` | `openai/gpt-5.5`                         |
 
 Use a model specifier to choose an agent's default model:
 
@@ -71,6 +72,7 @@ Most hosted providers require credentials before they will accept model requests
 | Provider ID  | Environment variable |
 | ------------ | -------------------- |
 | `anthropic`  | `ANTHROPIC_API_KEY`  |
+| `nebius`     | `NEBIUS_API_KEY`     |
 | `openai`     | `OPENAI_API_KEY`     |
 | `openrouter` | `OPENROUTER_API_KEY` |
 
@@ -80,9 +82,31 @@ Some provider paths authenticate through their platform integration instead of a
 
 ### Built-in providers
 
-Flue includes Pi's catalog-backed providers and models. To use a built-in provider, choose one of its supported model specifiers and make its required credentials available at runtime; you do not need to register the provider in application code.
+Flue includes Pi's catalog-backed providers and models, plus Flue-bundled provider defaults for selected OpenAI-compatible services such as Nebius Token Factory. To use a built-in provider, choose one of its supported model specifiers and make its required credentials available at runtime; you do not need to register the provider in application code.
 
 See Pi's [provider documentation](https://pi.dev/docs/latest/providers) for the built-in providers, their supported authentication variables, and their model catalog.
+
+### Nebius Token Factory
+
+Flue includes a built-in `nebius` provider for [Nebius Token Factory](https://docs.tokenfactory.nebius.com/api-reference/introduction), which exposes an OpenAI-compatible chat completions API. Set `NEBIUS_API_KEY` and use `nebius/<model-id>` with the model ID shown in Token Factory:
+
+```ts title="src/agents/assistant.ts"
+import { createAgent } from '@flue/runtime';
+
+export default createAgent(() => ({
+  model: 'nebius/meta-llama/Meta-Llama-3.1-70B-Instruct',
+}));
+```
+
+Nebius model availability can change independently of Flue, so Flue does not pin a local Nebius model catalog. The model ID after `nebius/` is sent to Token Factory as-is and validated by Nebius at request time. To route Nebius through a gateway or pass a key explicitly, override only the settings you need:
+
+```ts title="src/app.ts"
+import { registerProvider } from '@flue/runtime';
+
+registerProvider('nebius', {
+  apiKey: process.env.NEBIUS_API_KEY,
+});
+```
 
 ### Cloudflare providers
 
@@ -118,7 +142,7 @@ A provider override can change its endpoint, API key, or headers without changin
 
 ### Custom providers
 
-Use `registerProvider(...)` in `src/app.ts` when you want to connect Flue to a model provider that is not built in. Registering a provider assigns it a provider ID, which you can then use in model specifiers throughout your application. Provider IDs outside the built-in catalog must supply `api` and `baseUrl`.
+Use `registerProvider(...)` in `src/app.ts` when you want to connect Flue to a model provider that is not built in. Registering a provider assigns it a provider ID, which you can then use in model specifiers throughout your application. Provider IDs outside the built-in catalog and Flue-bundled defaults must supply `api` and `baseUrl`.
 
 For example, you can register a local Ollama server through its OpenAI-compatible endpoint:
 

--- a/packages/runtime/src/runtime/providers.ts
+++ b/packages/runtime/src/runtime/providers.ts
@@ -35,14 +35,15 @@ export type ProviderRegistration = HttpProviderRegistration | CloudflareAIBindin
 /** Register an HTTP-backed provider ID with {@link registerProvider}. */
 export interface HttpProviderRegistration {
 	/**
-	 * Wire protocol used for requests. Required for provider IDs the catalog
-	 * doesn't know; defaults to the catalog protocol for catalog provider IDs.
+	 * Wire protocol used for requests. Required for provider IDs that neither
+	 * Pi's catalog nor Flue's built-in provider defaults know; otherwise
+	 * defaults to the built-in protocol.
 	 */
 	api?: Api;
 	/**
 	 * Endpoint root, e.g. `'https://api.anthropic.com/v1'`. Required for
-	 * provider IDs the catalog doesn't know; defaults to the catalog endpoint
-	 * for catalog provider IDs.
+	 * provider IDs that neither Pi's catalog nor Flue's built-in provider
+	 * defaults know; otherwise defaults to the built-in endpoint.
 	 */
 	baseUrl?: string;
 	/**
@@ -116,6 +117,35 @@ function isCloudflareBindingRegistration(
  */
 const providersById = new Map<string, ProviderRegistration>();
 
+type BuiltInHttpProviderDefaults = Pick<HttpProviderRegistration, 'api' | 'baseUrl'> & {
+	api: Api;
+	baseUrl: string;
+	apiKeyEnvVar?: string;
+};
+
+const builtInHttpProvidersById = new Map<string, BuiltInHttpProviderDefaults>([
+	[
+		'nebius',
+		{
+			api: 'openai-completions',
+			baseUrl: 'https://api.tokenfactory.nebius.com/v1',
+			apiKeyEnvVar: 'NEBIUS_API_KEY',
+		},
+	],
+]);
+
+function getBuiltInHttpProviderDefaults(
+	providerId: string,
+): BuiltInHttpProviderDefaults | undefined {
+	return builtInHttpProvidersById.get(providerId);
+}
+
+function getEnvVar(name: string): string | undefined {
+	if (typeof process === 'undefined' || !process.env) return undefined;
+	const value = process.env[name];
+	return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
 /**
  * Register a model provider keyed by the provider ID used in model specifiers.
  *
@@ -131,19 +161,24 @@ const providersById = new Map<string, ProviderRegistration>();
  * });
  * ```
  *
- * Provider IDs the catalog doesn't know are registered from scratch and must
- * supply `api` and `baseUrl`.
+ * Provider IDs that neither Pi's catalog nor Flue's built-in provider defaults
+ * know are registered from scratch and must supply `api` and `baseUrl`.
  *
  * Each call REPLACES the provider ID's previous registration; calls do not
- * accumulate. The effective settings are always the catalog defaults (when
- * the ID is known) plus the latest call's options. On Cloudflare, registering
- * the `cloudflare` provider ID in `app.ts` takes precedence over the
- * generated Workers AI binding default.
+ * accumulate. The effective settings are always the built-in defaults (when
+ * the ID is known through Pi's catalog or Flue's provider defaults) plus the
+ * latest call's options. On Cloudflare, registering the `cloudflare` provider
+ * ID in `app.ts` takes precedence over the generated Workers AI binding
+ * default.
  */
 export function registerProvider(providerId: string, registration: ProviderRegistration): void {
+	const builtInDefaults = isCloudflareBindingRegistration(registration)
+		? undefined
+		: getBuiltInHttpProviderDefaults(providerId);
 	if (
 		!isCloudflareBindingRegistration(registration) &&
-		(registration.api === undefined || registration.baseUrl === undefined) &&
+		((registration.api ?? builtInDefaults?.api) === undefined ||
+			(registration.baseUrl ?? builtInDefaults?.baseUrl) === undefined) &&
 		getModels(providerId as KnownProvider).length === 0
 	) {
 		throw new ProviderRegistrationError({ providerId });
@@ -160,11 +195,14 @@ export function hasRegisteredProvider(providerId: string): boolean {
 	return providersById.has(providerId);
 }
 
-/** Look up an API key registered for a provider ID. */
+/** Look up an API key registered for a provider ID or supplied by a Flue built-in provider. */
 export function getRegisteredApiKey(providerId: string): string | undefined {
 	const registration = providersById.get(providerId);
-	if (!registration || isCloudflareBindingRegistration(registration)) return undefined;
-	return registration.apiKey;
+	if (registration && isCloudflareBindingRegistration(registration)) return undefined;
+	if (registration?.apiKey) return registration.apiKey;
+
+	const builtInDefaults = getBuiltInHttpProviderDefaults(providerId);
+	return builtInDefaults?.apiKeyEnvVar ? getEnvVar(builtInDefaults.apiKeyEnvVar) : undefined;
 }
 
 /** Whether a registered provider opted into OpenAI-hosted response storage. */
@@ -248,7 +286,7 @@ export function resolveRegisteredModel(
 	providerId: string,
 	modelId: string,
 ): Model<Api> | undefined {
-	const registration = providersById.get(providerId);
+	const registration = providersById.get(providerId) ?? getBuiltInHttpProviderDefaults(providerId);
 	if (!registration) return undefined;
 	return buildModelFromRegistration(providerId, registration, modelId);
 }
@@ -286,9 +324,10 @@ function buildModelFromRegistration(
 	// exposing a brand-new model), provider-level transport facts still
 	// hydrate from the provider's other catalog entries.
 	const catalog = getModel(providerId as KnownProvider, modelId as never) as Model<Api> | undefined;
+	const builtInDefaults = getBuiltInHttpProviderDefaults(providerId);
 	const providerDefaults = catalog ?? getModels(providerId as KnownProvider)[0];
-	const api = registration.api ?? providerDefaults?.api;
-	const baseUrl = registration.baseUrl ?? providerDefaults?.baseUrl;
+	const api = registration.api ?? providerDefaults?.api ?? builtInDefaults?.api;
+	const baseUrl = registration.baseUrl ?? providerDefaults?.baseUrl ?? builtInDefaults?.baseUrl;
 	if (api === undefined || baseUrl === undefined) {
 		// Unreachable: registerProvider() rejects non-catalog registrations
 		// that omit api/baseUrl.

--- a/packages/runtime/test/providers.test.ts
+++ b/packages/runtime/test/providers.test.ts
@@ -8,6 +8,7 @@ import { createNoopSessionEnv } from './fixtures/session-env.ts';
 afterEach(() => {
 	resetProvidersForTests();
 	vi.unstubAllGlobals();
+	vi.unstubAllEnvs();
 });
 
 /** Stub global fetch, capture outgoing requests, and answer with a valid SSE stream. */
@@ -182,6 +183,52 @@ describe('registerProvider()', () => {
 		expect(resolveModel('metadata-http/other')).toMatchObject({
 			contextWindow: 8000,
 			maxTokens: 1000,
+		});
+	});
+
+	it('resolves Nebius Token Factory models when using the built-in provider id', () => {
+		const resolved = resolveModel('nebius/meta-llama/Meta-Llama-3.1-70B-Instruct');
+
+		expect(resolved).toMatchObject({
+			id: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
+			name: 'meta-llama/Meta-Llama-3.1-70B-Instruct',
+			provider: 'nebius',
+			api: 'openai-completions',
+			baseUrl: 'https://api.tokenfactory.nebius.com/v1',
+			contextWindow: 0,
+			maxTokens: 0,
+		});
+	});
+
+	it('sends NEBIUS_API_KEY when a built-in Nebius model makes a request', async () => {
+		vi.stubEnv('NEBIUS_API_KEY', 'sk-nebius');
+		const seen = captureFetch('Hello from Nebius.');
+		const harness = await createContext().init(
+			createAgent(() => ({ model: 'nebius/meta-llama/Meta-Llama-3.1-70B-Instruct' })),
+		);
+		const session = await harness.session();
+
+		await session.prompt('Say hello.');
+
+		expect(seen).toHaveLength(1);
+		const [request] = seen;
+		if (!request) throw new Error('Expected a provider request.');
+		const url = new URL(request.url);
+		expect(url.origin).toBe('https://api.tokenfactory.nebius.com');
+		expect(url.pathname).toBe('/v1/chat/completions');
+		expect(request.headers.get('authorization')).toBe('Bearer sk-nebius');
+	});
+
+	it('keeps Nebius transport defaults when overriding only its API key', () => {
+		registerProvider('nebius', { apiKey: 'sk-override' });
+
+		const resolved = resolveModel('nebius/deepseek-ai/DeepSeek-R1-0528');
+
+		expect(resolved).toMatchObject({
+			id: 'deepseek-ai/DeepSeek-R1-0528',
+			provider: 'nebius',
+			api: 'openai-completions',
+			baseUrl: 'https://api.tokenfactory.nebius.com/v1',
 		});
 	});
 


### PR DESCRIPTION
adds Nebius Token Factory as a built-in OpenAI-compatible model provider for Flue.

This lets users configure agents with nebius/<model-id>, authenticate with NEBIUS_API_KEY, and override Nebius transport settings through registerProvider('nebius', ...). 

The PR also updates model/provider docs and adds focused runtime tests for model resolution and request authentication.