### PR TITLE
Add Cloudflare Sandbox example

### DIFF
--- a/examples/cloudflare-sandbox/Dockerfile
+++ b/examples/cloudflare-sandbox/Dockerfile
@@ -1,0 +1,1 @@
+FROM docker.io/cloudflare/sandbox:0.7.0

--- a/examples/cloudflare-sandbox/README.md
+++ b/examples/cloudflare-sandbox/README.md
@@ -1,0 +1,71 @@
+# Cloudflare Sandbox SDK example
+
+This example demonstrates using [Cloudflare Sandbox SDK](https://developers.cloudflare.com/sandbox/) through Flue's Cloudflare sandbox adapter.
+
+Use this example when you want a real Linux/container sandbox for shell commands, package installs, filesystem work, or generated-code execution. For Cloudflare features that do not use Workers Containers, see `examples/cloudflare`.
+
+## What this demonstrates
+
+`src/workflows/sandbox-sdk-smoke.ts` follows the intended Flue layering:
+
+```ts
+getSandbox(env.Sandbox, id)
+  -> cloudflareSandbox(...)
+  -> ctx.init(agent)
+  -> harness.fs / harness.shell
+```
+
+The workflow constructs the sandbox with `@cloudflare/sandbox`, then uses Flue harness APIs for filesystem and shell operations. Application code stays on Flue's sandbox abstraction after the Cloudflare Sandbox stub is wrapped.
+
+## Requirements
+
+- Cloudflare account access to Workers Containers.
+- Docker for local container builds.
+- Wrangler authenticated for your account.
+
+Running this example provisions a Cloudflare Container. Accounts without Workers Containers access can still build the example locally, but workflow execution requires the Containers binding.
+
+## Setup
+
+Install workspace dependencies from the repository root:
+
+```bash
+pnpm install
+```
+
+Build the local Flue packages once if `dist/` is stale:
+
+```bash
+pnpm run build -F @flue/runtime -F @flue/cli
+```
+
+## Run locally
+
+From this directory:
+
+```bash
+pnpm run dev
+```
+
+Then invoke the deterministic smoke workflow:
+
+```bash
+curl -X POST 'http://localhost:3583/workflows/sandbox-sdk-smoke?wait=result' \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+A successful response includes stdout containing:
+
+```text
+file: hello from Flue via Cloudflare Sandbox
+pwd: /workspace
+```
+
+## Build
+
+```bash
+pnpm run build
+```
+
+The build uses `wrangler.jsonc`, which enables the `Sandbox` container and Durable Object binding for this example package. The container uses the `standard-2` instance type for agent/code-execution workloads; switch it to a smaller type for a lighter development container.

--- a/examples/cloudflare-sandbox/package.json
+++ b/examples/cloudflare-sandbox/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "cloudflare-sandbox-example",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "flue dev --target cloudflare",
+		"build": "flue build --target cloudflare"
+	},
+	"dependencies": {
+		"@cloudflare/sandbox": "*",
+		"@flue/runtime": "workspace:*",
+		"agents": "^0.14.1",
+		"hono": "^4.7.0"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20260602.1",
+		"@flue/cli": "workspace:*",
+		"wrangler": "^4.97.0"
+	}
+}

--- a/examples/cloudflare-sandbox/src/app.ts
+++ b/examples/cloudflare-sandbox/src/app.ts
@@ -1,0 +1,9 @@
+import { flue } from '@flue/runtime/routing';
+import { Hono } from 'hono';
+
+const app = new Hono();
+
+app.get('/api/ping', (c) => c.json({ pong: true, at: new Date().toISOString() }));
+app.route('/', flue());
+
+export default app;

--- a/examples/cloudflare-sandbox/src/cloudflare.ts
+++ b/examples/cloudflare-sandbox/src/cloudflare.ts
@@ -1,0 +1,3 @@
+// The Cloudflare Worker entry exports the Durable Object class that backs
+// getSandbox(env.Sandbox, id).
+export { Sandbox } from '@cloudflare/sandbox';

--- a/examples/cloudflare-sandbox/src/workflows/sandbox-sdk-smoke.ts
+++ b/examples/cloudflare-sandbox/src/workflows/sandbox-sdk-smoke.ts
@@ -1,0 +1,31 @@
+import { getSandbox } from '@cloudflare/sandbox';
+import { createAgent, type FlueContext, type WorkflowRouteHandler } from '@flue/runtime';
+import { cloudflareSandbox } from '@flue/runtime/cloudflare';
+
+export const route: WorkflowRouteHandler = async (_c, next) => next();
+
+interface Env {
+	Sandbox: DurableObjectNamespace;
+}
+
+const sandboxedAgent = createAgent(({ id, env }) => ({
+	model: false,
+	instructions:
+		'You are a smoke-test agent. This workflow exercises your sandbox through deterministic harness calls.',
+	sandbox: cloudflareSandbox(getSandbox(env.Sandbox, id)),
+}));
+
+export async function run(ctx: FlueContext<unknown, Env>) {
+	const harness = await ctx.init(sandboxedAgent);
+	await harness.fs.writeFile('/workspace/flue-smoke.txt', 'hello from Flue via Cloudflare Sandbox');
+
+	const result = await harness.shell(
+		'printf "file: "; cat /workspace/flue-smoke.txt; printf "\\npwd: "; pwd',
+	);
+
+	return {
+		exitCode: result.exitCode,
+		stdout: result.stdout,
+		stderr: result.stderr,
+	};
+}

--- a/examples/cloudflare-sandbox/tsconfig.json
+++ b/examples/cloudflare-sandbox/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"types": ["@cloudflare/workers-types"]
+	},
+	"include": ["src/**/*.ts"]
+}

--- a/examples/cloudflare-sandbox/wrangler.jsonc
+++ b/examples/cloudflare-sandbox/wrangler.jsonc
@@ -1,0 +1,38 @@
+{
+	// This example uses Workers Containers through Cloudflare Sandbox SDK.
+	// src/cloudflare.ts exports the Sandbox class that backs the binding below.
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "cloudflare-sandbox-example",
+	"compatibility_date": "2026-06-01",
+	"compatibility_flags": ["nodejs_compat"],
+	"durable_objects": {
+		"bindings": [
+			{
+				"class_name": "Sandbox",
+				"name": "Sandbox"
+			}
+		]
+	},
+	"migrations": [
+		{
+			"tag": "sandbox-v1",
+			"new_sqlite_classes": ["Sandbox"]
+		},
+		{
+			"tag": "flue-class-FlueRegistry",
+			"new_sqlite_classes": ["FlueRegistry"]
+		},
+		{
+			"tag": "flue-class-FlueSandboxSdkSmokeWorkflow",
+			"new_sqlite_classes": ["FlueSandboxSdkSmokeWorkflow"]
+		}
+	],
+	"containers": [
+		{
+			"class_name": "Sandbox",
+			"image": "./Dockerfile",
+			"instance_type": "standard-2",
+			"max_instances": 1
+		}
+	]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,31 @@ importers:
         specifier: ^4.97.0
         version: 4.97.0(@cloudflare/workers-types@4.20260602.1)
 
+  examples/cloudflare-sandbox:
+    dependencies:
+      '@cloudflare/sandbox':
+        specifier: '*'
+        version: 0.12.1
+      '@flue/runtime':
+        specifier: workspace:*
+        version: link:../../packages/runtime
+      agents:
+        specifier: ^0.14.1
+        version: 0.14.1(@babel/core@7.29.0)(@babel/runtime@7.29.7)(@cloudflare/codemode@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ai@6.0.191(zod@4.4.3))(zod@4.4.3))(@cloudflare/workers-types@4.20260602.1)(ai@6.0.191(zod@4.4.3))(chat@4.30.0(ai@6.0.191(zod@4.4.3))(zod@4.4.3))(just-bash@3.0.1)(react@19.2.6)(rolldown@1.0.3)(vite@8.0.16(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(zod@4.4.3)
+      hono:
+        specifier: ^4.7.0
+        version: 4.12.22
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260602.1
+        version: 4.20260602.1
+      '@flue/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      wrangler:
+        specifier: ^4.97.0
+        version: 4.100.0(@cloudflare/workers-types@4.20260602.1)
+
   examples/discord-channel:
     dependencies:
       '@discordjs/rest':


### PR DESCRIPTION
Add a standalone `examples/cloudflare-sandbox` package showing how to run a real Linux container sandbox on Cloudflare through Flue's `cloudflareSandbox()` adapter.

`examples/cloudflare` demonstrates the `@cloudflare/shell` sandbox, which exposes a JavaScript `code` tool over a Workspace rather than a real shell. Its README already tells users who need bash, Linux tools, or mounted bucket paths to reach for `@cloudflare/sandbox` (Workers Containers) instead — but there was no runnable example of that path. This adds one as a separate package so the Containers requirement stays opt-in.

The smoke workflow runs with `model: false` and drives the sandbox only through harness calls, so it exercises the adapter boundary deterministically, without depending on model output.
