### PR TITLE
Add GPT-5.6 model family support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+- OpenAI GPT-5.6 Sol, Terra, and Luna are now available through the built-in model catalog, including the new `max` reasoning effort tier, so agents can select the capability, cost, and latency profile that fits their workload.
 - Public conversation messages now expose typed `purpose` (`user`, `assistant`, `dispatch`, or `advisory`) and `display` (`visible`, `hidden`, or `diagnostic`), plus optional `turnId` grouping and a `signal` descriptor, so clients can distinguish public chat from internal, control, and advisory activity without parsing message text, timestamps, or ordering. The classification is applied identically across `client.agents.history()` snapshots and live updates, and `@flue/sdk` / `@flue/react` shapes are updated in lockstep (#404).
 - `@flue/react`'s `useFlueAgent()` now exposes `refresh()`, so apps observing an agent conversation that may be created out-of-band (a server-side wakeup, queue worker, or webhook) can re-check on their own schedule instead of faking an empty history snapshot. Retry policy stays in userland (#403).
 

--- a/apps/docs/src/content/docs/guide/models.md
+++ b/apps/docs/src/content/docs/guide/models.md
@@ -1,7 +1,7 @@
 ---
 title: LLM (Models & Providers)
 description: Select models, configure providers, and tune reasoning behavior in Flue agents.
-lastReviewedAt: 2026-05-29
+lastReviewedAt: 2026-07-09
 ---
 
 Models determine what kind of work an agent can perform. Providers determine how your application reaches those models, authenticates its requests, and applies any transport-specific configuration.
@@ -15,10 +15,14 @@ A model specifier is the unique string Flue uses to refer to a specific model ac
 | Model specifier                       | Provider ID  | Model ID                   |
 | ------------------------------------- | ------------ | -------------------------- |
 | `anthropic/claude-sonnet-4-6`         | `anthropic`  | `claude-sonnet-4-6`        |
-| `openai/gpt-5.5`                      | `openai`     | `gpt-5.5`                  |
+| `openai/gpt-5.6-sol`                  | `openai`     | `gpt-5.6-sol`              |
+| `openai/gpt-5.6-terra`                | `openai`     | `gpt-5.6-terra`            |
+| `openai/gpt-5.6-luna`                 | `openai`     | `gpt-5.6-luna`             |
 | `openrouter/moonshotai/kimi-k2.6`     | `openrouter` | `moonshotai/kimi-k2.6`     |
 | `cloudflare/@cf/moonshotai/kimi-k2.6` | `cloudflare` | `@cf/moonshotai/kimi-k2.6` |
 | `cloudflare/openai/gpt-5.5`           | `cloudflare` | `openai/gpt-5.5`           |
+
+For direct OpenAI access, choose `openai/gpt-5.6-sol` for flagship capability, `openai/gpt-5.6-terra` for a balance of capability and cost, or `openai/gpt-5.6-luna` for fast, high-volume work at the lowest cost in the family.
 
 Use a model specifier to choose an agent's default model:
 
@@ -43,7 +47,8 @@ Reasoning effort controls how much additional reasoning Flue requests from a mod
 | `'low'`     | Favor lower reasoning cost or latency.                     |
 | `'medium'`  | Balance reasoning effort and cost. This is Flue's default. |
 | `'high'`    | Favor more careful reasoning.                              |
-| `'xhigh'`   | Request the highest exposed effort tier.                   |
+| `'xhigh'`   | Request an exceptionally high reasoning effort.            |
+| `'max'`     | Request the highest exposed effort tier.                   |
 
 Set the ordinary reasoning effort for an agent alongside its model:
 

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -12,7 +12,7 @@
 	},
 	"dependencies": {
 		"@astrojs/mdx": "7.0.0-beta.2",
-		"@earendil-works/pi-ai": "^0.80.2",
+		"@earendil-works/pi-ai": "^0.80.6",
 		"@paper-design/shaders": "0.0.76",
 		"@tailwindcss/vite": "^4.2.0",
 		"astro": "7.0.0-beta.3",

--- a/apps/www/src/pages/start.md.ts
+++ b/apps/www/src/pages/start.md.ts
@@ -52,7 +52,9 @@ ${DEPLOY_GUIDE_LIST}
    - We suggest these exact model specifiers:
      - \`anthropic/claude-sonnet-4-6\` - latest Sonnet
      - \`anthropic/claude-opus-4-7\` - latest Opus
-     - \`openai/gpt-5.5\` - GPT-5.5
+     - \`openai/gpt-5.6-sol\` - GPT-5.6 flagship capability
+     - \`openai/gpt-5.6-terra\` - GPT-5.6 balanced capability and cost
+     - \`openai/gpt-5.6-luna\` - GPT-5.6 fastest, lowest-cost option
      - \`openrouter/moonshotai/kimi-k2.6\` - latest Kimi
    - If the user wants a different provider or model, use this list to get the best model specifier: \`https://flueframework.com/models.json\`
    - If their requested model is unavailable, ask before substituting another model. Don't continue until you have a model specifier.

--- a/examples/chat-sdk/package.json
+++ b/examples/chat-sdk/package.json
@@ -8,7 +8,7 @@
 	"dependencies": {
 		"@chat-adapter/github": "*",
 		"@chat-adapter/state-memory": "*",
-		"@earendil-works/pi-ai": "^0.80.2",
+		"@earendil-works/pi-ai": "^0.80.6",
 		"@flue/runtime": "workspace:*",
 		"agents": "^0.14.2",
 		"chat": "*",

--- a/examples/react-chat/package.json
+++ b/examples/react-chat/package.json
@@ -9,7 +9,7 @@
 		"check:types": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@earendil-works/pi-ai": "^0.80.2",
+		"@earendil-works/pi-ai": "^0.80.6",
 		"@flue/react": "workspace:*",
 		"@flue/runtime": "workspace:*",
 		"@flue/sdk": "workspace:*",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -73,8 +73,8 @@
 	},
 	"dependencies": {
 		"@cfworker/json-schema": "^4.1.1",
-		"@earendil-works/pi-agent-core": "^0.80.2",
-		"@earendil-works/pi-ai": "^0.80.2",
+		"@earendil-works/pi-agent-core": "^0.80.6",
+		"@earendil-works/pi-ai": "^0.80.6",
 		"@hono/node-server": "^2.0.3",
 		"@hono/standard-validator": "^0.2.0",
 		"@modelcontextprotocol/sdk": "^1.29.0",

--- a/packages/runtime/src/agent-definition.ts
+++ b/packages/runtime/src/agent-definition.ts
@@ -20,6 +20,7 @@ const VALID_THINKING_LEVELS = {
 	medium: true,
 	high: true,
 	xhigh: true,
+	max: true,
 } as const satisfies Record<ThinkingLevel, true>;
 
 const AgentProfileSchema = v.strictObject(

--- a/packages/runtime/src/cloudflare/workers-ai-provider.ts
+++ b/packages/runtime/src/cloudflare/workers-ai-provider.ts
@@ -765,6 +765,7 @@ function mapReasoningEffort(
 			return 'medium';
 		case 'high':
 		case 'xhigh':
+		case 'max':
 			return 'high';
 	}
 }

--- a/packages/runtime/test/agent-definition.test.ts
+++ b/packages/runtime/test/agent-definition.test.ts
@@ -80,6 +80,10 @@ describe('defineAgent()', () => {
 });
 
 describe('defineAgentProfile()', () => {
+	it('accepts max reasoning effort when a profile selects the highest supported tier', () => {
+		expect(() => defineAgentProfile({ model: 'openai/gpt-5.6-sol', thinkingLevel: 'max' })).not.toThrow();
+	});
+
 	it('rejects unknown profile fields when a profile contains unsupported configuration', () => {
 		expect(() => defineAgentProfile({ model: 'anthropic/claude-haiku-4-5', unsupported: true } as never)).toThrow(
 			'unknown agent profile field "unsupported"',

--- a/packages/runtime/test/providers.test.ts
+++ b/packages/runtime/test/providers.test.ts
@@ -64,6 +64,39 @@ function createContext() {
 	});
 }
 
+describe('resolveModel()', () => {
+	it('resolves every GPT-5.6 variant when an OpenAI model is selected', () => {
+		const sol = resolveModel('openai/gpt-5.6-sol');
+		const terra = resolveModel('openai/gpt-5.6-terra');
+		const luna = resolveModel('openai/gpt-5.6-luna');
+
+		expect(sol).toMatchObject({
+			id: 'gpt-5.6-sol',
+			provider: 'openai',
+			api: 'openai-responses',
+			reasoning: true,
+			thinkingLevelMap: { max: 'max' },
+		});
+		expect(terra).toMatchObject({
+			id: 'gpt-5.6-terra',
+			provider: 'openai',
+			api: 'openai-responses',
+			reasoning: true,
+			thinkingLevelMap: { max: 'max' },
+		});
+		expect(luna).toMatchObject({
+			id: 'gpt-5.6-luna',
+			provider: 'openai',
+			api: 'openai-responses',
+			reasoning: true,
+			thinkingLevelMap: { max: 'max' },
+		});
+		expect(sol.contextWindow).toBeGreaterThan(0);
+		expect(terra.contextWindow).toBeGreaterThan(0);
+		expect(luna.contextWindow).toBeGreaterThan(0);
+	});
+});
+
 describe('registerProvider()', () => {
 	it('sends operations to the registered base URL when a model uses a registered provider id', async () => {
 		const seen = captureFetch('Hello from the registered provider.');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,8 +80,8 @@ importers:
         specifier: 7.0.0-beta.2
         version: 7.0.0-beta.2(astro@7.0.0-beta.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.0.0)(aws4fetch@1.0.20)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
       '@earendil-works/pi-ai':
-        specifier: ^0.80.2
-        version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.6
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@paper-design/shaders':
         specifier: 0.0.76
         version: 0.0.76
@@ -225,8 +225,8 @@ importers:
         specifier: '*'
         version: 4.30.0(ai@6.0.191(zod@4.4.3))(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: ^0.80.2
-        version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.6
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@flue/runtime':
         specifier: workspace:*
         version: link:../../packages/runtime
@@ -567,8 +567,8 @@ importers:
   examples/react-chat:
     dependencies:
       '@earendil-works/pi-ai':
-        specifier: ^0.80.2
-        version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.6
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@flue/react':
         specifier: workspace:*
         version: link:../../packages/react
@@ -1381,11 +1381,11 @@ importers:
         specifier: ^4.1.1
         version: 4.1.1
       '@earendil-works/pi-agent-core':
-        specifier: ^0.80.2
-        version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.6
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@earendil-works/pi-ai':
-        specifier: ^0.80.2
-        version: 0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: ^0.80.6
+        version: 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@hono/node-server':
         specifier: ^2.0.3
         version: 2.0.3(hono@4.12.22)
@@ -2481,12 +2481,12 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  '@earendil-works/pi-agent-core@0.80.2':
-    resolution: {integrity: sha512-BF9WPhixIFjT6Kp3Iz3H6ugkU+4AWotM8py96XE5pIK0arJbQKMWbR+dXSWWDEmR5yc/aFQODnuyowOEzMGO7Q==}
+  '@earendil-works/pi-agent-core@0.80.6':
+    resolution: {integrity: sha512-Lvn89ko42h5ETUb6Z0Ku6ldskEqXaTdQBYvSa0+7bdG9V6rUEpXptv5e0OVZ1HDcvi8s6/2lGCQWsxKX+DFHNw==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.80.2':
-    resolution: {integrity: sha512-5GNKfdrRJ4uZ5Zd9iudoXggi/BbUcKnD/xfRHtdR+7q4vWqPvfx8auFuaT+ewGBVI8K4wj87eigFQ/iCSuy9RQ==}
+  '@earendil-works/pi-ai@0.80.6':
+    resolution: {integrity: sha512-7xfLk8sANBp+bpPEbjoOZTbPxsa+++b1JXAoSJsNa3vbs9AHHEclmvg54XLQcxH+fuwaeti/g2jeIfJ+mVYLpA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -11051,9 +11051,9 @@ snapshots:
       '@microsoft/fetch-event-source': 2.0.1
       fastq: 1.20.1
 
-  '@earendil-works/pi-agent-core@0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -11065,7 +11065,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.80.2(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.80.6(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0


### PR DESCRIPTION
## Summary

- update the shared Pi dependencies to expose `openai/gpt-5.6-sol`, `openai/gpt-5.6-terra`, and `openai/gpt-5.6-luna` through runtime resolution and `/models.json`
- accept GPT-5.6’s `max` reasoning effort while preserving Cloudflare’s coarser effort mapping
- add starter guidance, model documentation, changelog coverage, and focused runtime tests

## Why

Flue users need to select the GPT-5.6 variant that matches their capability, cost, and latency requirements without adding a second Flue-specific model registry.

## Validation

- `pnpm --dir packages/runtime run build`
- `pnpm --dir packages/runtime run check:types`
- `pnpm --dir packages/runtime run test` — 774 passed, 1 skipped
- `pnpm --dir apps/www run build`
- `pnpm --dir apps/docs run build`
- `pnpm --dir examples/react-chat run check:types`
- touched-file Biome lint
- generated `/models.json` contains Sol, Terra, and Luna

## Notes

- No live OpenAI API request was made.
- The repo-wide typecheck remains blocked by an existing demo message-role mismatch at `demo/src/components/chat/message-list.tsx:75`.
- The repo-wide lint command reports existing unused variables/exports outside this diff.