### PR TITLE
Document internal Flue route calls

### DIFF
--- a/apps/docs/src/content/docs/guide/routing.md
+++ b/apps/docs/src/content/docs/guide/routing.md
@@ -1,7 +1,7 @@
 ---
 title: Routing
 description: Compose Flue with application routes, middleware, and custom HTTP ingress.
-lastReviewedAt: 2026-06-20
+lastReviewedAt: 2026-06-22
 ---
 
 `src/app.ts` is an optional entrypoint for providing your own HTTP application in a Flue project. Add this file when your application needs authentication, health checks, route prefixes, or custom routes alongside the agents, workflows, and channels exposed by Flue.
@@ -78,6 +78,53 @@ export default app;
 ```
 
 Here, the webhook route belongs to your application: it determines which requests are valid and which agent instance receives the accepted input. `dispatch(...)` delivers that input asynchronously to the continuing agent session. See [Agents](/docs/guide/building-agents/) for agent interaction patterns and [Channels](/docs/guide/channels/) for provider integrations.
+
+## Call Flue from your own routes
+
+Sometimes an application-owned route should use a workflow as an internal job boundary, but the browser or external caller should not call Flue directly. Mount `flue()` behind private middleware, then call the same Hono app in process:
+
+```ts title="src/app.ts"
+import { createFlueClient } from '@flue/sdk';
+import { flue } from '@flue/runtime/routing';
+import { Hono } from 'hono';
+
+type Env = { INTERNAL_FLUE_TOKEN: string };
+
+const app = new Hono<{ Bindings: Env }>();
+
+app.use('/_flue/*', async (c, next) => {
+  if (c.req.header('x-internal-flue') !== c.env.INTERNAL_FLUE_TOKEN) {
+    return c.notFound();
+  }
+
+  await next();
+});
+
+app.route('/_flue', flue());
+
+app.post('/api/summaries', async (c) => {
+  const client = createFlueClient({
+    baseUrl: new URL('/_flue', c.req.url).toString(),
+    headers: { 'x-internal-flue': c.env.INTERNAL_FLUE_TOKEN },
+    fetch: async (input, init) => app.fetch(new Request(input, init), c.env),
+  });
+
+  const run = await client.workflows.invoke('summarize-ticket', {
+    input: await c.req.json(),
+    wait: 'result',
+  });
+
+  return c.json(run.result);
+});
+
+export default app;
+```
+
+This is still the HTTP workflow surface. The workflow module must export `route`, because the SDK call goes through `POST /workflows/<name>`. Export `runs` as well only when the internal caller also needs `client.runs.get()`, `client.runs.events()`, or `client.runs.stream()` for that workflow's run IDs.
+
+Prefer ambient [`invoke()`](/docs/api/workflow-api/#invoke) when application code only needs to admit background work and keep the returned `runId`. Use an internal HTTP call when you intentionally want route middleware, `?wait=result`, SDK streaming, or the same request/response contract used by external HTTP clients.
+
+Calling the full `app.fetch()` or `app.request()` runs application-level middleware on the private mount. Calling a saved `flue()` sub-app directly skips outer `app.use()` middleware, so do that only when the workflow's own `route` or `runs` middleware performs the required authorization.
 
 ## Customized routing
 

--- a/apps/docs/src/content/docs/guide/routing.md
+++ b/apps/docs/src/content/docs/guide/routing.md
@@ -79,52 +79,32 @@ export default app;
 
 Here, the webhook route belongs to your application: it determines which requests are valid and which agent instance receives the accepted input. `dispatch(...)` delivers that input asynchronously to the continuing agent session. See [Agents](/docs/guide/building-agents/) for agent interaction patterns and [Channels](/docs/guide/channels/) for provider integrations.
 
-## Call Flue from your own routes
+## Invoke workflows from application routes
 
-Sometimes an application-owned route should use a workflow as an internal job boundary, but the browser or external caller should not call Flue directly. Mount `flue()` behind private middleware, then call the same Hono app in process:
+Application-owned routes can invoke a workflow without exposing its HTTP route:
 
 ```ts title="src/app.ts"
-import { createFlueClient } from '@flue/sdk';
+import { invoke } from '@flue/runtime';
 import { flue } from '@flue/runtime/routing';
 import { Hono } from 'hono';
+import summarizeTicket from './workflows/summarize-ticket.ts';
 
-type Env = { INTERNAL_FLUE_TOKEN: string };
-
-const app = new Hono<{ Bindings: Env }>();
-
-app.use('/_flue/*', async (c, next) => {
-  if (c.req.header('x-internal-flue') !== c.env.INTERNAL_FLUE_TOKEN) {
-    return c.notFound();
-  }
-
-  await next();
-});
-
-app.route('/_flue', flue());
+const app = new Hono();
 
 app.post('/api/summaries', async (c) => {
-  const client = createFlueClient({
-    baseUrl: new URL('/_flue', c.req.url).toString(),
-    headers: { 'x-internal-flue': c.env.INTERNAL_FLUE_TOKEN },
-    fetch: async (input, init) => app.fetch(new Request(input, init), c.env),
-  });
-
-  const run = await client.workflows.invoke('summarize-ticket', {
+  const receipt = await invoke(summarizeTicket, {
     input: await c.req.json(),
-    wait: 'result',
   });
 
-  return c.json(run.result);
+  return c.json(receipt, 202);
 });
+
+app.route('/', flue());
 
 export default app;
 ```
 
-This is still the HTTP workflow surface. The workflow module must export `route`, because the SDK call goes through `POST /workflows/<name>`. Export `runs` as well only when the internal caller also needs `client.runs.get()`, `client.runs.events()`, or `client.runs.stream()` for that workflow's run IDs.
-
-Prefer ambient [`invoke()`](/docs/api/workflow-api/#invoke) when application code only needs to admit background work and keep the returned `runId`. Use an internal HTTP call when you intentionally want route middleware, `?wait=result`, SDK streaming, or the same request/response contract used by external HTTP clients.
-
-Calling the full `app.fetch()` or `app.request()` runs application-level middleware on the private mount. Calling a saved `flue()` sub-app directly skips outer `app.use()` middleware, so do that only when the workflow's own `route` or `runs` middleware performs the required authorization.
+`invoke()` admits the workflow through the configured runtime and returns its `runId` without waiting for execution to finish. The workflow does not need to export `route`; that export controls only direct HTTP invocation through the Flue mount. See [`invoke()`](/docs/api/workflow-api/#invoke) for its input and lifecycle contract.
 
 ## Customized routing
 
@@ -159,7 +139,7 @@ Mounting `flue()` does not make every discovered agent or workflow directly invo
 | ----------------- | --------------------------------------------------------------------------------------------------------------- |
 | Agent `route`     | HTTP prompts at `POST /agents/:name/:id` and event streaming at `GET /agents/:name/:id` beneath the mount path. |
 | Workflow `route`  | HTTP invocation at `POST /workflows/:name` beneath the mount path.                                              |
-| Workflow `runs`   | Authorized HTTP operations on existing runs owned by that workflow beneath `/runs/:runId`.                     |
+| Workflow `runs`   | Authorized HTTP operations on existing runs owned by that workflow beneath `/runs/:runId`.                      |
 | Channel `channel` | Provider-declared HTTP surfaces beneath `/channels/:name/<suffix>`.                                             |
 
 `route` controls workflow invocation only. Export `runs` separately when HTTP clients should inspect runs, including runs created by ambient `invoke()`, schedules, or other non-HTTP callers:

--- a/apps/docs/src/content/docs/sdk/client.md
+++ b/apps/docs/src/content/docs/sdk/client.md
@@ -1,7 +1,6 @@
 ---
 title: createFlueClient(...)
-description: Configure an SDK client for a mounted Flue application.
-lastReviewedAt: 2026-06-22
+description: Configure an SDK client for a deployed Flue application.
 ---
 
 ```ts
@@ -27,7 +26,7 @@ Outside a browser, `baseUrl` must be absolute; a relative value throws an error.
 function createFlueClient(options: CreateFlueClientOptions): FlueClient;
 ```
 
-Creates a client for the HTTP routes of a mounted Flue application.
+Creates a client for the public routes of a deployed Flue application.
 
 ## `CreateFlueClientOptions`
 
@@ -47,5 +46,3 @@ type RequestHeaders =
 ```
 
 Use a function to resolve headers separately for each HTTP request and stream reconnection.
-
-`fetch` may target an in-process Hono app instead of the network. This is useful for application-owned routes that call a private `flue()` mount; see [Call Flue from your own routes](/docs/guide/routing/#call-flue-from-your-own-routes).

--- a/apps/docs/src/content/docs/sdk/client.md
+++ b/apps/docs/src/content/docs/sdk/client.md
@@ -1,6 +1,7 @@
 ---
 title: createFlueClient(...)
-description: Configure an SDK client for a deployed Flue application.
+description: Configure an SDK client for a mounted Flue application.
+lastReviewedAt: 2026-06-22
 ---
 
 ```ts
@@ -26,7 +27,7 @@ Outside a browser, `baseUrl` must be absolute; a relative value throws an error.
 function createFlueClient(options: CreateFlueClientOptions): FlueClient;
 ```
 
-Creates a client for the public routes of a deployed Flue application.
+Creates a client for the HTTP routes of a mounted Flue application.
 
 ## `CreateFlueClientOptions`
 
@@ -46,3 +47,5 @@ type RequestHeaders =
 ```
 
 Use a function to resolve headers separately for each HTTP request and stream reconnection.
+
+`fetch` may target an in-process Hono app instead of the network. This is useful for application-owned routes that call a private `flue()` mount; see [Call Flue from your own routes](/docs/guide/routing/#call-flue-from-your-own-routes).


### PR DESCRIPTION
Document how application routes can call a private mounted Flue app in process.

Discussion: https://github.com/withastro/flue/discussions/343

Some applications want their own API route to run a Flue workflow without exposing the Flue mount directly to browsers or external callers. The docs covered `flue()`, workflow `route`/`runs` exports, and SDK `fetch` overrides, but not how to combine them safely.

- add a routing guide example using a private `/_flue` mount and `createFlueClient()` with custom `fetch`
- clarify that internal SDK calls still require the workflow module to export `route`
- explain when `runs` is needed for `client.runs.*` access
- distinguish this pattern from ambient `invoke()`
- note middleware behavior when calling the full Hono app versus a saved `flue()` sub-app

Validated with `pnpm --dir apps/docs run check` and `pnpm --dir apps/docs run build`.