### PR TITLE
[RUN-5026] Add publish workflow for flue fork packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,50 @@
+name: Publish Flue fork packages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@argonavis-labs'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build runtime, SDK, React, and CLI
+        run: pnpm --filter @flue/runtime --filter @flue/sdk --filter @flue/react --filter @flue/cli run build
+
+      - name: Test runtime, SDK, React, and CLI
+        run: pnpm --filter @flue/runtime --filter @flue/sdk --filter @flue/react --filter @flue/cli run test
+
+      - name: Prepare publish artifacts
+        run: node scripts/prepare-publish.mjs
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/publish-fork.mjs

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,6 +19,7 @@
 	"types": "./dist/index.d.mts",
 	"files": [
 		"dist",
+		"docs",
 		"README.md"
 	],
 	"scripts": {

--- a/scripts/prepare-publish.mjs
+++ b/scripts/prepare-publish.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Prepares publish artifacts for the core packages (`@flue/cli`,
- * `@flue/runtime`, and `@flue/sdk`):
+ * Prepares publish artifacts for the fork packages (`@flue/cli`,
+ * `@flue/runtime`, `@flue/sdk`, and `@flue/react`):
  * - Copies `apps/docs/src/content/docs` into `<package>/docs` for agent consumption.
  * - Syncs the root README.md into each package.
  * - Embeds the `flue docs` catalog into the installable Flue skill.
@@ -9,7 +9,8 @@
  * Run from anywhere: `node scripts/prepare-publish.mjs`
  */
 import { execFile } from 'node:child_process';
-import { copyFile, cp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, cp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
@@ -22,7 +23,7 @@ const skillPath = join(repoRoot, 'skills/flue/SKILL.md');
 const catalogStart = '<!-- flue-docs-catalog:start -->';
 const catalogEnd = '<!-- flue-docs-catalog:end -->';
 
-const PUBLISH_ARTIFACT_PACKAGES = new Set(['@flue/cli', '@flue/runtime', '@flue/sdk']);
+const PUBLISH_ARTIFACT_PACKAGES = new Set(['@flue/cli', '@flue/runtime', '@flue/sdk', '@flue/react']);
 
 export function embedDocsCatalog(skillSource, catalog) {
 	const start = skillSource.indexOf(catalogStart);
@@ -62,7 +63,13 @@ export async function preparePublishArtifacts() {
 		}
 
 		await cp(docsSource, docsTarget, { recursive: true });
-		await copyFile(readmeSource, join(packageRoot, 'README.md'));
+
+		const packageReadme = join(packageRoot, 'README.md');
+		try {
+			await access(packageReadme, constants.F_OK);
+		} catch {
+			await copyFile(readmeSource, packageReadme);
+		}
 
 		console.error(`[flue] Prepared publish artifacts for ${manifest.name}`);
 	}

--- a/scripts/publish-fork.mjs
+++ b/scripts/publish-fork.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Publishes the four forked Flue packages to GitHub Packages under the
+ * @argonavis-labs scope.
+ *
+ * Run after `pnpm install`, `build`, `test`, and `prepare-publish`.
+ *
+ * The script rewrites each package's `name` to `@argonavis-labs/flue-*`,
+ * appends a fork prerelease suffix to the version, and rewrites internal
+ * `workspace:*` references to npm aliases that keep the original `@flue/*`
+ * import specifiers resolving inside consumers.
+ */
+import { execFile } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const registry = process.env.NPM_CONFIG_REGISTRY || 'https://npm.pkg.github.com';
+const forkScope = '@argonavis-labs';
+const forkPrefix = 'flue-';
+
+const packages = [
+	{ base: 'runtime', oldName: '@flue/runtime' },
+	{ base: 'sdk', oldName: '@flue/sdk' },
+	{ base: 'react', oldName: '@flue/react' },
+	{ base: 'cli', oldName: '@flue/cli' },
+];
+
+const oldNameToBase = new Map(packages.map((p) => [p.oldName, p.base]));
+const baseToNewName = new Map(packages.map((p) => [p.base, `${forkScope}/${forkPrefix}${p.base}`]));
+
+async function gitShortSha() {
+	const { stdout } = await execFileAsync('git', ['rev-parse', '--short=8', 'HEAD'], { cwd: repoRoot });
+	return stdout.trim();
+}
+
+function forkVersion(baseVersion, sha) {
+	// Strip any existing fork prerelease suffix so re-runs and manual bumps are
+	// deterministic and do not accumulate `...-argonavis.sha-argonavis.sha`.
+	const clean = baseVersion.replace(/-argonavis\.[a-f0-9]+$/i, '');
+	return `${clean}-argonavis.${sha}`;
+}
+
+async function isPublished(name, version) {
+	try {
+		await execFileAsync('npm', ['view', `${name}@${version}`, 'version', '--registry', registry], {
+			cwd: repoRoot,
+			env: { ...process.env, npm_config_registry: registry },
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function publishPackage(pkg, sha) {
+	const packageDir = join(repoRoot, 'packages', pkg.base);
+	const manifestPath = join(packageDir, 'package.json');
+	const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+
+	if (manifest.name !== pkg.oldName) {
+		throw new Error(
+			`Expected ${packageDir}/package.json name to be ${pkg.oldName}, got ${manifest.name}`,
+		);
+	}
+
+	const newName = baseToNewName.get(pkg.base);
+	const publishVersion = forkVersion(manifest.version, sha);
+
+	// Rewrite internal dependency references. Keep the original @flue/* keys so
+	// emitted dist files resolve inside consumers that install via npm aliases.
+	for (const depType of ['dependencies', 'peerDependencies']) {
+		const deps = manifest[depType];
+		if (!deps) continue;
+		for (const depName of Object.keys(deps)) {
+			const depBase = oldNameToBase.get(depName);
+			if (!depBase) continue;
+			if (depType === 'peerDependencies') {
+				// Preserve the original semver range; the fork prerelease version
+				// (e.g. 1.0.0-beta.9-argonavis.abc1234) satisfies the existing
+				// `>=1.0.0-beta.3 <1.0.0` range.
+				continue;
+			}
+			const targetName = baseToNewName.get(depBase);
+			deps[depName] = `npm:${targetName}@${publishVersion}`;
+		}
+	}
+
+	// Dev dependencies are not installed for consumers and may carry
+	// `workspace:*` references. Drop them to avoid leaking workspace state.
+	delete manifest.devDependencies;
+
+	manifest.name = newName;
+	manifest.version = publishVersion;
+	manifest.publishConfig = { registry, access: 'public' };
+	manifest.repository = {
+		type: 'git',
+		url: 'git+https://github.com/argonavis-labs/flue.git',
+		directory: `packages/${pkg.base}`,
+	};
+
+	await writeFile(manifestPath, `${JSON.stringify(manifest, null, '\t')}\n`);
+
+	if (await isPublished(newName, publishVersion)) {
+		console.error(`[publish-fork] ${newName}@${publishVersion} already published; skipping`);
+		return;
+	}
+
+	console.error(`[publish-fork] Publishing ${newName}@${publishVersion} ...`);
+	await execFileAsync('npm', ['publish', '--access', 'public', '--tag', 'latest'], {
+		cwd: packageDir,
+		env: { ...process.env, npm_config_registry: registry },
+	});
+	console.error(`[publish-fork] Published ${newName}@${publishVersion}`);
+}
+
+async function main() {
+	const sha = await gitShortSha();
+	console.error(`[publish-fork] Publishing fork build from ${sha}`);
+
+	for (const pkg of packages) {
+		// eslint-disable-next-line no-await-in-loop
+		await publishPackage(pkg, sha);
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow and a small publish script so the fork builds, tests, and publishes the four Flue packages (`runtime`, `sdk`, `react`, `cli`) to GitHub Packages under the `@argonavis-labs` scope on every merge to `main`.

- `.github/workflows/publish.yml` installs dependencies, builds and tests the four packages, prepares publish artifacts, and publishes to GitHub Packages.
- `scripts/publish-fork.mjs` rewrites package names to `@argonavis-labs/flue-*`, appends a fork prerelease suffix (`1.0.0-beta.9-argonavis.<sha>`), rewrites internal `workspace:*` references to npm aliases, and skips already-published versions.
- `scripts/prepare-publish.mjs` now includes `@flue/react` and avoids overwriting existing package READMEs.
- `packages/react/package.json` includes `docs` in `files` so React publishes docs like the other three packages.

## Test plan

- [ ] Workflow YAML passes `actionlint`.
- [ ] `node --check` passes for `scripts/publish-fork.mjs` and `scripts/prepare-publish.mjs`.
- [ ] Merge to `main` successfully publishes all four packages to `https://npm.pkg.github.com/@argonavis-labs/`.
- [ ] Runner Next can install the published version via npm aliases.

Generated with [Devin](https://devin.ai)