### PR TITLE
fix(runtime): clean up orphaned assistants after interrupted attempts

### DIFF
--- a/packages/runtime/src/conversation-reducer.ts
+++ b/packages/runtime/src/conversation-reducer.ts
@@ -550,6 +550,13 @@ export function applyConversationRecord(
 			break;
 		}
 		case 'submission_settled':
+			if (typeof record.submissionId === 'string') {
+				for (const [messageId, message] of conversation.inProgressMessages) {
+					if (message.submissionId === record.submissionId) {
+						conversation.inProgressMessages.delete(messageId);
+					}
+				}
+			}
 			break;
 	}
 	state.recordsById.set(record.id, record);

--- a/packages/runtime/src/runtime/agent-submissions.ts
+++ b/packages/runtime/src/runtime/agent-submissions.ts
@@ -333,9 +333,11 @@ export async function reconcileInterruptedSubmission(
 	// Resumable progress, or the one accepted degraded window. Both the
 	// durable-partial-stream case and the trailing-incomplete-tool-batch case
 	// classify 'continuable'; 'uncertain' is the accepted provider-redispatch
-	// window — nothing observable was persisted, so a single retry (which may
-	// re-dispatch the provider once) is safe under the at-least-once execution
-	// contract and `store: true` response replay.
+	// window. In the input-only case, the assistant start may already be
+	// persisted even though no output was produced, so recovery must terminalize
+	// that in-progress message before the provider is re-dispatched. A single
+	// retry is safe under the at-least-once execution contract and `store: true`
+	// response replay.
 	//
 	// Acquire the replacement attempt (the fencing CAS) BEFORE any recovery
 	// append, so a reconciler that loses the CAS never mutates session history.
@@ -362,7 +364,7 @@ export async function reconcileInterruptedSubmission(
 			lease,
 		);
 		if (!replacement?.attemptId) return undefined;
-		if (state === 'continuable') {
+		if (state === 'continuable' || state === 'uncertain') {
 			const recoveryCtx = createContext(dispatchId);
 			if (submission.kind === 'direct') recoveryCtx.setSubmissionId?.(submission.submissionId);
 			await createAgentSubmissionSessionHandler(agent, input, (s) =>

--- a/packages/runtime/test/conversation-reducer.test.ts
+++ b/packages/runtime/test/conversation-reducer.test.ts
@@ -523,6 +523,146 @@ describe('reduceConversationRecords()', () => {
 		expect(buildConversationContext(conversation)).toHaveLength(1);
 	});
 
+	it('accepts the next user message when a settled submission left an orphaned assistant', () => {
+		const state = reduceConversationRecords(createReducedInstanceState(), [
+			required(canonicalConversation()[0]),
+			{
+				...scope,
+				id: 'record_user',
+				type: 'user_message',
+				timestamp: '2026-06-25T00:00:01.000Z',
+				messageId: 'entry_user',
+				parentId: null,
+				content: [{ type: 'text', text: 'Hello' }],
+				submissionId: 'submission_01',
+				attemptId: 'attempt_01',
+			},
+			{
+				...scope,
+				id: 'record_assistant_old_start',
+				type: 'assistant_message_started',
+				timestamp: '2026-06-25T00:00:02.000Z',
+				messageId: 'entry_assistant_old',
+				parentId: 'entry_user',
+				turnId: 'turn_01',
+				modelInfo: { api: 'test', provider: 'test', model: 'test-model' },
+				submissionId: 'submission_01',
+				attemptId: 'attempt_01',
+			},
+			{
+				...scope,
+				id: 'record_assistant_replacement_start',
+				type: 'assistant_message_started',
+				timestamp: '2026-06-25T00:00:03.000Z',
+				messageId: 'entry_assistant_replacement',
+				parentId: 'entry_user',
+				turnId: 'turn_02',
+				modelInfo: { api: 'test', provider: 'test', model: 'test-model' },
+				submissionId: 'submission_01',
+				attemptId: 'attempt_02',
+			},
+			{
+				...scope,
+				id: 'record_assistant_replacement_complete',
+				type: 'assistant_message_completed',
+				timestamp: '2026-06-25T00:00:04.000Z',
+				messageId: 'entry_assistant_replacement',
+				stopReason: 'error',
+				usage,
+				error: 'Provider failed.',
+				submissionId: 'submission_01',
+				attemptId: 'attempt_02',
+			},
+			{
+				...scope,
+				id: 'record_submission_settled',
+				type: 'submission_settled',
+				timestamp: '2026-06-25T00:00:05.000Z',
+				submissionId: 'submission_01',
+				attemptId: 'attempt_02',
+				outcome: 'failed',
+				error: { message: 'Provider failed.' },
+			},
+		], '5');
+
+		expect(() => applyConversationRecord(state, {
+			...scope,
+			id: 'record_user_follow_up',
+			type: 'user_message',
+			timestamp: '2026-06-25T00:00:06.000Z',
+			messageId: 'entry_user_follow_up',
+			parentId: 'entry_assistant_replacement',
+			content: [{ type: 'text', text: 'Try again' }],
+			submissionId: 'submission_02',
+			attemptId: 'attempt_03',
+		})).not.toThrow();
+	});
+
+	it('preserves committed entries and the active leaf when settlement clears submission-owned assistants', () => {
+		const records: ConversationRecord[] = [
+			required(canonicalConversation()[0]),
+			{
+				...scope,
+				id: 'record_user',
+				type: 'user_message',
+				timestamp: '2026-06-25T00:00:01.000Z',
+				messageId: 'entry_user',
+				parentId: null,
+				content: [{ type: 'text', text: 'Hello' }],
+				submissionId: 'submission_01',
+			},
+			{
+				...scope,
+				id: 'record_assistant_old_start',
+				type: 'assistant_message_started',
+				timestamp: '2026-06-25T00:00:02.000Z',
+				messageId: 'entry_assistant_old',
+				parentId: 'entry_user',
+				modelInfo: { api: 'test', provider: 'test', model: 'test-model' },
+				submissionId: 'submission_01',
+			},
+			{
+				...scope,
+				id: 'record_assistant_replacement_start',
+				type: 'assistant_message_started',
+				timestamp: '2026-06-25T00:00:03.000Z',
+				messageId: 'entry_assistant_replacement',
+				parentId: 'entry_user',
+				modelInfo: { api: 'test', provider: 'test', model: 'test-model' },
+				submissionId: 'submission_01',
+			},
+			{
+				...scope,
+				id: 'record_assistant_replacement_complete',
+				type: 'assistant_message_completed',
+				timestamp: '2026-06-25T00:00:04.000Z',
+				messageId: 'entry_assistant_replacement',
+				stopReason: 'error',
+				usage,
+				error: 'Provider failed.',
+				submissionId: 'submission_01',
+			},
+		];
+		const state = reduceConversationRecords(createReducedInstanceState(), records, '4');
+		const conversation = required(state.conversations.get('conv_01'));
+		const committedEntries = new Map(conversation.entries);
+		const activeLeafId = conversation.activeLeafId;
+
+		applyConversationRecord(state, {
+			...scope,
+			id: 'record_submission_settled',
+			type: 'submission_settled',
+			timestamp: '2026-06-25T00:00:05.000Z',
+			submissionId: 'submission_01',
+			outcome: 'failed',
+			error: { message: 'Provider failed.' },
+		});
+
+		expect(conversation.inProgressMessages).toHaveLength(0);
+		expect(conversation.entries).toEqual(committedEntries);
+		expect(conversation.activeLeafId).toBe(activeLeafId);
+	});
+
 	it('projects one complete UI snapshot through the physical catch-up offset', () => {
 		const state = reduceConversationRecords(createReducedInstanceState(), canonicalConversation(), '8');
 		const snapshot = projectConversationUi(required(state.conversations.get('conv_01')), '8');

--- a/packages/runtime/test/node-agent-coordinator.test.ts
+++ b/packages/runtime/test/node-agent-coordinator.test.ts
@@ -202,13 +202,15 @@ async function createFauxCoordinator(
  *   retained child conversation (no outcome, no commit).
  * - 'partial-batch': a durable toolUse turn with two `lookup` calls, one
  *   outcome recorded, none committed.
+ * - 'ghost-start': an in-progress assistant started before any output was
+ *   persisted.
  * - 'ghost-stream': an in-progress assistant stream (started + one durable
  *   delta) never completed.
  */
 async function seedDanglingSubmission(options: {
 	dbPath: string;
 	dispatchId: string;
-	shape: 'task-call' | 'partial-batch' | 'ghost-stream';
+	shape: 'task-call' | 'partial-batch' | 'ghost-start' | 'ghost-stream';
 	durability?: { maxRetry: number; timeoutAt: number };
 }): Promise<{ conversationId: string; childConversationId?: string }> {
 	const adapter = sqlite(options.dbPath);
@@ -290,8 +292,8 @@ async function seedDanglingSubmission(options: {
 		options.durability ?? { maxRetry: 1, timeoutAt: Date.now() + 60_000 },
 	);
 
-	if (options.shape === 'ghost-stream') {
-		await append([
+	if (options.shape === 'ghost-start' || options.shape === 'ghost-stream') {
+		const records: ConversationRecord[] = [
 			{
 				...scope,
 				id: 'record-stream-started',
@@ -300,6 +302,8 @@ async function seedDanglingSubmission(options: {
 				parentId: inputEntryId,
 				modelInfo: { api: 'faux', provider: 'faux', model: 'reviewer' },
 			},
+		];
+		if (options.shape === 'ghost-stream') records.push(
 			{
 				...scope,
 				id: 'record-stream-text-started',
@@ -317,7 +321,8 @@ async function seedDanglingSubmission(options: {
 				sequence: 0,
 				delta: 'Durable partial',
 			},
-		]);
+		);
+		await append(records);
 		return { conversationId };
 	}
 
@@ -768,6 +773,51 @@ describe('NodeAgentCoordinator', () => {
 			expect(await executionStore.submissions.getSubmission('dispatch-stream-recovery')).toMatchObject({
 				status: 'settled',
 			});
+		});
+
+		it('terminalizes an input-only assistant start before running the replacement attempt', async () => {
+			const dbPath = createTempDbPath();
+			await seedDanglingSubmission({
+				dbPath,
+				dispatchId: 'dispatch-input-only-start',
+				shape: 'ghost-start',
+				durability: { maxRetry: 2, timeoutAt: Date.now() + 60_000 },
+			});
+			let providerCalls = 0;
+			const provider = createFauxProvider();
+			provider.setResponses([
+				() => {
+					providerCalls += 1;
+					return fauxAssistantMessage('Recovered after interruption.');
+				},
+				() => {
+					providerCalls += 1;
+					return fauxAssistantMessage('Follow-up reply.');
+				},
+			]);
+			const { coordinator, executionStore } = await createFauxCoordinator(dbPath, provider);
+
+			await coordinator.reconcileSubmissions();
+			await coordinator.waitForIdle();
+
+			expect(providerCalls).toBe(1);
+			expect(
+				await executionStore.submissions.getSubmission('dispatch-input-only-start'),
+			).toMatchObject({ status: 'settled' });
+			let records = await readCanonicalRecords(dbPath);
+			expect(records.find((record) => record.id === 'record_recovery_entry_stream_partial_aborted'))
+				.toMatchObject({ type: 'assistant_message_completed', stopReason: 'aborted' });
+
+			await coordinator.admitDispatch(makeDispatchInput({ dispatchId: 'dispatch-after-recovery' }));
+			await coordinator.waitForIdle();
+
+			expect(providerCalls).toBe(2);
+			expect(await executionStore.submissions.getSubmission('dispatch-after-recovery')).toMatchObject({
+				status: 'settled',
+			});
+			records = await readCanonicalRecords(dbPath);
+			expect(records.some((record) => record.submissionId === 'dispatch-after-recovery')).toBe(true);
+			await coordinator.shutdown();
 		});
 
 		it('reuses a completed parallel tool outcome after a real process kill before graph materialization', async () => {


### PR DESCRIPTION
Addresses #477.

- clean up an old started assistant before a replacement attempt runs
- clear leftover in-progress bookkeeping when a submission settles
- cover poisoned replay, active-tail preservation, and end-to-end SQLite reconciliation

Tested with:

- `corepack pnpm --filter @flue/runtime build`
- `corepack pnpm --filter @flue/runtime check:types`
- `corepack pnpm --filter @flue/runtime test` (48 files, 786 passed, 1 skipped)

This is a reference implementation for #477 — happy for you to close it and reimplement differently; the issue carries the full analysis.