### PR TITLE
Fix packaged skill resource reads

### DIFF
--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -10,6 +10,7 @@ const MAX_GREP_LINE_LENGTH = 500;
 const MAX_GLOB_RESULTS = 1000;
 const BASE64_READ_LINE_LENGTH = 76;
 const PACKAGED_SKILLS_ROOT = '/.flue/packaged-skills/';
+export const READ_SKILL_RESOURCE_TOOL_NAME = 'read_skill_resource';
 
 export interface TaskToolParams {
 	prompt: string;
@@ -59,8 +60,8 @@ export function createPackagedSkillReadTool(
 	packagedSkills: Record<string, PackagedSkillDirectory>,
 ): AgentTool<typeof ReadParams> {
 	return {
-		name: 'read',
-		label: 'Read Packaged Skill File',
+		name: READ_SKILL_RESOURCE_TOOL_NAME,
+		label: 'Read Skill Resource',
 		description: 'Read a packaged skill supporting file by its advertised path.',
 		parameters: ReadParams,
 		async execute(_toolCallId: string, params: Static<typeof ReadParams>, signal?: AbortSignal) {

--- a/packages/runtime/src/result.ts
+++ b/packages/runtime/src/result.ts
@@ -1,7 +1,10 @@
 import type { AgentTool } from '@earendil-works/pi-agent-core';
 import type * as v from 'valibot';
-import { formatPackagedSkillFilePath } from './agent.ts';
-import { parseValibot, isTopLevelObjectSchema, valibotToJsonSchema } from './schema.ts';
+import {
+	formatPackagedSkillFilePath,
+	READ_SKILL_RESOURCE_TOOL_NAME,
+} from './agent.ts';
+import { isTopLevelObjectSchema, parseValibot, valibotToJsonSchema } from './schema.ts';
 import { parseSkillMarkdown } from './skill-frontmatter.ts';
 import type { PackagedSkillDirectory, SkillReference } from './types.ts';
 
@@ -61,7 +64,8 @@ export function buildPackagedSkillPrompt(
 			'Supporting skill resources are available but are not loaded into context unless needed:',
 			'<skill_resources>',
 			...resources.map(
-				(filePath) => `- ${filePath} → read ${formatPackagedSkillFilePath(reference.id, filePath)}`,
+				(filePath) =>
+					`- ${filePath} → ${READ_SKILL_RESOURCE_TOOL_NAME} ${formatPackagedSkillFilePath(reference.id, filePath)}`,
 			),
 			'</skill_resources>',
 		);

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -29,6 +29,7 @@ import {
 	createPackagedSkillReadTool,
 	createTaskTool,
 	createTools,
+	READ_SKILL_RESOURCE_TOOL_NAME,
 	type TaskToolParams,
 	type TaskToolResultDetails,
 } from './agent.ts';
@@ -1619,6 +1620,7 @@ export class Session implements FlueSession, AgentSubmissionSession {
 		const frameworkReserved = new Set([
 			'task',
 			'activate_skill',
+			READ_SKILL_RESOURCE_TOOL_NAME,
 			FINISH_TOOL_NAME,
 			GIVE_UP_TOOL_NAME,
 		]);
@@ -1686,13 +1688,20 @@ export class Session implements FlueSession, AgentSubmissionSession {
 			skillNames.length > 0
 				? createActivateSkillTool(skillNames, (name) => this.activateSkillForTool(name))
 				: undefined;
-		const frameworkTools = (taskTool: AgentTool<any>) =>
-			activateSkillTool ? [taskTool, activateSkillTool] : [taskTool];
+		const packagedRead = Object.values(packagedSkills).some((skill) =>
+			Object.keys(skill.files).some((path) => path !== 'SKILL.md'),
+		)
+			? createPackagedSkillReadTool(packagedSkills)
+			: undefined;
+		const frameworkTools = (taskTool: AgentTool<any>) => [
+			taskTool,
+			...(activateSkillTool ? [activateSkillTool] : []),
+			...(packagedRead ? [packagedRead] : []),
+		];
 
 		if (this.toolFactory) {
 			let adapterTools = this.toolFactory(env, { subagents: this.config.subagents ?? {} });
-			if (Object.keys(packagedSkills).length > 0) {
-				const packagedRead = createPackagedSkillReadTool(packagedSkills);
+			if (packagedRead) {
 				const adapterRead = adapterTools.find((tool) => tool.name === 'read');
 				if (adapterRead) {
 					adapterTools = adapterTools.map((tool) =>
@@ -1716,8 +1725,6 @@ export class Session implements FlueSession, AgentSubmissionSession {
 									},
 								},
 					);
-				} else {
-					adapterTools = [...adapterTools, packagedRead];
 				}
 			}
 			return [

--- a/packages/runtime/test/action-execution.test.ts
+++ b/packages/runtime/test/action-execution.test.ts
@@ -9,8 +9,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
 	ActionOutputSerializationError,
 	ActionOutputValidationError,
-	defineAgent,
 	defineAction,
+	defineAgent,
 	defineTool,
 	ToolNameConflictError,
 } from '../src/index.ts';
@@ -615,7 +615,7 @@ describe('Action model tools', () => {
 	});
 
 	it('rejects adapter framework-reserved names regardless of active result or skill tools', async () => {
-		for (const name of ['task', 'activate_skill', 'finish', 'give_up']) {
+		for (const name of ['task', 'activate_skill', 'read_skill_resource', 'finish', 'give_up']) {
 			const provider = createProvider();
 			const harness = await createContext(
 				provider,
@@ -636,7 +636,7 @@ describe('Action model tools', () => {
 			});
 		}
 
-		for (const name of ['task', 'activate_skill', 'finish', 'give_up']) {
+		for (const name of ['task', 'activate_skill', 'read_skill_resource', 'finish', 'give_up']) {
 			const provider = createProvider();
 			const harness = await createContext(
 				provider,

--- a/packages/runtime/test/define-skill.test.ts
+++ b/packages/runtime/test/define-skill.test.ts
@@ -86,7 +86,7 @@ describe('defineSkill()', () => {
 		});
 	});
 
-	it('lazily advertises and reads resources when activated autonomously', async () => {
+	it('exposes packaged resources without synthesizing adapter filesystem read', async () => {
 		const provider = registerFauxProvider({ provider: `define-skill-${crypto.randomUUID()}` });
 		providers.push(provider);
 		let activationResult: unknown;
@@ -104,7 +104,7 @@ describe('defineSkill()', () => {
 			}),
 			(context) => {
 				activationResult = context.messages.at(-1);
-				return fauxAssistantMessage(fauxToolCall('read', { path: resourcePath }), {
+				return fauxAssistantMessage(fauxToolCall('read_skill_resource', { path: resourcePath }), {
 					stopReason: 'toolUse',
 				});
 			},
@@ -124,6 +124,10 @@ describe('defineSkill()', () => {
 			defineAgent(() => ({
 				model: `${provider.getModel().provider}/${provider.getModel().id}`,
 				skills: [review],
+				sandbox: {
+					createSessionEnv: async () => createEnv(),
+					tools: () => [],
+				},
 			})),
 		);
 		const session = await harness.session();
@@ -136,7 +140,9 @@ describe('defineSkill()', () => {
 			content: [
 				{
 					type: 'text',
-					text: expect.stringContaining(`references/checklist.md → read ${resourcePath}`),
+					text: expect.stringContaining(
+						`references/checklist.md → read_skill_resource ${resourcePath}`,
+					),
 				},
 			],
 			isError: false,
@@ -146,7 +152,7 @@ describe('defineSkill()', () => {
 		});
 		expect(readResult).toMatchObject({
 			role: 'toolResult',
-			toolName: 'read',
+			toolName: 'read_skill_resource',
 			content: [{ type: 'text', text: 'Check errors.' }],
 			isError: false,
 		});


### PR DESCRIPTION
## Summary
- expose packaged skill supporting files through a dedicated `read_skill_resource` framework tool
- stop synthesizing a packaged-only tool named `read` for sandbox adapters that intentionally replace default filesystem tools
- advertise the dedicated resource tool during progressive disclosure and reserve its framework-owned name

## Why
Sandbox adapter tools replace Flue's default model-facing filesystem tools. When an adapter omitted `read`, registering a packaged skill caused Flue to inject a packaged-only tool named `read`. Models could reasonably pass workspace paths to it and receive a misleading `Packaged skill file not found` error even though the workspace file existed.

A dedicated tool matches the Agent Skills client guidance: activate instructions first, then load bundled supporting resources on demand without implying general sandbox filesystem authority.

## Verification
- `pnpm run test` in `packages/runtime` (759 tests)
- `pnpm run check:types` in `packages/runtime`
- Biome check for all changed files