### PR TITLE
feat: add gen_ai.agent.name to chat spans

### DIFF
--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -199,6 +199,7 @@ export function createOpenTelemetryInstrumentation(
 					[ATTR.providerName]: request.providerName,
 					[ATTR.requestModel]: request.requestedModel,
 					[ATTR.requestStream]: true,
+					...(event.agentName ? { [ATTR.agentName]: event.agentName } : {}),
 					...(event.conversationId ? { [ATTR.conversationId]: event.conversationId } : {}),
 					...(request.reasoningLevel ? { [ATTR.reasoningLevel]: request.reasoningLevel } : {}),
 					...(request.maxTokens !== undefined ? { [ATTR.maxTokens]: request.maxTokens } : {}),

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -412,6 +412,7 @@ export function createOpenTelemetryInstrumentation(
 				env: {},
 				req: undefined,
 				log: { info() {}, warn() {}, error() {} },
+				emitData() {},
 			}));
 			const tracked = runs.get(runKey(operation));
 			if (tracked) tracked.awaitingWorkflowObservation = true;

--- a/packages/opentelemetry/test/index.test.ts
+++ b/packages/opentelemetry/test/index.test.ts
@@ -118,6 +118,7 @@ describe('createOpenTelemetryInstrumentation()', () => {
 			observation({
 				type: 'turn_request',
 				instanceId: 'instance-1',
+				agentName: 'assistant',
 				conversationId: 'conv_01KT3P3GZGFBCKHKMQ11A7H2HW',
 				operationId: 'op-1',
 				turnId: 'turn-1',
@@ -152,6 +153,8 @@ describe('createOpenTelemetryInstrumentation()', () => {
 			'gen_ai.provider.name': 'gateway',
 			'gen_ai.request.model': 'model-1',
 			'gen_ai.request.stream': true,
+			'gen_ai.agent.name': 'assistant',
+			'flue.agent.name': 'assistant',
 			'gen_ai.response.id': 'resp-1',
 			'gen_ai.response.model': 'model-actual',
 			'gen_ai.usage.input_tokens': 5,

--- a/packages/opentelemetry/test/index.test.ts
+++ b/packages/opentelemetry/test/index.test.ts
@@ -440,6 +440,39 @@ describe('createOpenTelemetryInstrumentation()', () => {
 		expect(tracer.spans[0]?.attributes['gen_ai.tool.call.id']).toBe('call-1');
 	});
 
+	it('uses the closest agent name on delegated task and chat spans', () => {
+		const tracer = new RecordingTracer();
+		const instrumentation = createOpenTelemetryInstrumentation({ tracer: tracer as unknown as Tracer });
+		instrumentation.observe(observation({
+			type: 'task_start',
+			taskId: 'task-1',
+			prompt: 'delegate',
+			agent: 'researcher',
+			agentName: 'researcher',
+			conversationId: 'conv_child',
+		}), ctx);
+		instrumentation.observe(observation({
+			type: 'turn_request',
+			taskId: 'task-1',
+			turnId: 'turn-1',
+			purpose: 'agent',
+			agentName: 'researcher',
+			conversationId: 'conv_child',
+			request: {
+				providerId: 'p',
+				providerName: 'p',
+				requestedModel: 'm',
+				api: 'a',
+				input: { messages: [] },
+			},
+		}), ctx);
+
+		expect(tracer.spans.map((span) => span.name)).toEqual(['invoke_agent researcher', 'chat m']);
+		expect(tracer.spans[0]?.attributes['gen_ai.agent.name']).toBe('researcher');
+		expect(tracer.spans[1]?.attributes['gen_ai.agent.name']).toBe('researcher');
+		expect(tracer.spans[1]?.attributes['flue.agent.name']).toBe('researcher');
+	});
+
 	it('creates one span when a tool start is duplicated', () => {
 		const tracer = new RecordingTracer();
 		const instrumentation = createOpenTelemetryInstrumentation({ tracer: tracer as unknown as Tracer });

--- a/packages/runtime/src/client.ts
+++ b/packages/runtime/src/client.ts
@@ -76,7 +76,9 @@ export function createFlueContext(config: FlueContextConfig): FlueContextInterna
 		...(config.runId === undefined ? { instanceId: config.id } : { runId: config.runId }),
 		...(config.dispatchId === undefined ? {} : { dispatchId: config.dispatchId }),
 		...(submissionId === undefined ? {} : { submissionId }),
-		...(config.agentName === undefined ? {} : { agentName: config.agentName }),
+		...(event.agentName === undefined && config.agentName !== undefined
+			? { agentName: config.agentName }
+			: {}),
 		v: 3,
 		eventIndex: eventIndex++,
 		timestamp: new Date().toISOString(),

--- a/packages/runtime/src/harness.ts
+++ b/packages/runtime/src/harness.ts
@@ -262,9 +262,11 @@ export class Harness implements FlueHarness {
 		const data = createEmptySessionData();
 		const eventCallback: FlueEventInputCallback | undefined = this.eventCallback
 			? (event, observation) => {
+					const agentName = event.agentName ?? taskAgent?.name;
 					this.eventCallback?.({
 						...event,
 						harness: event.harness ?? this.name,
+						...(agentName ? { agentName } : {}),
 						parentSession: event.parentSession ?? options.parentSession,
 						taskId: event.taskId ?? options.taskId,
 					}, observation);
@@ -288,7 +290,12 @@ export class Harness implements FlueHarness {
 			actions: taskConfig.actions ?? [],
 			createActionHarness: (actionOptions) => this.createActionHarness(actionOptions),
 			scopeSignal: this.scopeAbortController.signal,
-			executionContext: { ...this.executionContext, harness: this.name, taskId: options.taskId },
+			executionContext: {
+				...this.executionContext,
+				harness: this.name,
+				taskId: options.taskId,
+				...(taskAgent?.name ? { agentName: taskAgent.name } : {}),
+			},
 		});
 	}
 

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -1882,6 +1882,7 @@ export class Session implements FlueSession, AgentSubmissionSession {
 				taskId,
 				prompt: text,
 				agent: taskAgent?.name,
+				...(taskAgent?.name ? { agentName: taskAgent.name } : {}),
 				cwd: options?.cwd,
 				parentSession: this.name,
 				session: child.name,

--- a/packages/runtime/test/session-operations.test.ts
+++ b/packages/runtime/test/session-operations.test.ts
@@ -39,10 +39,11 @@ function createProvider(models?: FauxModelDefinition[]): FauxProviderRegistratio
 
 function createContext(
 	provider: FauxProviderRegistration,
-	options: { env?: SessionEnv; store?: SessionStore } = {},
+	options: { env?: SessionEnv; store?: SessionStore; agentName?: string } = {},
 ) {
 	return createFlueContext({
 		id: 'session-operations-instance',
+		agentName: options.agentName,
 		env: {},
 		agentConfig: {
 			resolveModel: (specifier) => {
@@ -977,7 +978,17 @@ describe('session.task()', () => {
 				return fauxAssistantMessage('Delegated profile response.');
 			},
 		]);
-		const ctx = createContext(provider);
+		const ctx = createContext(provider, { agentName: 'root-agent' });
+		const events: Array<{ type: string; agentName?: string; agent?: string; taskId?: string }> = [];
+		ctx.subscribeEvent((event) => {
+			if (
+				event.type === 'task_start' ||
+				event.type === 'operation_start' ||
+				event.type === 'turn_request'
+			) {
+				events.push(event);
+			}
+		});
 		const harness = await ctx.initializeRootHarness(
 			defineAgent(() => ({
 				model: `${provider.getModel().provider}/parent-model`,
@@ -998,6 +1009,26 @@ describe('session.task()', () => {
 		expect(response).toMatchObject({
 			text: 'Delegated profile response.',
 			model: { provider: provider.getModel().provider, id: 'delegate-model' },
+		});
+		const taskStart = events.find((event) => event.type === 'task_start');
+		const childOperationStart = events.find(
+			(event) => event.type === 'operation_start' && event.taskId === taskStart?.taskId,
+		);
+		const childTurnRequest = events.find(
+			(event) => event.type === 'turn_request' && event.taskId === taskStart?.taskId,
+		);
+		expect(taskStart).toMatchObject({
+			type: 'task_start',
+			agent: 'code-reviewer',
+			agentName: 'code-reviewer',
+		});
+		expect(childOperationStart).toMatchObject({
+			type: 'operation_start',
+			agentName: 'code-reviewer',
+		});
+		expect(childTurnRequest).toMatchObject({
+			type: 'turn_request',
+			agentName: 'code-reviewer',
 		});
 	});
 


### PR DESCRIPTION
This PR adds the `gen_ai.agent.name` attribute to `chat <model name>` spans. chat spans carry the same name as the nearest parent `invoke_agent` span. This makes it easier for OTel backends to know which chat spans come from which agent without having to do relational checks.

An alternative solution would be to propagate `gen_ai.agent.name` to all child spans, but this is the smaller implementation.