### PR TITLE
fix(runtime): document agent submission ids

### DIFF
--- a/packages/runtime/src/runtime/schemas.ts
+++ b/packages/runtime/src/runtime/schemas.ts
@@ -35,11 +35,13 @@ export const ErrorEnvelopeSchema = v.object({
 // (runs are workflow-only), and sync responses add `result`.
 
 export const AgentAdmissionResponseSchema = v.object({
+	submissionId: v.string(),
 	streamUrl: v.string(),
 	offset: v.string(),
 });
 
 export const AgentInvocationResponseSchema = v.object({
+	submissionId: v.string(),
 	result: v.unknown(),
 	streamUrl: v.string(),
 	offset: v.string(),

--- a/packages/runtime/test/routing.test.ts
+++ b/packages/runtime/test/routing.test.ts
@@ -232,6 +232,25 @@ describe('flue()', () => {
 		});
 		expect(Object.keys(body.paths['/workflows/{name}'] ?? {})).toEqual(['post']);
 		expect(Object.keys(body.paths['/agents/{name}/{id}'] ?? {})).toEqual(['post']);
+		const agentResponses = body.paths['/agents/{name}/{id}']?.post?.responses;
+		expect(agentResponses?.['202']?.content?.['application/json']?.schema).toMatchObject({
+			type: 'object',
+			required: expect.arrayContaining(['submissionId', 'streamUrl', 'offset']),
+			properties: {
+				submissionId: { type: 'string' },
+				streamUrl: { type: 'string' },
+				offset: { type: 'string' },
+			},
+		});
+		expect(agentResponses?.['200']?.content?.['application/json']?.schema).toMatchObject({
+			type: 'object',
+			required: expect.arrayContaining(['submissionId', 'result', 'streamUrl', 'offset']),
+			properties: {
+				submissionId: { type: 'string' },
+				streamUrl: { type: 'string' },
+				offset: { type: 'string' },
+			},
+		});
 		// Both invocation routes document the same modes: 202 admission by
 		// default plus the ?wait=result synchronous mode.
 		for (const post of [


### PR DESCRIPTION
## Summary
- Add `submissionId` to the public agent admission and synchronous invocation response schemas.
- Extend the OpenAPI routing test so both documented agent response modes expose `submissionId` alongside stream coordinates.

## Test Plan
- `pnpm --dir packages/runtime exec vitest run test/routing.test.ts`
- `pnpm --dir packages/runtime run build`
- `pnpm --dir packages/runtime exec tsc --noEmit`
- `git diff --check`

Fixes #292