### PR TITLE
fix(runtime): workerd-safe MCP outputSchema validation

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -72,6 +72,7 @@
 		"test:watch": "vitest"
 	},
 	"dependencies": {
+		"@cfworker/json-schema": "^4.1.1",
 		"@earendil-works/pi-agent-core": "^0.80.2",
 		"@earendil-works/pi-ai": "^0.80.2",
 		"@hono/node-server": "^2.0.3",

--- a/packages/runtime/src/mcp.ts
+++ b/packages/runtime/src/mcp.ts
@@ -7,8 +7,11 @@ import {
 	McpError,
 	type Tool,
 } from '@modelcontextprotocol/sdk/types.js';
-import type { JsonSchemaValidator } from '@modelcontextprotocol/sdk/validation';
-import { AjvJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/ajv';
+import type {
+	JsonSchemaValidator,
+	jsonSchemaValidator as JsonSchemaValidatorProvider,
+} from '@modelcontextprotocol/sdk/validation';
+import { CfWorkerJsonSchemaValidator } from '@modelcontextprotocol/sdk/validation/cfworker';
 import { version as runtimeVersion } from '../package.json' with { type: 'json' };
 import { registerPreparedToolAdapter } from './tool-adapter.ts';
 import type { ToolDefinition } from './types.ts';
@@ -32,6 +35,18 @@ export interface McpServerOptions {
 	timeoutMs?: number;
 	/** Reset the per-request timeout whenever the server sends a progress notification. Defaults to `false`. */
 	resetTimeoutOnProgress?: boolean;
+	/**
+	 * JSON Schema validator used to validate MCP tool `outputSchema`s.
+	 *
+	 * Defaults to {@link CfWorkerJsonSchemaValidator}, which interprets JSON
+	 * Schema at runtime with no code generation. The MCP SDK's default
+	 * `AjvJsonSchemaValidator` compiles schemas via `new Function`, which throws
+	 * `EvalError: Code generation from strings disallowed` on edge runtimes such
+	 * as Cloudflare Workers (workerd). The default keeps `connectMcpServer`
+	 * working everywhere; pass a custom validator (e.g. `AjvJsonSchemaValidator`)
+	 * to opt into AJV on Node.js.
+	 */
+	jsonSchemaValidator?: JsonSchemaValidatorProvider;
 }
 
 /** Request options in the MCP SDK's shape (its `timeout` is milliseconds). */
@@ -72,15 +87,25 @@ export async function connectMcpServer(
 		requestInit,
 		options.fetch,
 	);
-	const client = new Client({
-		name: 'flue',
-		version: runtimeVersion,
-	});
+	const jsonSchemaValidator = options.jsonSchemaValidator ?? new CfWorkerJsonSchemaValidator();
+	const client = new Client(
+		{
+			name: 'flue',
+			version: runtimeVersion,
+		},
+		{ jsonSchemaValidator },
+	);
 
-	return connectMcpServerWithClient(name, client, transport, {
-		timeout: options.timeoutMs,
-		resetTimeoutOnProgress: options.resetTimeoutOnProgress,
-	});
+	return connectMcpServerWithClient(
+		name,
+		client,
+		transport,
+		{
+			timeout: options.timeoutMs,
+			resetTimeoutOnProgress: options.resetTimeoutOnProgress,
+		},
+		jsonSchemaValidator,
+	);
 }
 
 export async function connectMcpServerWithClient(
@@ -88,6 +113,7 @@ export async function connectMcpServerWithClient(
 	client: McpClient,
 	transport: Transport,
 	requestOptions: McpRequestOptions = {},
+	jsonSchemaValidator: JsonSchemaValidatorProvider = new CfWorkerJsonSchemaValidator(),
 ): Promise<McpServerConnection> {
 	try {
 		await client.connect(transport);
@@ -107,7 +133,7 @@ export async function connectMcpServerWithClient(
 
 		return {
 			name,
-			tools: createMcpTools(name, client, tools, requestOptions),
+			tools: createMcpTools(name, client, tools, requestOptions, jsonSchemaValidator),
 			close: () => client.close(),
 		};
 	} catch (error) {
@@ -140,9 +166,9 @@ function createMcpTools(
 	client: McpClient,
 	tools: Tool[],
 	requestOptions: McpRequestOptions,
+	validator: JsonSchemaValidatorProvider,
 ): ToolDefinition[] {
 	const names = new Set<string>();
-	const validator = new AjvJsonSchemaValidator();
 
 	const callableTools = tools.filter((tool) => {
 		if (tool.execution?.taskSupport !== 'required') return true;

--- a/packages/runtime/test/mcp.test.ts
+++ b/packages/runtime/test/mcp.test.ts
@@ -437,6 +437,55 @@ describe('connectMcpServerWithClient()', () => {
 		);
 	});
 
+	it('accepts conforming structured output for a schema-bearing MCP tool using the default workerd-safe validator', async () => {
+		// Default validator is CfWorkerJsonSchemaValidator, which interprets JSON
+		// Schema at runtime (no `new Function`), so it both compiles on workerd and
+		// still performs real validation. Conforming output must pass.
+		mcp.listToolsResult = {
+			tools: [
+				{
+					name: 'lookup',
+					inputSchema: { type: 'object' },
+					outputSchema: {
+						type: 'object',
+						properties: { count: { type: 'number' } },
+						required: ['count'],
+					},
+				},
+			],
+		};
+		mcp.callToolResult = { content: [], structuredContent: { count: 2 } };
+		const connection = await connectMcpServerWithClient('catalog', mcp.client, transport);
+
+		await expect(firstPreparedTool(connection.tools).execute({})).resolves.toContain('"count": 2');
+	});
+
+	it('uses a caller-supplied JSON Schema validator to validate structured output when one is provided', async () => {
+		const getValidator = vi.fn(() => (_value: unknown) => ({
+			valid: false as const,
+			data: undefined,
+			errorMessage: 'custom validator rejected the output',
+		}));
+		mcp.listToolsResult = {
+			tools: [
+				{
+					name: 'lookup',
+					inputSchema: { type: 'object' },
+					outputSchema: { type: 'object' },
+				},
+			],
+		};
+		mcp.callToolResult = { content: [], structuredContent: { count: 2 } };
+		const connection = await connectMcpServerWithClient('catalog', mcp.client, transport, {}, {
+			getValidator,
+		});
+
+		await expect(firstPreparedTool(connection.tools).execute({})).rejects.toThrow(
+			'custom validator rejected the output',
+		);
+		expect(getValidator).toHaveBeenCalledOnce();
+	});
+
 	it('excludes a required-task MCP tool from the adapted tool list when the server lists one', async () => {
 		mcp.listToolsResults = [
 			{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1377,6 +1377,9 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@cfworker/json-schema':
+        specifier: ^4.1.1
+        version: 4.1.1
       '@earendil-works/pi-agent-core':
         specifier: ^0.80.2
         version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)


### PR DESCRIPTION
## Problem

The MCP client validates tool `outputSchema`s with the MCP SDK's default `AjvJsonSchemaValidator`. AJV compiles each schema into a validator function via `new Function(...)`. Edge runtimes that disallow runtime codegen — notably **workerd** (Cloudflare Workers, e.g. `flue dev|build --target cloudflare`) — reject this with:

```
EvalError: Code generation from strings disallowed for this context
```

It throws at **MCP connect time** for any tool that advertises an `outputSchema`, at **two sites**:
1. The MCP SDK `Client` itself (`cacheToolMetadata` during `listTools`) — the first to trip.
2. `createMcpTools` in `packages/runtime/src/mcp.ts`.

This makes `connectMcpServer` unusable on Cloudflare Workers as soon as any MCP server exposes a tool with an output schema.

## Fix

Switch both validation sites to the MCP SDK's **first-party** `CfWorkerJsonSchemaValidator` (`@modelcontextprotocol/sdk/validation/cfworker`), which interprets JSON Schema at runtime with no codegen and runs everywhere while still performing real validation:

- pass `{ jsonSchemaValidator }` into `new Client(...)`
- thread the same provider into `createMcpTools`

The validator is exposed as an optional `jsonSchemaValidator` on `McpServerOptions`, defaulting to `CfWorkerJsonSchemaValidator`. Node-only callers can still opt into AJV by passing `new AjvJsonSchemaValidator()`.

`@cfworker/json-schema` is **already in the dependency tree** (the SDK's cfworker provider depends on it), so this adds no new transitive dependency — it's now declared as a direct dependency of `@flue/runtime`.

## Tests

Adds two tests to `packages/runtime/test/mcp.test.ts`:
- conforming structured output passes through the default workerd-safe validator;
- a caller-supplied `jsonSchemaValidator` is honored.

The existing schema-validation tests (malformed / missing structured output) continue to pass through the new default path. `pnpm --filter @flue/runtime build`, `tsc --noEmit`, and `vitest run test/mcp.test.ts` (19 passed) all green. Verified on **real workerd**: a tool advertising an `outputSchema` connects without the codegen `EvalError`, and validation is preserved (conforming output passes, non-conforming output rejected).