### PR TITLE
docs: remove duplicate workflows link on agents page

### DIFF
--- a/apps/docs/src/content/docs/concepts/agents.mdx
+++ b/apps/docs/src/content/docs/concepts/agents.mdx
@@ -91,4 +91,3 @@ Out of the box, Flue provides a lightweight virtual sandbox — an in-memory fil
 - [Agents](/docs/guide/building-agents/) — defining an addressable agent, its sessions, and its runtime configuration.
 - [Workflows](/docs/guide/workflows/) — initializing an agent from code during a finite operation.
 - [Sandboxes](/docs/guide/sandboxes/), [Tools](/docs/guide/tools/), [Skills](/docs/guide/skills/), and [Subagents](/docs/guide/subagents/) — the pieces of the harness, in depth.
-- [Workflows](/docs/guide/workflows/) — bounded jobs with inspectable run history.


### PR DESCRIPTION
"Where to go next" links Workflows twice (both → `/docs/guide/workflows/`). Drops the trailing duplicate.

Lineage: introduced in 3e07b2a5, untouched by #303 and its revert 1dd1c2dd.
