### PR TITLE
chore: prepare Flue 1.0.0-beta.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.0-beta.10 - 2026-07-16
 
 ### Breaking Changes
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/cli",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/dev-console/package.json
+++ b/packages/dev-console/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/dev-console",
-	"version": "1.0.0-beta.3",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/libsql/package.json
+++ b/packages/libsql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/libsql",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/mongodb/package.json
+++ b/packages/mongodb/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/mongodb",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/mysql/package.json
+++ b/packages/mysql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/mysql",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/postgres",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/react",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/redis",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/runtime",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/runtime/test/routing.test.ts
+++ b/packages/runtime/test/routing.test.ts
@@ -279,6 +279,57 @@ describe('flue()', () => {
 		});
 	});
 
+	it('admits an unwrapped signal DeliveredMessage when a direct agent POST receives one', async () => {
+		let delivered: unknown;
+		configureFlueRuntime(nodeRuntime({
+			target: 'node',
+			agents: [agentRecord('assistant', { route: async (_c, next) => next() })],
+			createAgentAdmission: (_agentName, _id) => async (message) => {
+				delivered = message;
+				return { submissionId: 'submission-1', offset: '-1' };
+			},
+			createWorkflowContext: createTestContext,
+			eventStreamStore: createTestEventStreamStore(),
+		}));
+		const app = new Hono();
+		app.route('/api', flue());
+
+		const response = await app.fetch(
+			new Request('http://localhost/api/agents/assistant/customer-123', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({
+					kind: 'signal',
+					type: 'slack.app_mention',
+					body: '<@UAPP> hello',
+					attributes: {
+						eventId: 'Ev1',
+						senderId: 'U1',
+						teamId: 'T1',
+						channelId: 'C1',
+						messageTs: '1.1',
+						threadTs: '1.1',
+					},
+				}),
+			}),
+		);
+
+		expect(response.status).toBe(202);
+		expect(delivered).toEqual({
+			kind: 'signal',
+			type: 'slack.app_mention',
+			body: '<@UAPP> hello',
+			attributes: {
+				eventId: 'Ev1',
+				senderId: 'U1',
+				teamId: 'T1',
+				channelId: 'C1',
+				messageTs: '1.1',
+				threadTs: '1.1',
+			},
+		});
+	});
+
 	it('rejects any wait query param with invalid_request when an agent POST is sent', async () => {
 		configureFlueRuntime(nodeRuntime({
 			target: 'node',

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@flue/sdk",
-	"version": "1.0.0-beta.9",
+	"version": "1.0.0-beta.10",
 	"type": "module",
 	"license": "Apache-2.0",
 	"homepage": "https://flueframework.com/",

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -57,6 +57,36 @@ describe('createFlueClient', () => {
 				attachments: [{ type: 'image', data: 'YWJj', mimeType: 'image/png' }],
 			});
 		});
+
+		it('sends an unwrapped signal when a structured event is delivered', async () => {
+			const seen: Request[] = [];
+			const client = createFlueClient({
+				baseUrl: 'https://flue.test',
+				fetch: async (input, init) => {
+					seen.push(new Request(input, init));
+					return Response.json({ streamUrl: 'https://flue.test/stream', offset: '-1' });
+				},
+			});
+			await client.agents.send('hello', 'inst-1', {
+				message: {
+					kind: 'signal',
+					type: 'slack.app_mention',
+					body: '<@UAPP> hello',
+					attributes: {
+						eventId: 'Ev1',
+						senderId: 'U1',
+						teamId: 'T1',
+						channelId: 'C1',
+						messageTs: '1.1',
+						threadTs: '1.1',
+					},
+				},
+			});
+
+			expect(await seen[0]?.text()).toBe(
+				'{"kind":"signal","type":"slack.app_mention","body":"<@UAPP> hello","attributes":{"eventId":"Ev1","senderId":"U1","teamId":"T1","channelId":"C1","messageTs":"1.1","threadTs":"1.1"}}',
+			);
+		});
 	});
 
 	describe('agents.history() attachment urls', () => {

--- a/skills/flue/SKILL.md
+++ b/skills/flue/SKILL.md
@@ -100,6 +100,7 @@ ecosystem/sandboxes/mirage -- Mirage
 ecosystem/sandboxes/modal -- Modal
 ecosystem/sandboxes/vercel -- Vercel Sandbox
 ecosystem/tooling/braintrust -- Braintrust
+ecosystem/tooling/jetty -- Jetty
 ecosystem/tooling/opentelemetry -- OpenTelemetry
 ecosystem/tooling/sentry -- Sentry
 ecosystem/tooling/vitest-evals -- Vitest Evals


### PR DESCRIPTION
## Summary

Prepares the current post-beta.9 Flue main for `1.0.0-beta.10`, including the unified `DeliveredMessage` direct/dispatch contract and reset-only persistence schema v5 required by OpenComputer managed Slack admission.

- bumps every publishable package changed since beta.9: runtime, SDK, CLI, React, dev console, and the five persistence adapters
- closes the durable public-wire coverage gap with exact unwrapped Slack-shaped signal tests at both SDK send and runtime direct admission boundaries
- promotes the existing unreleased changelog to beta.10
- synchronizes the tracked installable-skill catalog with the Jetty documentation already on main

No npm package is published and no tag is created by this PR.

## Verification

- full monorepo build + lint + typecheck: 103/103 tasks
- full monorepo tests: 96/96 tasks
- runtime direct/dispatch contract tests: 59 passing
- SDK client tests: 44 passing
- CLI tests: 93 Node tests + 83 Vitest tests passing
- `pnpm pack` for all ten release packages; packed workspace dependencies resolve to `1.0.0-beta.10`

This is the release branch for work 027; keep it draft until the coordinated OpenComputer package and starter pins are ready.