### PR TITLE
Simplify read tool to files only

### DIFF
--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -81,7 +81,7 @@ function createReadTool(
 		name: 'read',
 		label: 'Read File',
 		description:
-			'Read a file or list a directory. For files, output is truncated to 2000 lines or 50KB — use offset/limit for large files. For directories, returns the list of entries.',
+			'Read a file. Output is truncated to 2000 lines or 50KB — use offset/limit for large files.',
 		parameters: ReadParams,
 		async execute(_toolCallId: string, params: Static<typeof ReadParams>, signal?: AbortSignal) {
 			throwIfAborted(signal);
@@ -92,20 +92,6 @@ function createReadTool(
 			}
 			if (params.path.startsWith(PACKAGED_SKILLS_ROOT)) {
 				throw new Error(`[flue] Packaged skill file not found: ${params.path}`);
-			}
-
-			try {
-				const fileStat = await env.stat(params.path);
-				if (fileStat.isDirectory) {
-					const entries = await env.readdir(params.path);
-					const listing = entries.join('\n');
-					return {
-						content: [{ type: 'text', text: listing || '(empty directory)' }],
-						details: { path: params.path, isDirectory: true, entries: entries.length },
-					};
-				}
-			} catch {
-				// stat failed — fall through to readFile
 			}
 
 			const content = await env.readFile(params.path);

--- a/packages/runtime/test/edit-tool.test.ts
+++ b/packages/runtime/test/edit-tool.test.ts
@@ -11,4 +11,20 @@ describe('createTools()', () => {
 			edit?.execute('call', { path: 'a.txt', oldText: '', newText: 'inserted' }),
 		).rejects.toThrow('oldText must be a non-empty string');
 	});
+
+	it('returns the filesystem error when reading a directory', async () => {
+		const env = createNoopSessionEnv({
+			readFile: async () => {
+				throw new Error('EISDIR: illegal operation on a directory, read');
+			},
+			stat: async () => {
+				throw new Error('stat should not be called');
+			},
+		});
+		const read = createTools(env).find((tool) => tool.name === 'read');
+
+		await expect(read?.execute('call', { path: 'directory' })).rejects.toThrow(
+			'EISDIR: illegal operation on a directory, read',
+		);
+	});
 });


### PR DESCRIPTION
## Summary
- remove directory listing support from the read tool
- rely on the filesystem read error for directory paths
- update the tool description and cover the behavior

## Verification
- `pnpm exec vitest run test/edit-tool.test.ts`
- `pnpm run check:types`
- `pnpm exec biome lint packages/runtime/src/agent.ts packages/runtime/test/edit-tool.test.ts`