### PR TITLE
feat: add gen_ai.agent.name to chat spans

### DIFF
--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -199,6 +199,7 @@ export function createOpenTelemetryInstrumentation(
 					[ATTR.providerName]: request.providerName,
 					[ATTR.requestModel]: request.requestedModel,
 					[ATTR.requestStream]: true,
+					...(event.agentName ? { [ATTR.agentName]: event.agentName } : {}),
 					...(event.conversationId ? { [ATTR.conversationId]: event.conversationId } : {}),
 					...(request.reasoningLevel ? { [ATTR.reasoningLevel]: request.reasoningLevel } : {}),
 					...(request.maxTokens !== undefined ? { [ATTR.maxTokens]: request.maxTokens } : {}),

--- a/packages/opentelemetry/test/index.test.ts
+++ b/packages/opentelemetry/test/index.test.ts
@@ -118,6 +118,7 @@ describe('createOpenTelemetryInstrumentation()', () => {
 			observation({
 				type: 'turn_request',
 				instanceId: 'instance-1',
+				agentName: 'assistant',
 				conversationId: 'conv_01KT3P3GZGFBCKHKMQ11A7H2HW',
 				operationId: 'op-1',
 				turnId: 'turn-1',
@@ -152,6 +153,8 @@ describe('createOpenTelemetryInstrumentation()', () => {
 			'gen_ai.provider.name': 'gateway',
 			'gen_ai.request.model': 'model-1',
 			'gen_ai.request.stream': true,
+			'gen_ai.agent.name': 'assistant',
+			'flue.agent.name': 'assistant',
 			'gen_ai.response.id': 'resp-1',
 			'gen_ai.response.model': 'model-actual',
 			'gen_ai.usage.input_tokens': 5,


### PR DESCRIPTION
This PR adds the `gen_ai.agent.name` attribute to `chat <model name>` spans. This makes it easier for OTel backends to know which chat spans come from which agent without having to do relational checks.

An alternative solution would be to propagate `gen_ai.agent.name` to all child spans, but this is the smaller implementation.