### PR TITLE
Client submissionId send binding (re-port of the dropped #12 half)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @steven4354 @zvsdev

--- a/.github/pr-review.md
+++ b/.github/pr-review.md
@@ -1,0 +1,73 @@
+# PR Review Playbook
+
+**Status:** instructions the Claude review gate runs on every non-draft PR
+
+The `Claude Code Review` workflow feeds this document to
+`anthropics/claude-code-action` as the review prompt. The reviewer is
+read-only: it reads the diff, leaves comments, and returns a structured
+verdict. It never pushes commits.
+
+A PR that edits this playbook or the review workflow fails the gate by
+design; a maintainer merges those changes through an explicit bypass.
+
+## Golden Rule
+
+Block real correctness, security, and data problems. Approve with notes for
+everything else. Match effort to risk: a docs PR must not cost what a runtime
+change costs.
+
+Other CI proves what an automated suite can prove; do not re-run builds or
+tests. Your job is the part a suite cannot do: read the diff like a skeptical
+senior engineer.
+
+## Step 1: Gather Evidence
+
+- `gh pr view` for title, description, comments, and review state.
+- `gh pr diff` for the full patch.
+- Read-only git (`git diff`, `git show`, `git log`) only when it answers a
+  specific question the diff raises.
+
+## Step 2: Choose A Mode
+
+| Mode | Signal | What to do |
+| --- | --- | --- |
+| Follow-up | `PR EVENT: synchronize` and an earlier Claude review exists | Review only the delta since the reviewed head plus unresolved prior findings. Verify claimed fixes. Do not replay the full review unless the new diff broadens the risk. |
+| Quick | Docs-only, typo, config tweak, or dead-code deletion | Skim for landmines, then approve. |
+| Standard | Everything else | Steps 3 through 5. |
+
+## Step 3: Review By Path
+
+One reviewer, whole diff, full context. Weight attention by area:
+
+| Path | Lens |
+| --- | --- |
+| `packages/runtime/**` | Correctness first: session and turn state machines, tool execution, durability and replay, error propagation. Downstream consumers patch against this package, so behavior changes have blast radius beyond this repo. |
+| `packages/sdk/**`, `packages/cli/**` | Contract stability: check consumers of any changed public API or build output. |
+| Channel and integration packages (`packages/slack/**`, `packages/discord/**`, `packages/telegram/**`, and siblings) | Security: webhook signature verification, credential handling, request forgery. |
+| `.github/workflows/**` | Security first — see the blocking checklist. |
+| `apps/docs/**`, `apps/www/**`, `examples/**`, `blueprints/**`, `demo/**` | Quick mode. |
+
+## Step 4: Blocking Checklist
+
+A match is `[BLOCKING]`, even when the diff imitates existing code.
+
+| Class | Rule |
+| --- | --- |
+| `pull_request_target` safety | `.github/workflows/pr-redirect.yml` runs with base-repo secrets. Any change that checks out, builds, or executes PR-head code inside a `pull_request_target` workflow is blocked on sight; the file's own header documents why. |
+| Secrets | A credential in committed code, workflow files, or docs is blocked on sight. |
+| Fork discipline | This repo is a fork of `withastro/flue`. Broad drive-by rewrites of upstream-owned files make future upstream syncs painful; block wholesale rewrites the PR does not justify, and prefer the minimal diff. |
+
+## Step 5: Comment And Return The Verdict
+
+- Classify every finding `[BLOCKING]` or `[NOTE]`. Blocking is reserved for
+  the checklist above and real correctness or security defects. Style and
+  taste are notes at most.
+- Use `mcp__github_inline_comment__create_inline_comment` when a line-level
+  comment helps. Every comment states what is wrong, why it matters, and what
+  to do.
+- Leave one top-level summary: mode, risk areas touched, and verdict.
+
+Return the structured verdict:
+
+- `approved: true` — clean, or notes only.
+- `approved: false, reason: "..."` — blocking findings need action.

--- a/.github/workflows/approve-contributor.yml
+++ b/.github/workflows/approve-contributor.yml
@@ -6,6 +6,8 @@ on:
   discussion_comment:
     types: [created]
 
+permissions: {}
+
 jobs:
   approve:
     runs-on: ubuntu-latest
@@ -14,7 +16,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Open contributor approval PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const path = '.github/APPROVED_CONTRIBUTORS';

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -24,10 +26,12 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Enforce workflow and playbook parity with default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
-          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
           git fetch --no-tags --depth=1 origin "$DEFAULT_BRANCH"
 
           for GUARDED in .github/workflows/claude-code-review.yml .github/pr-review.md; do
@@ -43,16 +47,23 @@ jobs:
 
       - name: Load review instructions
         id: instructions
+        env:
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_EVENT: ${{ github.event.action }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           DELIM="INSTRUCTIONS_$(openssl rand -hex 16)"
           {
             echo "content<<$DELIM"
-            echo "REPO: ${{ github.repository }}"
-            echo "PR NUMBER: ${{ github.event.pull_request.number }}"
-            echo "PR EVENT: ${{ github.event.action }}"
-            echo "BASE REF: ${{ github.event.pull_request.base.ref }}"
-            echo "BASE SHA: ${{ github.event.pull_request.base.sha }}"
-            echo "HEAD SHA: ${{ github.event.pull_request.head.sha }}"
+            echo "REPO: $REPOSITORY"
+            echo "PR NUMBER: $PR_NUMBER"
+            echo "PR EVENT: $PR_EVENT"
+            echo "BASE REF: $BASE_REF"
+            echo "BASE SHA: $BASE_SHA"
+            echo "HEAD SHA: $HEAD_SHA"
             echo ""
             cat .github/pr-review.md
             echo "$DELIM"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,96 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 1
+
+      - name: Enforce workflow and playbook parity with default branch
+        run: |
+          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
+          git fetch --no-tags --depth=1 origin "$DEFAULT_BRANCH"
+
+          for GUARDED in .github/workflows/claude-code-review.yml .github/pr-review.md; do
+            if ! git cat-file -e "origin/$DEFAULT_BRANCH:$GUARDED" 2>/dev/null; then
+              echo "::warning::$GUARDED does not exist on $DEFAULT_BRANCH yet; skipping its parity check during rollout."
+              continue
+            fi
+            if ! git diff --quiet "origin/$DEFAULT_BRANCH" -- "$GUARDED"; then
+              echo "::error::This PR modifies $GUARDED. Claude review is fail-closed for edits to its own workflow or playbook; request maintainer bypass for this PR."
+              exit 1
+            fi
+          done
+
+      - name: Load review instructions
+        id: instructions
+        run: |
+          DELIM="INSTRUCTIONS_$(openssl rand -hex 16)"
+          {
+            echo "content<<$DELIM"
+            echo "REPO: ${{ github.repository }}"
+            echo "PR NUMBER: ${{ github.event.pull_request.number }}"
+            echo "PR EVENT: ${{ github.event.action }}"
+            echo "BASE REF: ${{ github.event.pull_request.base.ref }}"
+            echo "BASE SHA: ${{ github.event.pull_request.base.sha }}"
+            echo "HEAD SHA: ${{ github.event.pull_request.head.sha }}"
+            echo ""
+            cat .github/pr-review.md
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@f87768c6d25f92ae6efa7175e223ef77d4cbf97f # v1.0.166
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "claude"
+          show_full_output: true
+          track_progress: true
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --model opus
+            --effort high
+            --allowedTools "Read,Glob,Grep,Bash(gh pr *),Bash(git fetch:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),mcp__github_inline_comment__create_inline_comment"
+            --json-schema '{"type":"object","properties":{"approved":{"type":"boolean"},"reason":{"type":"string"}},"required":["approved"]}'
+          prompt: ${{ steps.instructions.outputs.content }}
+
+      - name: Enforce verdict
+        env:
+          VERDICT: ${{ steps.claude-review.outputs.structured_output }}
+        run: |
+          if [ -z "$VERDICT" ]; then
+            echo "::error::Claude review returned no structured verdict."
+            exit 1
+          fi
+
+          if ! APPROVED=$(printenv VERDICT | jq -r '.approved'); then
+            echo "::error::Claude review verdict is not valid JSON."
+            exit 1
+          fi
+          REASON=$(printenv VERDICT | jq -r '.reason // "blocking issues found"' | tr '\n' ' ')
+
+          if [ "$APPROVED" != "true" ]; then
+            echo "::error::Claude review blocked: $REASON"
+            exit 1
+          fi

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -18,13 +20,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/package-ci.yml
+++ b/.github/workflows/package-ci.yml
@@ -1,0 +1,44 @@
+name: Flue Package CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Build and test fork packages
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build runtime, SDK, React, and CLI
+        run: pnpm turbo run build --filter=@flue/runtime --filter=@flue/sdk --filter=@flue/react --filter=@flue/cli
+
+      - name: Prepare publish artifacts
+        run: node scripts/prepare-publish.mjs
+
+      - name: Test runtime, SDK, React, and CLI
+        env:
+          NO_COLOR: 1
+        run: pnpm turbo run test --filter=@flue/runtime --filter=@flue/sdk --filter=@flue/react --filter=@flue/cli -- --testTimeout=30000

--- a/.github/workflows/pr-redirect.yml
+++ b/.github/workflows/pr-redirect.yml
@@ -20,6 +20,8 @@ on:
     # The agent removes the label on success so re-adding it re-runs.
     types: [opened, labeled]
 
+permissions: {}
+
 # Concurrency keyed by PR. Queued (not cancelled) so an in-flight write
 # can finish before the next run starts.
 concurrency:
@@ -40,7 +42,7 @@ jobs:
     steps:
       - name: Check approved contributors
         id: check
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const path = '.github/APPROVED_CONTRIBUTORS';
@@ -80,13 +82,15 @@ jobs:
 
     steps:
       - name: Checkout (base ref only — never the PR head)
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish Flue fork packages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Queue publish runs instead of cancelling: a cancelled run can leave a commit
+# with only some of the four packages published, and it is never retried
+# because the next run publishes under a different sha-suffixed version.
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@argonavis-labs'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build runtime, SDK, React, and CLI
+        run: pnpm turbo run build --filter=@flue/runtime --filter=@flue/sdk --filter=@flue/react --filter=@flue/cli
+
+      - name: Prepare publish artifacts
+        run: node scripts/prepare-publish.mjs
+
+      - name: Test runtime, SDK, React, and CLI
+        run: pnpm turbo run test --filter=@flue/runtime --filter=@flue/sdk --filter=@flue/react --filter=@flue/cli -- --testTimeout=30000
+
+      - name: Publish to GitHub Packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/publish-fork.mjs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,6 +45,11 @@ jobs:
         run: node scripts/prepare-publish.mjs
 
       - name: Test runtime, SDK, React, and CLI
+        env:
+          # GitHub Actions sets CI=1, which makes picocolors emit ANSI codes
+          # even without a TTY; the CLI tests assert on plain-text output
+          # (e.g. `changed workflows/smoke.mjs`) and fail on colored logs.
+          NO_COLOR: 1
         run: pnpm turbo run test --filter=@flue/runtime --filter=@flue/sdk --filter=@flue/react --filter=@flue/cli -- --testTimeout=30000
 
       - name: Publish to GitHub Packages

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions: {}
+
 # Queue publish runs instead of cancelling: a cancelled run can leave a commit
 # with only some of the four packages published, and it is never retried
 # because the next run publishes under a different sha-suffixed version.
@@ -22,13 +24,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup PNPM
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/tech-debt-merge-gate.yml
+++ b/.github/workflows/tech-debt-merge-gate.yml
@@ -28,7 +28,7 @@ jobs:
     # The job name is the check-run name branch protection matches on;
     # it must stay in sync with the required status check configured on
     # Flue's default branch.
-    name: Flue Cross-Repo Gate
+    name: Verify package changes are tracked in Runner Next tech-debt.md
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/tech-debt-merge-gate.yml
+++ b/.github/workflows/tech-debt-merge-gate.yml
@@ -19,6 +19,8 @@ on:
     # after the base is switched to main.
     types: [opened, synchronize, ready_for_review, reopened, labeled, edited]
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/tech-debt-merge-gate.yml
+++ b/.github/workflows/tech-debt-merge-gate.yml
@@ -1,0 +1,171 @@
+name: Flue Cross-Repo Gate
+
+# Block a Flue package-source PR until Runner Next records it in
+# docs/tech-debt.md. Docs-only and CI-only PRs pass. The
+# `tech-debt-recheck` label reruns the gate after the Runner Next entry
+# merges.
+#
+# Security: this workflow uses pull_request_target so it always runs the
+# version on Flue's default branch, not the version proposed by the PR it
+# is judging. It only reads the PR's changed-file list and, when package
+# files change, one markdown file from a private Runner Next repository.
+# It never checks out or executes the PR branch.
+
+on:
+  pull_request_target:
+    # `edited` catches a base-branch retarget: a PR opened against a branch
+    # that already holds the package change reads as docs-only, and without
+    # a rerun the stale green check would still satisfy branch protection
+    # after the base is switched to main.
+    types: [opened, synchronize, ready_for_review, reopened, labeled, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    # The job name is the check-run name branch protection matches on;
+    # it must stay in sync with the required status check configured on
+    # Flue's default branch.
+    name: Flue Cross-Repo Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Detect package changes
+        id: changed
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const packagePrefixes = [
+              'packages/runtime/',
+              'packages/sdk/',
+              'packages/react/',
+              'packages/cli/',
+            ];
+
+            const files = [];
+            let page = 1;
+            while (true) {
+              const { data } = await github.rest.pulls.listFiles({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                per_page: 100,
+                page,
+              });
+              files.push(...data);
+              if (data.length < 100) break;
+              page++;
+            }
+
+            // The list-files API silently caps at 3000 files, so a gated
+            // package change past the cap would never appear here. Judge
+            // only a complete list; otherwise fail closed.
+            const expectedCount = context.payload.pull_request.changed_files;
+            if (files.length !== expectedCount) {
+              core.setFailed(
+                `Changed-file listing is incomplete (got ${files.length}, ` +
+                `PR reports ${expectedCount}); failing closed rather than ` +
+                'judging a partial list.'
+              );
+              return;
+            }
+
+            const changedPackages = new Set();
+            for (const file of files) {
+              // A rename out of a gated package mutates that package, and
+              // only previous_filename still records the gated path.
+              const paths = [file.filename, file.previous_filename].filter(Boolean);
+              for (const prefix of packagePrefixes) {
+                if (paths.some((path) => path.startsWith(prefix))) {
+                  changedPackages.add(prefix);
+                }
+              }
+            }
+
+            const hasChanges = changedPackages.size > 0;
+            core.setOutput('hasPackageChanges', hasChanges ? 'true' : 'false');
+            core.notice(
+              hasChanges
+                ? `Package changes detected: ${[...changedPackages].join(', ')}`
+                : 'No package changes detected; gate passes without reading Runner Next.'
+            );
+
+      - name: Create Runner Next token
+        if: steps.changed.outputs.hasPackageChanges == 'true'
+        id: runner-next-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.FLUE_FORK_MANAGER_APP_ID }}
+          private-key: ${{ secrets.FLUE_FORK_MANAGER_PRIVATE_KEY }}
+          owner: argonavis-labs
+          repositories: runner-next
+          # The App itself may hold wider grants; the minted token never
+          # needs more than reading one file.
+          permission-contents: read
+
+      - name: Verify Runner Next entry
+        if: steps.changed.outputs.hasPackageChanges == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          # Authenticate this step's client as the Runner Next App; the
+          # injected `github` object is an octokit instance and exposes no
+          # way to construct a second client from a raw token.
+          github-token: ${{ steps.runner-next-token.outputs.token }}
+          script: |
+            const prNumber = context.issue.number;
+            const marker = `<!-- flue-pr: argonavis-labs/flue#${prNumber} -->`;
+            const link = `https://github.com/argonavis-labs/flue/pull/${prNumber}`;
+            const deletePrefix = '**Delete this entry when**';
+
+            let content;
+            try {
+              const { data: file } = await github.rest.repos.getContent({
+                owner: 'argonavis-labs',
+                repo: 'runner-next',
+                path: 'docs/tech-debt.md',
+                ref: 'main',
+              });
+
+              if (!('content' in file) || typeof file.content !== 'string') {
+                throw new Error('Unexpected response shape for docs/tech-debt.md');
+              }
+
+              content = Buffer.from(file.content, 'base64').toString('utf8');
+            } catch (error) {
+              core.error('Could not read Runner Next docs/tech-debt.md.');
+              throw error;
+            }
+
+            // Split on the boundary between bullet entries. Each Tech Debt
+            // Tracker entry starts with a "- [ ]" checkbox at the beginning
+            // of a line; tolerate "- [x]" so a checked-off entry still
+            // counts until it is deleted.
+            const entries = content
+              .split(/\n(?=- \[[ xX]\] )/)
+              .filter((entry) => /^- \[[ xX]\] /.test(entry.trim()));
+
+            const matching = entries.filter(
+              (entry) =>
+                entry.includes(marker) &&
+                entry.includes(link) &&
+                entry.includes(deletePrefix)
+            );
+
+            if (matching.length === 0) {
+              core.setFailed(
+                `No matching Runner Next entry found for this PR. ` +
+                `An entry in argonavis-labs/runner-next:docs/tech-debt.md must contain all three of:\n` +
+                `  ${marker}\n` +
+                `  ${link}\n` +
+                `  ${deletePrefix} ...`
+              );
+              return;
+            }
+
+            core.notice('Runner Next entry verified; gate passes.');

--- a/packages/cli/src/lib/build-plugin-cloudflare.ts
+++ b/packages/cli/src/lib/build-plugin-cloudflare.ts
@@ -1,6 +1,9 @@
 /** Cloudflare build plugin. Produces a Worker + DO entry point for workflow runs and agent interactions. */
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
+	createCloudflareDeploymentManifest,
+	findCloudflareWranglerConfigPath,
 	type FlueAdditions,
 	mergeFlueAdditions,
 	readUserWranglerConfig,
@@ -649,6 +652,28 @@ export default {
 		// `containers[].image` points to.
 
 		return { wranglerConfig: JSON.stringify(merged, null, 2) };
+	}
+
+	async additionalOutputs(ctx: BuildContext): Promise<Record<string, string>> {
+		const wranglerPath = findCloudflareWranglerConfigPath(ctx.output);
+		let config: Record<string, unknown>;
+		try {
+			config = JSON.parse(fs.readFileSync(wranglerPath, 'utf-8')) as Record<string, unknown>;
+		} catch (err) {
+			throw new Error(
+				`[flue] Failed to read generated Cloudflare wrangler output for deployment manifest: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+		// The manifest sits beside the artifacts it describes, so paths in it are
+		// relative to the output root rather than to whoever runs the deploy.
+		const artifactRoot = path.relative(ctx.output, path.dirname(wranglerPath)) || '.';
+		return {
+			'flue-cloudflare-deployment.v1.json': `${JSON.stringify(
+				createCloudflareDeploymentManifest(config, artifactRoot),
+				null,
+				2,
+			)}\n`,
+		};
 	}
 }
 

--- a/packages/cli/src/lib/cloudflare-wrangler-merge.ts
+++ b/packages/cli/src/lib/cloudflare-wrangler-merge.ts
@@ -302,3 +302,117 @@ export function mergeFlueAdditions(
 
 	return merged;
 }
+
+// ─── Deployment manifest ────────────────────────────────────────────────────
+
+/** Worker topology a deploy driver needs, read off the generated wrangler output. */
+export interface CloudflareDeploymentManifest {
+	v: 1;
+	worker: {
+		name: string;
+		artifactRoot: string;
+		main: string;
+		accountId?: string;
+		compatibilityDate: string;
+		compatibilityFlags: string[];
+		observability?: unknown;
+	};
+	vars: Record<string, unknown>;
+	durableObjects: Array<{ binding: string; className: string }>;
+	workerLoaders: Array<{ binding: string }>;
+}
+
+/**
+ * Project the generated wrangler config into a stable deployment manifest.
+ *
+ * A deploy driver should not have to re-derive the worker's name, entrypoint,
+ * compatibility, or Durable Object bindings from a config it did not author.
+ */
+export function createCloudflareDeploymentManifest(
+	config: Record<string, unknown>,
+	artifactRoot: string,
+): CloudflareDeploymentManifest {
+	const requireString = (value: unknown, name: string): string => {
+		if (typeof value !== 'string' || value.length === 0) {
+			throw new Error(`[flue] Generated Cloudflare deployment manifest is missing ${name}.`);
+		}
+		return value;
+	};
+
+	const durableObjects = config.durable_objects as { bindings?: unknown } | undefined;
+	const durableObjectBindings = Array.isArray(durableObjects?.bindings)
+		? (durableObjects.bindings as Array<Record<string, unknown>>)
+		: [];
+	const workerLoaders = Array.isArray(config.worker_loaders)
+		? (config.worker_loaders as Array<Record<string, unknown>>)
+		: [];
+
+	return {
+		v: 1,
+		worker: {
+			name: requireString(config.name, 'worker.name'),
+			artifactRoot: requireString(artifactRoot, 'worker.artifactRoot'),
+			main: requireString(config.main, 'worker.main'),
+			...(typeof config.account_id === 'string' ? { accountId: config.account_id } : {}),
+			compatibilityDate: requireString(config.compatibility_date, 'worker.compatibilityDate'),
+			compatibilityFlags: Array.isArray(config.compatibility_flags)
+				? config.compatibility_flags.filter((flag): flag is string => typeof flag === 'string')
+				: [],
+			...(typeof config.observability === 'object' && config.observability !== null
+				? { observability: config.observability }
+				: {}),
+		},
+		vars:
+			typeof config.vars === 'object' && config.vars !== null && !Array.isArray(config.vars)
+				? (config.vars as Record<string, unknown>)
+				: {},
+		durableObjects: durableObjectBindings.map((binding) => {
+			if (typeof binding?.name !== 'string' || typeof binding.class_name !== 'string') {
+				throw new Error(
+					'[flue] Generated Cloudflare deployment manifest found an invalid Durable Object binding.',
+				);
+			}
+			// A cross-script or cross-environment binding names a Worker this manifest
+			// does not describe, so a deploy driver could not honor it.
+			if (binding.script_name !== undefined || binding.environment !== undefined) {
+				throw new Error(
+					'[flue] Generated Cloudflare deployment manifest only supports local Durable Object bindings.',
+				);
+			}
+			return { binding: binding.name, className: binding.class_name };
+		}),
+		workerLoaders: workerLoaders.map((loader) => {
+			if (typeof loader?.binding !== 'string') {
+				throw new Error(
+					'[flue] Generated Cloudflare deployment manifest found an invalid WorkerLoader binding.',
+				);
+			}
+			return { binding: loader.binding };
+		}),
+	};
+}
+
+/** Locate the single wrangler.json the Cloudflare build generated under `output`. */
+export function findCloudflareWranglerConfigPath(output: string): string {
+	const directPath = path.join(output, 'wrangler.json');
+	if (fs.existsSync(directPath)) return directPath;
+
+	const matches: string[] = [];
+	const visit = (dir: string): void => {
+		for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+			const absolutePath = path.join(dir, entry.name);
+			if (entry.isDirectory()) visit(absolutePath);
+			else if (entry.isFile() && entry.name === 'wrangler.json') matches.push(absolutePath);
+		}
+	};
+	if (fs.existsSync(output)) visit(output);
+
+	// More than one means we cannot tell which Worker the manifest should describe.
+	const [match] = matches;
+	if (matches.length !== 1 || match === undefined) {
+		throw new Error(
+			`[flue] Expected exactly one generated Cloudflare wrangler output under ${output} before emitting the deployment manifest; found ${matches.length}.`,
+		);
+	}
+	return match;
+}

--- a/packages/cli/test/cloudflare-deployment-manifest.test.ts
+++ b/packages/cli/test/cloudflare-deployment-manifest.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { createCloudflareDeploymentManifest } from '../src/lib/cloudflare-wrangler-merge.ts';
+
+describe('createCloudflareDeploymentManifest()', () => {
+	it('projects a representative generated wrangler config into the v1 manifest shape', () => {
+		const manifest = createCloudflareDeploymentManifest(
+			{
+				name: 'fixture-worker',
+				main: 'index.js',
+				account_id: 'acct-123',
+				compatibility_date: '2026-04-01',
+				compatibility_flags: ['nodejs_compat'],
+				observability: { enabled: true },
+				vars: { MODE: 'production' },
+				durable_objects: {
+					bindings: [{ name: 'FLUE_ASSISTANT_AGENT', class_name: 'FlueAssistantAgent' }],
+				},
+				worker_loaders: [{ binding: 'SANDBOX_LOADER' }],
+			},
+			'dist/fixture-worker',
+		);
+
+		expect(manifest).toEqual({
+			v: 1,
+			worker: {
+				name: 'fixture-worker',
+				artifactRoot: 'dist/fixture-worker',
+				main: 'index.js',
+				accountId: 'acct-123',
+				compatibilityDate: '2026-04-01',
+				compatibilityFlags: ['nodejs_compat'],
+				observability: { enabled: true },
+			},
+			vars: { MODE: 'production' },
+			durableObjects: [{ binding: 'FLUE_ASSISTANT_AGENT', className: 'FlueAssistantAgent' }],
+			workerLoaders: [{ binding: 'SANDBOX_LOADER' }],
+		});
+	});
+
+	it('omits optional worker fields the generated config does not set', () => {
+		const manifest = createCloudflareDeploymentManifest(
+			{
+				name: 'fixture-worker',
+				main: 'index.js',
+				compatibility_date: '2026-04-01',
+			},
+			'dist/fixture-worker',
+		);
+
+		expect(manifest.worker).not.toHaveProperty('accountId');
+		expect(manifest.worker).not.toHaveProperty('observability');
+		expect(manifest.worker.compatibilityFlags).toEqual([]);
+		expect(manifest.vars).toEqual({});
+		expect(manifest.durableObjects).toEqual([]);
+		expect(manifest.workerLoaders).toEqual([]);
+	});
+
+	it('rejects a cross-script Durable Object binding a deploy driver could not honor', () => {
+		expect(() =>
+			createCloudflareDeploymentManifest(
+				{
+					name: 'fixture-worker',
+					main: 'index.js',
+					compatibility_date: '2026-04-01',
+					durable_objects: {
+						bindings: [
+							{
+								name: 'FLUE_ASSISTANT_AGENT',
+								class_name: 'FlueAssistantAgent',
+								script_name: 'other-worker',
+							},
+						],
+					},
+				},
+				'dist/fixture-worker',
+			),
+		).toThrow('only supports local Durable Object bindings');
+	});
+
+	it('rejects a generated config missing a required worker field', () => {
+		expect(() =>
+			createCloudflareDeploymentManifest(
+				{ main: 'index.js', compatibility_date: '2026-04-01' },
+				'dist/fixture-worker',
+			),
+		).toThrow('missing worker.name');
+	});
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -19,6 +19,7 @@
 	"types": "./dist/index.d.mts",
 	"files": [
 		"dist",
+		"docs",
 		"README.md"
 	],
 	"scripts": {

--- a/packages/react/src/agent-reducer.ts
+++ b/packages/react/src/agent-reducer.ts
@@ -1,6 +1,7 @@
 import type {
 	DeliveredAttachment,
 	FlueConversationMessage,
+	FlueConversationSettlement,
 	FlueConversationState,
 } from '@flue/sdk';
 
@@ -26,6 +27,13 @@ export interface AgentSnapshot {
 	 * retry affordance instead of having them silently disappear.
 	 */
 	failedSends: FailedSend[];
+	/**
+	 * Terminal outcome of every tracked submission in the conversation, as the
+	 * durable snapshot reports it. A turn submitted by a backend is never a local
+	 * send, so neither `error` nor `failedSends` can carry its failure — only
+	 * these settlements let a transcript render such a turn's outcome.
+	 */
+	settlements: FlueConversationSettlement[];
 }
 
 interface PendingSend {
@@ -56,6 +64,7 @@ export const emptyAgentState: AgentState = {
 	historyReady: false,
 	error: undefined,
 	failedSends: [],
+	settlements: [],
 	conversation: undefined,
 	pendingSends: [],
 	failedOptimistic: [],
@@ -217,6 +226,7 @@ function converge(state: AgentState): AgentState {
 	return {
 		...state,
 		messages,
+		settlements: conversation?.settlements ?? [],
 		pendingSends,
 		activeSubmissionIds,
 		status,

--- a/packages/react/src/agent-session.ts
+++ b/packages/react/src/agent-session.ts
@@ -14,6 +14,8 @@ import {
 
 export interface SendMessageOptions {
 	images?: DeliveredAttachment[];
+	/** Client-minted idempotency key, threaded to `agents.send` (see `AgentPromptOptions`). */
+	submissionId?: string;
 }
 
 export interface CreateFlueAgentStoreOptions {
@@ -86,6 +88,7 @@ export class AgentSession {
 					body: message,
 					...(options.images?.length ? { attachments: options.images } : {}),
 				},
+				...(options.submissionId === undefined ? {} : { submissionId: options.submissionId }),
 			});
 			this.dispatch({ type: 'local_send_admitted', localId, submissionId: receipt.submissionId });
 			if (this.observation?.getSnapshot().phase === 'absent') this.observation.refresh();

--- a/packages/react/src/agent-session.ts
+++ b/packages/react/src/agent-session.ts
@@ -16,6 +16,24 @@ export interface SendMessageOptions {
 	images?: DeliveredAttachment[];
 }
 
+export interface CreateFlueAgentStoreOptions {
+	client: FlueClient;
+	name: string;
+	id: string;
+	live?: ConversationLiveMode;
+}
+
+export type FlueAgentStoreSnapshot = AgentSnapshot;
+
+export interface FlueAgentStore {
+	getSnapshot(): FlueAgentStoreSnapshot;
+	refresh(): void;
+	sendMessage(message: string, options?: SendMessageOptions): Promise<void>;
+	start(): void;
+	stop(): void;
+	subscribe(listener: () => void): () => void;
+}
+
 export class AgentSession {
 	private state: AgentState = { ...emptyAgentState };
 	private snapshot: AgentSnapshot = publicSnapshot(this.state);
@@ -78,13 +96,17 @@ export class AgentSession {
 		}
 	}
 
-	dispose(): void {
+	stop(): void {
 		if (!this.active) return;
 		this.active = false;
 		this.unsubscribeObservation?.();
 		this.unsubscribeObservation = undefined;
 		this.observation?.close();
 		this.observation = undefined;
+	}
+
+	dispose(): void {
+		this.stop();
 	}
 
 	private applyObservation(): void {
@@ -109,6 +131,10 @@ export class AgentSession {
 		this.snapshot = publicSnapshot(this.state);
 		for (const listener of this.listeners) listener();
 	}
+}
+
+export function createFlueAgentStore(options: CreateFlueAgentStoreOptions): FlueAgentStore {
+	return new AgentSession(options.client, options.name, options.id, options.live ?? 'sse');
 }
 
 function publicSnapshot(state: AgentState): AgentSnapshot {

--- a/packages/react/src/agent-session.ts
+++ b/packages/react/src/agent-session.ts
@@ -118,6 +118,7 @@ function publicSnapshot(state: AgentState): AgentSnapshot {
 		historyReady: state.historyReady,
 		error: state.error,
 		failedSends: state.failedSends,
+		settlements: state.settlements,
 	};
 }
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,6 +1,12 @@
 export type { DeliveredAttachment, FlueEvent, PromptUsage } from '@flue/sdk';
 export type { AgentStatus, FailedSend } from './agent-reducer.ts';
-export type { SendMessageOptions } from './agent-session.ts';
+export {
+	createFlueAgentStore,
+	type CreateFlueAgentStoreOptions,
+	type FlueAgentStore,
+	type FlueAgentStoreSnapshot,
+	type SendMessageOptions,
+} from './agent-session.ts';
 export { FlueProvider, type FlueProviderProps, useFlueClient } from './provider.ts';
 export type {
 	FlueConversationMessage,

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,7 +2,11 @@ export type { DeliveredAttachment, FlueEvent, PromptUsage } from '@flue/sdk';
 export type { AgentStatus, FailedSend } from './agent-reducer.ts';
 export type { SendMessageOptions } from './agent-session.ts';
 export { FlueProvider, type FlueProviderProps, useFlueClient } from './provider.ts';
-export type { FlueConversationMessage, FlueConversationPart } from './types.ts';
+export type {
+	FlueConversationMessage,
+	FlueConversationPart,
+	FlueConversationSettlement,
+} from './types.ts';
 export { type UseFlueAgentOptions, type UseFlueAgentResult, useFlueAgent } from './use-agent.ts';
 export {
 	type UseFlueWorkflowOptions,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,8 @@
 // Flue's conversation message types are owned by @flue/sdk and consumed
 // directly here — React adds optimistic/local state but does not reinterpret
 // canonical part semantics.
-export type { FlueConversationMessage, FlueConversationPart } from '@flue/sdk';
+export type {
+	FlueConversationMessage,
+	FlueConversationPart,
+	FlueConversationSettlement,
+} from '@flue/sdk';

--- a/packages/react/src/use-agent.ts
+++ b/packages/react/src/use-agent.ts
@@ -10,6 +10,7 @@ const emptySnapshot: AgentSnapshot = {
 	historyReady: false,
 	error: undefined,
 	failedSends: emptyAgentState.failedSends,
+	settlements: emptyAgentState.settlements,
 };
 const emptySubscribe = () => () => {};
 

--- a/packages/react/test/agent-snapshot-settlements.test.ts
+++ b/packages/react/test/agent-snapshot-settlements.test.ts
@@ -1,0 +1,66 @@
+import type { FlueClient, FlueConversationSettlement } from '@flue/sdk';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { emptyAgentState, reduceAgentEvent } from '../src/agent-reducer.ts';
+import { AgentSession } from '../src/agent-session.ts';
+import { useFlueAgent } from '../src/use-agent.ts';
+import { conversation, createFakeObservation } from './fixtures/observation.ts';
+
+function client(overrides: Partial<FlueClient>): FlueClient {
+	return overrides as FlueClient;
+}
+
+describe('AgentSnapshot settlements', () => {
+	const failedSettlement: FlueConversationSettlement = {
+		submissionId: 'submission-backend',
+		outcome: 'failed',
+		error: { message: 'provider exploded' },
+	};
+
+	it('carries observed conversation settlements onto the reducer state', () => {
+		const state = reduceAgentEvent(emptyAgentState, {
+			type: 'local_observation',
+			conversation: conversation([], [failedSettlement]),
+			phase: 'live',
+			error: undefined,
+		});
+
+		// A backend-submitted turn is never a local send, so `error`/`failedSends`
+		// cannot carry its failure — the settlement row is its only permanent record.
+		expect(state.settlements).toEqual([failedSettlement]);
+		expect(state.failedSends).toEqual([]);
+		expect(state.error).toBeUndefined();
+	});
+
+	it('surfaces settlements on the session public snapshot', () => {
+		const observation = createFakeObservation();
+		const observe = vi.fn().mockReturnValue(observation);
+		const session = new AgentSession(
+			client({ agents: { observe } as unknown as FlueClient['agents'] }),
+			'agent',
+			'id',
+		);
+
+		session.start();
+		expect(session.getSnapshot().settlements).toEqual([]);
+
+		observation.emit({
+			conversation: conversation([], [failedSettlement]),
+			offset: 'offset-history',
+			phase: 'live',
+			error: undefined,
+		});
+
+		expect(session.getSnapshot().settlements).toEqual([failedSettlement]);
+		session.dispose();
+	});
+
+	it('defaults settlements to an empty array before any conversation is observed', () => {
+		expect(emptyAgentState.settlements).toEqual([]);
+
+		// A dormant hook (no id yet) serves the module-level empty snapshot; it
+		// must expose the same `settlements: []` default as the reducer state.
+		const { result } = renderHook(() => useFlueAgent({ name: 'agent', client: client({}) }));
+		expect(result.current.settlements).toEqual([]);
+	});
+});

--- a/packages/react/test/agent-store.test.ts
+++ b/packages/react/test/agent-store.test.ts
@@ -1,0 +1,73 @@
+import type { FlueClient } from '@flue/sdk';
+import { describe, expect, it, vi } from 'vitest';
+import { createFlueAgentStore } from '../src/index.ts';
+import { conversation, createFakeObservation } from './fixtures/observation.ts';
+
+describe('createFlueAgentStore()', () => {
+	it('retains its snapshot when observation is stopped and restarted', () => {
+		const firstObservation = createFakeObservation();
+		const secondObservation = createFakeObservation();
+		const observe = vi
+			.fn()
+			.mockReturnValueOnce(firstObservation)
+			.mockReturnValueOnce(secondObservation);
+		const store = createFlueAgentStore({
+			client: { agents: { observe } } as unknown as FlueClient,
+			name: 'agent',
+			id: 'conversation',
+		});
+
+		store.start();
+		firstObservation.emit({
+			conversation: conversation([
+				{
+					id: 'entry-user',
+					role: 'user',
+					purpose: 'user',
+					display: 'visible',
+					parts: [{ type: 'text', text: 'hello', state: 'done' }],
+				},
+			]),
+			offset: 'offset-1',
+			phase: 'live',
+			error: undefined,
+		});
+
+		store.stop();
+		expect(firstObservation.close).toHaveBeenCalledOnce();
+		expect(store.getSnapshot().messages.map((message) => message.id)).toEqual(['entry-user']);
+
+		store.start();
+		expect(observe).toHaveBeenCalledTimes(2);
+		expect(store.getSnapshot().messages.map((message) => message.id)).toEqual(['entry-user']);
+
+		secondObservation.emit({
+			conversation: conversation([
+				{
+					id: 'entry-user',
+					role: 'user',
+					purpose: 'user',
+					display: 'visible',
+					parts: [{ type: 'text', text: 'hello', state: 'done' }],
+				},
+				{
+					id: 'entry-assistant',
+					role: 'assistant',
+					purpose: 'assistant',
+					display: 'visible',
+					parts: [],
+					metadata: { model: { provider: 'test', id: 'model' } },
+				},
+			]),
+			offset: 'offset-2',
+			phase: 'live',
+			error: undefined,
+		});
+
+		expect(store.getSnapshot().messages.map((message) => message.id)).toEqual([
+			'entry-user',
+			'entry-assistant',
+		]);
+		store.stop();
+	});
+});

--- a/packages/react/test/agent-store.test.ts
+++ b/packages/react/test/agent-store.test.ts
@@ -70,4 +70,26 @@ describe('createFlueAgentStore()', () => {
 		]);
 		store.stop();
 	});
+
+	it('threads a client-supplied submissionId through sendMessage to agents.send', async () => {
+		const observation = createFakeObservation();
+		const send = vi.fn(async () => ({
+			streamUrl: 'https://flue.test/stream',
+			offset: '-1',
+			submissionId: 'send-1',
+		}));
+		const store = createFlueAgentStore({
+			client: { agents: { observe: () => observation, send } } as unknown as FlueClient,
+			name: 'agent',
+			id: 'conversation',
+		});
+
+		store.start();
+		await store.sendMessage('hello', { submissionId: 'send-1' });
+
+		expect(send).toHaveBeenCalledWith('agent', 'conversation', {
+			message: { kind: 'user', body: 'hello' },
+			submissionId: 'send-1',
+		});
+	});
 });

--- a/packages/runtime/src/agent-definition.ts
+++ b/packages/runtime/src/agent-definition.ts
@@ -36,6 +36,7 @@ const AgentProfileSchema = v.strictObject(
 		promptFrame: v.optional(v.picklist(['full', 'none'])),
 		compaction: v.optional(v.union([v.literal(false), v.looseObject({})])),
 		durability: v.optional(v.looseObject({})),
+		imageMemory: v.optional(v.looseObject({})),
 	},
 	(issue) =>
 		issue.expected === 'never'
@@ -123,6 +124,7 @@ export function resolveAgentProfile(options: AgentRuntimeConfig | undefined): Ag
 		promptFrame: hasOwn(options, 'promptFrame') ? options?.promptFrame : profile?.promptFrame,
 		compaction: hasOwn(options, 'compaction') ? options?.compaction : profile?.compaction,
 		durability: hasOwn(options, 'durability') ? options?.durability : profile?.durability,
+		imageMemory: hasOwn(options, 'imageMemory') ? options?.imageMemory : profile?.imageMemory,
 	};
 }
 
@@ -192,6 +194,7 @@ function assertAgentProfile(
 	assertThinkingLevel(definition.thinkingLevel, label);
 	assertCompaction(definition.compaction, label);
 	assertDurability(definition.durability, label);
+	assertImageMemory(definition.imageMemory, label);
 	assertTools(definition.tools, label);
 	assertActions(definition.actions, label);
 	assertSkills(definition.skills, label);
@@ -238,6 +241,16 @@ function assertDurability(definition: AgentProfile['durability'], label: string)
 	}
 	assertPositiveInteger(definition.maxAttempts, `${label} durability.maxAttempts`);
 	assertPositiveInteger(definition.timeoutMs, `${label} durability.timeoutMs`);
+}
+
+function assertImageMemory(definition: AgentProfile['imageMemory'], label: string): void {
+	if (definition === undefined) return;
+	for (const key of Object.keys(definition)) {
+		if (key !== 'maxImages') {
+			throw new Error(`[flue] ${label} imageMemory received unknown field "${key}".`);
+		}
+	}
+	assertPositiveInteger(definition.maxImages, `${label} imageMemory.maxImages`);
 }
 
 function assertPositiveInteger(value: number | undefined, label: string): void {

--- a/packages/runtime/src/agent-definition.ts
+++ b/packages/runtime/src/agent-definition.ts
@@ -33,6 +33,7 @@ const AgentProfileSchema = v.strictObject(
 		actions: v.optional(v.array(v.unknown())),
 		subagents: v.optional(v.array(v.unknown())),
 		thinkingLevel: v.optional(v.string()),
+		promptFrame: v.optional(v.picklist(['full', 'none'])),
 		compaction: v.optional(v.union([v.literal(false), v.looseObject({})])),
 		durability: v.optional(v.looseObject({})),
 	},
@@ -119,6 +120,7 @@ export function resolveAgentProfile(options: AgentRuntimeConfig | undefined): Ag
 		thinkingLevel: hasOwn(options, 'thinkingLevel')
 			? options?.thinkingLevel
 			: profile?.thinkingLevel,
+		promptFrame: hasOwn(options, 'promptFrame') ? options?.promptFrame : profile?.promptFrame,
 		compaction: hasOwn(options, 'compaction') ? options?.compaction : profile?.compaction,
 		durability: hasOwn(options, 'durability') ? options?.durability : profile?.durability,
 	};

--- a/packages/runtime/src/client.ts
+++ b/packages/runtime/src/client.ts
@@ -289,6 +289,7 @@ export async function initializeRootHarness(
 		thinkingLevel: definition.thinkingLevel ?? config.agentConfig.thinkingLevel,
 		compaction: definition.compaction ?? config.agentConfig.compaction,
 		durability: definition.durability,
+		imageMemory: definition.imageMemory ?? config.agentConfig.imageMemory,
 	};
 	if (!config.conversationWriter || !config.attachmentStore) {
 		throw new Error('[flue] Canonical conversation runtime is not configured.');

--- a/packages/runtime/src/client.ts
+++ b/packages/runtime/src/client.ts
@@ -270,6 +270,7 @@ export async function initializeRootHarness(
 		env,
 		definition.instructions,
 		definition.skills,
+		definition.promptFrame,
 	);
 	const agentConfig: AgentConfig = {
 		...config.agentConfig,
@@ -277,6 +278,7 @@ export async function initializeRootHarness(
 		instructions: definition.instructions,
 		definitionSkills: definition.skills,
 		skills: localContext.skills,
+		promptFrame: definition.promptFrame,
 		actions: definition.actions,
 		subagents: Object.fromEntries(
 			(definition.subagents ?? [])

--- a/packages/runtime/src/cloudflare/agent-coordinator.ts
+++ b/packages/runtime/src/cloudflare/agent-coordinator.ts
@@ -1,3 +1,4 @@
+import { SUBMISSION_HARNESS_NAME, SUBMISSION_SESSION_NAME } from '../adapter-helpers.ts';
 import type {
 	AgentExecutionStore,
 	AgentSubmission,
@@ -5,7 +6,9 @@ import type {
 } from '../agent-execution-store.ts';
 import type { FlueContextInternal } from '../client.ts';
 import { ConversationRecordWriter } from '../conversation-writer.ts';
+import { SubmissionAbortedError } from '../errors.ts';
 import type { FlueTraceCarrier } from '../execution-interceptor.ts';
+import { createConversationIdentity } from '../harness.ts';
 import {
 	agentSubmissionDispatchId,
 	type createAgentSubmissionSessionHandler,
@@ -16,9 +19,6 @@ import {
 	reconcileInterruptedSubmission,
 	submissionSyntheticRequest,
 } from '../runtime/agent-submissions.ts';
-import { SUBMISSION_HARNESS_NAME, SUBMISSION_SESSION_NAME } from '../adapter-helpers.ts';
-import { createSessionStorageKey } from '../session-identity.ts';
-import { SubmissionAbortedError } from '../errors.ts';
 import type { AttachmentStore } from '../runtime/attachment-store.ts';
 import type { ConversationStreamStore } from '../runtime/conversation-stream-store.ts';
 import type { AgentInteractionStart } from '../runtime/dev-lifecycle-logger.ts';
@@ -29,11 +29,13 @@ import {
 	handleAgentConversationHead,
 	handleAgentConversationRead,
 } from '../runtime/handle-conversation-routes.ts';
+import { createSessionStorageKey } from '../session-identity.ts';
 import type { DeliveredMessage } from '../types.ts';
 import {
 	createSqlAgentExecutionStore,
 	createSqlConversationStores,
 } from './agent-execution-store.ts';
+import { type AgentConversationSignalInput, cloudflareAgentCoordinators } from './app-signals.ts';
 
 export const CLOUDFLARE_AGENT_INTERNAL_DISPATCH_PATH = '/__flue/internal/dispatch';
 
@@ -147,15 +149,16 @@ export function createCloudflareAgentRuntime(
 			};
 		},
 		attach(instance, prepared) {
-			coordinators.set(
+			const coordinator = new CloudflareAgentCoordinator(
 				instance,
-				new CloudflareAgentCoordinator(
-					instance,
-					prepared,
-					options,
-					activeAttempts,
-				),
+				prepared,
+				options,
+				activeAttempts,
 			);
+			coordinators.set(instance, coordinator);
+			// Also reachable from the DO instance alone, so an application can append
+			// an out-of-turn conversation signal without owning a turn.
+			cloudflareAgentCoordinators.set(instance, coordinator);
 		},
 		onStart(instance, inherited) {
 			return getCoordinator(instance).onStart(inherited);
@@ -172,7 +175,7 @@ export function createCloudflareAgentRuntime(
 	};
 }
 
-class CloudflareAgentCoordinator {
+export class CloudflareAgentCoordinator {
 	constructor(
 		private readonly instance: CloudflareAgentInstance,
 		private readonly prepared: CloudflareAgentPreparedCoordinator,
@@ -306,6 +309,48 @@ class CloudflareAgentCoordinator {
 
 	private runWithInstanceContext<T>(callback: () => T): T {
 		return this.options.runWithInstanceContext(this.instance, this.agentName, callback);
+	}
+
+	/** See {@link appendAgentConversationSignal}: out-of-turn canonical signal append. */
+	async appendConversationSignal(signal: AgentConversationSignalInput): Promise<void> {
+		const writer = await this.ensureConversationWriter();
+		let conversation = await writer.findConversation(SUBMISSION_HARNESS_NAME, SUBMISSION_SESSION_NAME);
+		if (!conversation) {
+			// A signal may precede the very first submission, so the root conversation
+			// may not exist yet. Create it the same way the root session path does.
+			const identity = createConversationIdentity();
+			await writer.ensureConversation({
+				kind: 'root',
+				conversationId: identity.conversationId,
+				harness: SUBMISSION_HARNESS_NAME,
+				session: SUBMISSION_SESSION_NAME,
+				affinityKey: identity.affinityKey,
+				createdAt: identity.createdAt,
+			});
+			conversation = await writer.findConversation(SUBMISSION_HARNESS_NAME, SUBMISSION_SESSION_NAME);
+			if (!conversation) {
+				throw new Error('[flue] The agent instance has no root conversation to signal.');
+			}
+		}
+		const parentId = await writer.getConversationLeaf(conversation.conversationId);
+		const unique = crypto.randomUUID();
+		await writer.append([
+			{
+				v: 1,
+				id: `record_app_signal_${unique}`,
+				type: 'signal',
+				conversationId: conversation.conversationId,
+				harness: conversation.harness,
+				session: conversation.session,
+				timestamp: new Date().toISOString(),
+				messageId: `entry_app_signal_${unique}`,
+				parentId,
+				signalType: signal.type,
+				...(signal.tagName ? { tagName: signal.tagName } : {}),
+				content: signal.body,
+				...(signal.attributes ? { attributes: signal.attributes } : {}),
+			},
+		]);
 	}
 
 	private async ensureConversationWriter(): Promise<ConversationRecordWriter> {

--- a/packages/runtime/src/cloudflare/agent-coordinator.ts
+++ b/packages/runtime/src/cloudflare/agent-coordinator.ts
@@ -272,8 +272,8 @@ class CloudflareAgentCoordinator {
 			request,
 			id: this.instance.name,
 			agentName: this.agentName,
-			admitAttachedSubmission: (message, traceCarrier) =>
-				this.admitAttachedSubmission(message, traceCarrier),
+			admitAttachedSubmission: (message, submissionId, traceCarrier) =>
+				this.admitAttachedSubmission(message, submissionId, traceCarrier),
 		});
 	}
 
@@ -699,9 +699,11 @@ class CloudflareAgentCoordinator {
 
 	private async admitAttachedSubmission(
 		message: DeliveredMessage,
+		submissionId?: string,
 		traceCarrier?: FlueTraceCarrier,
 	) {
 		const input = createDirectAgentSubmissionInput({
+			submissionId,
 			agent: this.agentName,
 			id: this.instance.name,
 			message,

--- a/packages/runtime/src/cloudflare/app-signals.ts
+++ b/packages/runtime/src/cloudflare/app-signals.ts
@@ -1,0 +1,48 @@
+/**
+ * Out-of-turn conversation signals appended by the embedding application.
+ *
+ * A signal is machine-originated context the model must see but the user never
+ * typed — a compaction summary, or an application-authored note about something
+ * that happened outside the conversation. flue records it canonically as a
+ * `signal` record, and the next submission's model context renders it as a
+ * synthetic user message (`<tagName type="...">content</tagName>`).
+ *
+ * The application needs to append one without owning a turn, so this exposes the
+ * coordinator attached to the agent's Durable Object instance.
+ */
+import type { DeliveredMessage } from '../types.ts';
+import type { CloudflareAgentCoordinator } from './agent-coordinator.ts';
+
+/** An out-of-turn conversation signal appended by the embedding application. */
+export type AgentConversationSignalInput = Extract<DeliveredMessage, { kind: 'signal' }>;
+
+/**
+ * Attached by `createCloudflareAgentRuntime` as each agent instance is bound, so
+ * an application holding only the Durable Object instance can reach its
+ * coordinator.
+ */
+export const cloudflareAgentCoordinators = new WeakMap<
+	object,
+	CloudflareAgentCoordinator
+>();
+
+/**
+ * Append a canonical `signal` record to the agent instance's root conversation,
+ * outside any turn. Pass the Durable Object instance the generated agent runtime
+ * attached to.
+ *
+ * Creates the root conversation when none exists yet, mirroring the root session
+ * path, so a signal may precede the very first submission. Throws while an
+ * assistant turn is in progress — the canonical reducer only accepts linear,
+ * out-of-turn appends.
+ */
+export async function appendAgentConversationSignal(
+	instance: object,
+	signal: AgentConversationSignalInput,
+): Promise<void> {
+	const coordinator = cloudflareAgentCoordinators.get(instance);
+	if (!coordinator) {
+		throw new Error('[flue] Cloudflare agent coordinator is not attached to this instance.');
+	}
+	return coordinator.appendConversationSignal(signal);
+}

--- a/packages/runtime/src/context.ts
+++ b/packages/runtime/src/context.ts
@@ -3,7 +3,7 @@
  * working directory. Used at runtime by the session initialisation path.
  */
 import { parseSkillMarkdown } from './skill-frontmatter.ts';
-import type { SessionEnv, Skill } from './types.ts';
+import type { PromptFrame, SessionEnv, Skill } from './types.ts';
 
 export interface WorkspaceSkill {
 	readonly __flueWorkspaceSkill: true;
@@ -180,16 +180,29 @@ function composeSystemPrompt(
 	return parts.join('\n');
 }
 
-/** Discover AGENTS.md, local skills, and directory listing from the session's cwd. */
+/**
+ * Discover AGENTS.md, local skills, and directory listing from the session's cwd.
+ *
+ * Under `promptFrame: 'none'` the framework contributes nothing to the system
+ * prompt — no headless preamble, AGENTS.md, skills catalog, date, cwd, or
+ * directory listing. The profile's instructions are the entire prompt and the
+ * application owns every byte of it, including advertising skills. Skills are
+ * still discovered and registered so `activate_skill` keeps working.
+ */
 export async function discoverSessionContext(
 	env: SessionEnv,
 	instructions?: string,
 	definitionSkills: readonly Skill[] = [],
+	promptFrame: PromptFrame = 'full',
 ): Promise<{ systemPrompt: string; skills: Record<string, Skill> }> {
 	const cwd = env.cwd;
 
 	const agentsMd = await readAgentsMd(env, cwd);
 	const skills = mergeSkillCatalog(definitionSkills, await discoverLocalSkills(env, cwd));
+
+	if (promptFrame === 'none') {
+		return { systemPrompt: instructions ?? '', skills };
+	}
 
 	let directoryListing: string[] | undefined;
 	try {

--- a/packages/runtime/src/conversation-projections.ts
+++ b/packages/runtime/src/conversation-projections.ts
@@ -144,6 +144,57 @@ export interface ConversationUiSnapshot {
 	conversationId: string;
 	streamOffset: string;
 	messages: ConversationUiMessage[];
+	/**
+	 * Present when older history exists before this window (RUN-5220). Fetch
+	 * the next older page with `beforeEntry` set to this entry id; absent when
+	 * the window reaches the conversation's beginning.
+	 */
+	truncatedBefore?: string;
+}
+
+/** Window over the active conversation path for a UI projection (RUN-5220). */
+export interface ConversationUiWindow {
+	/** Maximum path entries projected; the newest `entryLimit` are kept. */
+	entryLimit?: number;
+	/** Project only entries strictly before this entry id (older-page cursor). */
+	beforeEntry?: string;
+}
+
+/**
+ * Cut the active path to the requested window. The start boundary is
+ * group-aware: a tool-result run is never split from the assistant message it
+ * folds into, so the window start walks back over leading tool-result entries
+ * (the older page then ends before that assistant — no duplication, because
+ * `truncatedBefore` is the post-extension first entry).
+ */
+function windowActivePath(
+	path: ReducedEntry[],
+	window: ConversationUiWindow,
+): { entries: ReducedEntry[]; truncatedBefore?: string; isHead: boolean } {
+	let end = path.length;
+	if (window.beforeEntry !== undefined) {
+		const boundary = path.findIndex((entry) => entry.id === window.beforeEntry);
+		if (boundary === -1) return { entries: [], isHead: false };
+		end = boundary;
+	}
+	const limit = window.entryLimit !== undefined && window.entryLimit > 0 ? window.entryLimit : end;
+	let start = Math.max(0, end - limit);
+	while (
+		start > 0 &&
+		start < end &&
+		(() => {
+			const entry = path[start];
+			return entry?.type === 'message' && entry.message.role === 'toolResult';
+		})()
+	) {
+		start--;
+	}
+	const entries = path.slice(start, end);
+	return {
+		entries,
+		...(start > 0 && entries.length > 0 ? { truncatedBefore: entries[0]?.id } : {}),
+		isHead: window.beforeEntry === undefined,
+	};
 }
 
 export type CanonicalSubmissionState =
@@ -174,10 +225,12 @@ export function classifyConversationSubmission(
 export function projectConversationUi(
 	conversation: ReducedConversationState,
 	streamOffset: string,
+	window: ConversationUiWindow = {},
 ): ConversationUiSnapshot {
 	const messages: ConversationUiMessage[] = [];
 	const byId = new Map<string, ConversationUiMessage>();
-	for (const entry of getActiveConversationPath(conversation)) {
+	const windowed = windowActivePath(getActiveConversationPath(conversation), window);
+	for (const entry of windowed.entries) {
 		if (entry.type !== 'message') continue;
 		const projected = projectCompletedMessage(entry);
 		if (projected) {
@@ -201,11 +254,20 @@ export function projectConversationUi(
 			break;
 		}
 	}
-	for (const inProgress of conversation.inProgressMessages.values()) {
-		const projected = projectInProgressMessage(inProgress);
-		if (projected && !byId.has(projected.id)) messages.push(projected);
+	// In-progress messages ride only the head window: an older page is settled
+	// history and must not grow a live tail.
+	if (windowed.isHead) {
+		for (const inProgress of conversation.inProgressMessages.values()) {
+			const projected = projectInProgressMessage(inProgress);
+			if (projected && !byId.has(projected.id)) messages.push(projected);
+		}
 	}
-	return { conversationId: conversation.conversationId, streamOffset, messages };
+	return {
+		conversationId: conversation.conversationId,
+		streamOffset,
+		messages,
+		...(windowed.truncatedBefore !== undefined ? { truncatedBefore: windowed.truncatedBefore } : {}),
+	};
 }
 
 export function getActiveConversationPathSince(

--- a/packages/runtime/src/conversation-public.ts
+++ b/packages/runtime/src/conversation-public.ts
@@ -2,6 +2,7 @@ import {
 	classifySignal,
 	type ConversationUiMessage,
 	type ConversationUiSnapshot,
+	type ConversationUiWindow,
 	projectConversationUi,
 } from './conversation-projections.ts';
 import type {
@@ -28,6 +29,8 @@ export interface AgentConversationSnapshot {
 	offset: string;
 	messages: ConversationUiMessage[];
 	settlements: AgentConversationSettlement[];
+	/** Present when older history exists before this window (RUN-5220). */
+	truncatedBefore?: string;
 }
 
 /**
@@ -113,16 +116,22 @@ function selectRootConversation(state: ReducedInstanceState) {
 
 export function projectAgentConversationSnapshot(
 	state: ReducedInstanceState,
+	window: ConversationUiWindow = {},
 ): AgentConversationSnapshot | undefined {
 	const conversation = selectRootConversation(state);
 	if (!conversation) return undefined;
-	const ui: ConversationUiSnapshot = projectConversationUi(conversation, state.recordsThroughOffset);
+	const ui: ConversationUiSnapshot = projectConversationUi(
+		conversation,
+		state.recordsThroughOffset,
+		window,
+	);
 	return {
 		v: 1,
 		conversationId: conversation.conversationId,
 		offset: ui.streamOffset,
 		messages: ui.messages,
 		settlements: projectSettlements(state, conversation.conversationId),
+		...(ui.truncatedBefore !== undefined ? { truncatedBefore: ui.truncatedBefore } : {}),
 	};
 }
 

--- a/packages/runtime/src/conversation-public.ts
+++ b/packages/runtime/src/conversation-public.ts
@@ -8,7 +8,7 @@ import type {
 	ConversationRecord,
 	SubmissionSettledRecord,
 } from './conversation-records.ts';
-import type { ReducedInstanceState } from './conversation-reducer.ts';
+import { type ReducedInstanceState, toolResultEntryId } from './conversation-reducer.ts';
 import { toolResultOutput, toolResultText } from './message-rendering.ts';
 import type { PromptUsage } from './types.ts';
 
@@ -151,7 +151,7 @@ export function projectAgentConversationBatch(options: {
 	}
 
 	return withPositions(
-		relevant.flatMap((record) => encodeRecord(record, conversationId, options.state)),
+		relevant.flatMap((record) => encodeRecord(record, conversationId, options.state, relevant)),
 		options.batchOrdinal,
 	);
 }
@@ -177,6 +177,7 @@ function encodeRecord(
 	record: ConversationRecord,
 	conversationId: string,
 	state: ReducedInstanceState,
+	batchRecords: readonly ConversationRecord[],
 ): ConversationStreamChunkBody[] {
 	switch (record.type) {
 		case 'user_message':
@@ -265,8 +266,8 @@ function encodeRecord(
 				},
 			];
 		case 'tool_results_committed':
-			return record.outcomeIds.flatMap((outcomeId) =>
-				encodeToolOutcome(outcomeId, conversationId, record, state),
+			return record.outcomeIds.flatMap((outcomeId, index) =>
+				encodeToolOutcome(outcomeId, index, conversationId, record, state, batchRecords),
 			);
 		case 'submission_settled':
 			return record.submissionId
@@ -285,30 +286,81 @@ function encodeRecord(
 	}
 }
 
+/**
+ * Projects the tool-output chunks for one committed outcome. The outcome
+ * record body is no longer resident in the reduced state (RUN-5210), so it is
+ * resolved from the batch being projected — outcomes and their commit are
+ * written together — and, for a cross-batch commit, from the materialized
+ * tool-result entry. An entry whose content was evicted by compaction projects
+ * its placeholder text, matching what every other post-compaction projection
+ * of that history renders.
+ */
 function encodeToolOutcome(
 	outcomeId: string,
+	outcomeIndex: number,
 	conversationId: string,
 	commit: Extract<ConversationRecord, { type: 'tool_results_committed' }>,
 	state: ReducedInstanceState,
+	batchRecords: readonly ConversationRecord[],
 ): ConversationStreamChunkBody[] {
-	const outcome = state.recordsById.get(outcomeId);
-	if (
-		outcome?.type !== 'tool_outcome' ||
-		outcome.conversationId !== commit.conversationId ||
-		outcome.harness !== commit.harness ||
-		outcome.session !== commit.session
-	) {
-		return [];
+	const outcome = batchRecords.find(
+		(record): record is Extract<ConversationRecord, { type: 'tool_outcome' }> =>
+			record.id === outcomeId && record.type === 'tool_outcome',
+	);
+	if (outcome) {
+		if (
+			outcome.conversationId !== commit.conversationId ||
+			outcome.harness !== commit.harness ||
+			outcome.session !== commit.session
+		) {
+			return [];
+		}
+		return outcome.isError
+			? [{ type: 'tool-output-error', conversationId, toolCallId: outcome.toolCallId, errorText: toolResultText(outcome.content), ...(outcome.durationMs !== undefined ? { durationMs: outcome.durationMs } : {}) }]
+			: [
+					{
+						type: 'tool-output',
+						conversationId,
+						toolCallId: outcome.toolCallId,
+						output: outcome.output !== undefined ? outcome.output : toolResultOutput(outcome.content),
+						...(outcome.durationMs !== undefined ? { durationMs: outcome.durationMs } : {}),
+					},
+				];
 	}
-	return outcome.isError
-		? [{ type: 'tool-output-error', conversationId, toolCallId: outcome.toolCallId, errorText: toolResultText(outcome.content), ...(outcome.durationMs !== undefined ? { durationMs: outcome.durationMs } : {}) }]
+	// Cross-batch commit: recover the projection from the materialized entry.
+	// `outcomeIds` are in assistant tool-call order (validated at reduction), so
+	// the call at the same index names the tool-result entry.
+	const conversation = state.conversations.get(commit.conversationId);
+	const assistant = conversation?.entries.get(commit.assistantMessageId);
+	if (assistant?.type !== 'message') return [];
+	const assistantContent = (assistant.message as { content?: unknown }).content;
+	const calls = (Array.isArray(assistantContent) ? assistantContent : []).filter(
+		(block): block is { type: 'toolCall'; id: string } =>
+			typeof block === 'object' && block !== null && (block as { type?: unknown }).type === 'toolCall',
+	);
+	const call = calls[outcomeIndex];
+	if (!call) return [];
+	const entry = conversation?.entries.get(toolResultEntryId(commit.assistantMessageId, call.id));
+	if (entry?.type !== 'message') return [];
+	const result = entry.message as {
+		isError?: boolean;
+		content?: unknown;
+	};
+	const text = Array.isArray(result.content)
+		? result.content
+				.map((block) => (typeof (block as { text?: unknown }).text === 'string' ? (block as { text: string }).text : ''))
+				.filter((piece) => piece !== '')
+				.join('\n')
+		: '';
+	return result.isError
+		? [{ type: 'tool-output-error', conversationId, toolCallId: call.id, errorText: text, ...(entry.toolDurationMs !== undefined ? { durationMs: entry.toolDurationMs } : {}) }]
 		: [
 				{
 					type: 'tool-output',
 					conversationId,
-					toolCallId: outcome.toolCallId,
-					output: outcome.output !== undefined ? outcome.output : toolResultOutput(outcome.content),
-					...(outcome.durationMs !== undefined ? { durationMs: outcome.durationMs } : {}),
+					toolCallId: call.id,
+					output: entry.toolOutput !== undefined ? entry.toolOutput.value : text,
+					...(entry.toolDurationMs !== undefined ? { durationMs: entry.toolDurationMs } : {}),
 				},
 			];
 }
@@ -317,12 +369,10 @@ function projectSettlements(
 	state: ReducedInstanceState,
 	conversationId: string,
 ): AgentConversationSettlement[] {
-	return [...state.recordsById.values()]
+	return [...state.settledSubmissions.values()]
 		.filter(
 			(record): record is SubmissionSettledRecord =>
-				record.conversationId === conversationId &&
-				record.type === 'submission_settled' &&
-				typeof record.submissionId === 'string',
+				record.conversationId === conversationId && typeof record.submissionId === 'string',
 		)
 		.map((record) => ({
 			submissionId: record.submissionId as string,

--- a/packages/runtime/src/conversation-reader.ts
+++ b/packages/runtime/src/conversation-reader.ts
@@ -3,6 +3,7 @@ import {
 	createReducedInstanceState,
 	type ReducedInstanceState,
 } from './conversation-reducer.ts';
+import { decodeReducedState, SNAPSHOT_VERSION } from './conversation-snapshot.ts';
 import type { ConversationStreamStore } from './runtime/conversation-stream-store.ts';
 
 /**
@@ -18,13 +19,39 @@ export async function loadReducedConversationState(options: {
 	store: ConversationStreamStore;
 	path: string;
 }): Promise<ReducedInstanceState> {
-	// The state is private until returned, so records apply in place instead of
-	// going through `reduceConversationRecords`'s defensive clone — the
-	// clone-per-batch was O(entries × batches) map churn across a replay
-	// (RUN-5210). Failure semantics are unchanged: a bad record throws and the
-	// whole load fails.
-	const state = createReducedInstanceState();
-	let offset = '-1';
+	// Checkpoint-accelerated load (RUN-5218): start from the store's derived
+	// snapshot when one is valid, replaying only the tail. The snapshot is a
+	// cache, never truth — any failure on the snapshot path (stale incarnation,
+	// version mismatch, decode error, tail-read error) falls back to a full
+	// replay from genesis, so a checkpoint can never break loading. A genuinely
+	// corrupt log still throws from the clean full-replay path.
+	const snapshot = await options.store.loadDerivedSnapshot?.(options.path)?.catch(() => null);
+	if (snapshot && snapshot.version === SNAPSHOT_VERSION) {
+		try {
+			const meta = await options.store.getMeta(options.path);
+			if (meta && meta.incarnation === snapshot.incarnation) {
+				const state = decodeReducedState(snapshot.data);
+				state.recordsThroughOffset = snapshot.offset;
+				return await replayInto(state, snapshot.offset, options);
+			}
+		} catch {
+			// fall through to the full replay
+		}
+	}
+	return replayInto(createReducedInstanceState(), '-1', options);
+}
+
+// The state is private until returned, so records apply in place instead of
+// going through `reduceConversationRecords`'s defensive clone — the
+// clone-per-batch was O(entries × batches) map churn across a replay
+// (RUN-5210). Failure semantics are unchanged: a bad record throws and the
+// whole load fails.
+async function replayInto(
+	state: ReducedInstanceState,
+	fromOffset: string,
+	options: { store: ConversationStreamStore; path: string },
+): Promise<ReducedInstanceState> {
+	let offset = fromOffset;
 	while (true) {
 		const read = await options.store.read(options.path, { offset, limit: REPLAY_READ_LIMIT });
 		for (const batch of read.batches) {

--- a/packages/runtime/src/conversation-reader.ts
+++ b/packages/runtime/src/conversation-reader.ts
@@ -68,9 +68,34 @@ export async function loadReducedConversationPrefix(options: {
 	path: string;
 	offset: string;
 }): Promise<ReducedInstanceState> {
-	const state = createReducedInstanceState();
-	if (options.offset === '-1') return state;
-	let offset = '-1';
+	if (options.offset === '-1') return createReducedInstanceState();
+	// Checkpoint acceleration (RUN-5220): usable whenever the snapshot sits at
+	// or before the requested boundary — offsets are fixed-width and sort
+	// lexically. Same cache-never-truth contract as the head load: any failure
+	// on the snapshot path falls back to the clean full replay.
+	const snapshot = await options.store.loadDerivedSnapshot?.(options.path)?.catch(() => null);
+	if (snapshot && snapshot.version === SNAPSHOT_VERSION && snapshot.offset <= options.offset) {
+		try {
+			const meta = await options.store.getMeta(options.path);
+			if (meta && meta.incarnation === snapshot.incarnation) {
+				const decoded = decodeReducedState(snapshot.data);
+				decoded.recordsThroughOffset = snapshot.offset;
+				if (snapshot.offset === options.offset) return decoded;
+				return await replayPrefixInto(decoded, snapshot.offset, options);
+			}
+		} catch {
+			// fall through to the full replay
+		}
+	}
+	return replayPrefixInto(createReducedInstanceState(), '-1', options);
+}
+
+async function replayPrefixInto(
+	state: ReducedInstanceState,
+	fromOffset: string,
+	options: { store: ConversationStreamStore; path: string; offset: string },
+): Promise<ReducedInstanceState> {
+	let offset = fromOffset;
 	while (true) {
 		const read = await options.store.read(options.path, { offset, limit: REPLAY_READ_LIMIT });
 		for (const batch of read.batches) {

--- a/packages/runtime/src/conversation-reader.ts
+++ b/packages/runtime/src/conversation-reader.ts
@@ -1,20 +1,35 @@
 import {
+	applyConversationRecord,
 	createReducedInstanceState,
 	type ReducedInstanceState,
-	reduceConversationRecords,
 } from './conversation-reducer.ts';
 import type { ConversationStreamStore } from './runtime/conversation-stream-store.ts';
+
+/**
+ * Replay page size, in batches. Small on purpose (RUN-5210): each page is
+ * fully parsed into memory before it is reduced, so the replay's transient
+ * peak is O(page bytes) + O(retained state) — a 1000-batch default page
+ * materializes an entire long session's log at once and was itself enough to
+ * exceed a Durable Object's heap before a single record reduced.
+ */
+const REPLAY_READ_LIMIT = 32;
 
 export async function loadReducedConversationState(options: {
 	store: ConversationStreamStore;
 	path: string;
 }): Promise<ReducedInstanceState> {
-	let state = createReducedInstanceState();
+	// The state is private until returned, so records apply in place instead of
+	// going through `reduceConversationRecords`'s defensive clone — the
+	// clone-per-batch was O(entries × batches) map churn across a replay
+	// (RUN-5210). Failure semantics are unchanged: a bad record throws and the
+	// whole load fails.
+	const state = createReducedInstanceState();
 	let offset = '-1';
 	while (true) {
-		const read = await options.store.read(options.path, { offset, limit: 1000 });
+		const read = await options.store.read(options.path, { offset, limit: REPLAY_READ_LIMIT });
 		for (const batch of read.batches) {
-			state = reduceConversationRecords(state, batch.records, batch.offset);
+			for (const record of batch.records) applyConversationRecord(state, record, batch.offset);
+			state.recordsThroughOffset = batch.offset;
 			offset = batch.offset;
 		}
 		if (read.upToDate) return state;
@@ -26,13 +41,14 @@ export async function loadReducedConversationPrefix(options: {
 	path: string;
 	offset: string;
 }): Promise<ReducedInstanceState> {
-	let state = createReducedInstanceState();
+	const state = createReducedInstanceState();
 	if (options.offset === '-1') return state;
 	let offset = '-1';
 	while (true) {
-		const read = await options.store.read(options.path, { offset, limit: 1000 });
+		const read = await options.store.read(options.path, { offset, limit: REPLAY_READ_LIMIT });
 		for (const batch of read.batches) {
-			state = reduceConversationRecords(state, batch.records, batch.offset);
+			for (const record of batch.records) applyConversationRecord(state, record, batch.offset);
+			state.recordsThroughOffset = batch.offset;
 			offset = batch.offset;
 			if (offset === options.offset) return state;
 		}

--- a/packages/runtime/src/conversation-reducer.ts
+++ b/packages/runtime/src/conversation-reducer.ts
@@ -158,8 +158,16 @@ export interface ReducedInstanceState {
 	recordsById: Map<string, ConversationRecord>;
 }
 
+/**
+ * Result of resolving an attachment for model input: either the image bytes to
+ * inline, or an `evicted` marker when the image-memory cap dropped it. An
+ * evicted attachment is projected as a text placeholder instead of image bytes,
+ * so its base64 is never materialized.
+ */
+export type ProjectedAttachment = { data: string; mimeType: string } | { evicted: true };
+
 export interface ConversationProjectionOptions {
-	resolveAttachment?: (attachment: AttachmentRef) => { data: string; mimeType: string };
+	resolveAttachment?: (attachment: AttachmentRef) => ProjectedAttachment;
 }
 
 export interface ReducedContextEntry {
@@ -1000,28 +1008,53 @@ function resolveMessageAttachments(
 		return message;
 	}
 	const attachments = [...(entry.attachmentRefs?.values() ?? [])];
+	// Resolve each attachment once: the `<attachments>` manifest and the inline
+	// image blocks must agree on which images are evicted, so both read from the
+	// same resolution rather than the manifest claiming an image is present while
+	// its inline block says `evicted`.
+	const resolved = new Map<string, ProjectedAttachment>();
+	if (options.resolveAttachment) {
+		for (const attachment of attachments) {
+			resolved.set(attachment.id, options.resolveAttachment(attachment));
+		}
+	}
 	let manifestProjected = false;
 	const content = message.content.map((block) => {
 		if (block.type === 'text' && !manifestProjected && attachments.length > 0) {
 			manifestProjected = true;
-			return { ...block, text: attachmentManifest(block.text, attachments) };
+			return { ...block, text: attachmentManifest(block.text, attachments, resolved) };
 		}
 		if (block.type !== 'image') return block;
 		const ref = entry.attachmentRefs?.get(block.data);
 		if (!ref) return block;
-		if (!options.resolveAttachment) throw new AttachmentNotAvailableError({ attachmentId: ref.id });
-		return { type: 'image' as const, ...options.resolveAttachment(ref) };
+		const projected = resolved.get(ref.id);
+		if (!projected) throw new AttachmentNotAvailableError({ attachmentId: ref.id });
+		if ('evicted' in projected) {
+			return {
+				type: 'text' as const,
+				text: `<image id="${ref.id}" mimeType="${ref.mimeType}" evicted />`,
+			};
+		}
+		return { type: 'image' as const, ...projected };
 	});
 	if (!manifestProjected && attachments.length > 0) {
-		content.unshift({ type: 'text', text: attachmentManifest('', attachments) });
+		content.unshift({ type: 'text', text: attachmentManifest('', attachments, resolved) });
 	}
 	return { ...message, content } as AgentMessage;
 }
 
-function attachmentManifest(text: string, attachments: readonly AttachmentRef[]): string {
+function attachmentManifest(
+	text: string,
+	attachments: readonly AttachmentRef[],
+	resolved: ReadonlyMap<string, ProjectedAttachment>,
+): string {
 	if (attachments.length === 0) return text;
 	const manifest = attachments
-		.map((attachment) => `<image id="${attachment.id}" mimeType="${attachment.mimeType}" />`)
+		.map((attachment) => {
+			const projected = resolved.get(attachment.id);
+			const evicted = projected !== undefined && 'evicted' in projected ? ' evicted' : '';
+			return `<image id="${attachment.id}" mimeType="${attachment.mimeType}"${evicted} />`;
+		})
 		.join('\n');
 	const projection = `\n\n<attachments>\n${manifest}\n</attachments>`;
 	return text.endsWith(projection) ? text : `${text}${projection}`;

--- a/packages/runtime/src/conversation-reducer.ts
+++ b/packages/runtime/src/conversation-reducer.ts
@@ -35,6 +35,15 @@ interface ReducedEntryBase {
 export interface ReducedMessageEntry extends ReducedEntryBase {
 	type: 'message';
 	message: AgentMessage;
+	/**
+	 * Set when compaction evicted this entry's heavy content (RUN-5210): text
+	 * bodies and tool-call arguments are replaced with placeholders while the
+	 * entry's structure (id, parent, timestamps, usage, attachment refs) stays.
+	 * Evicted entries are never projected into model context — they sit before
+	 * the latest compaction's `firstKeptEntryId` — and history projections
+	 * render the placeholder. The byte-faithful content remains in the log.
+	 */
+	contentEvicted?: true;
 	attachmentRefs?: Map<string, AttachmentRef>;
 	/**
 	 * Validated structured tool output for tool-result entries, distinct from the
@@ -104,6 +113,12 @@ export interface InProgressAssistantMessage {
 	blockIndexes: Set<number>;
 }
 
+/**
+ * A tool outcome awaiting its `tool_results_committed` record. Carries every
+ * field the commit application materializes into the tool-result entry, so the
+ * raw outcome record body does not need to stay resident (RUN-5210). Deleted
+ * when the commit consumes it.
+ */
 interface ReducedToolOutcome {
 	recordId: string;
 	assistantMessageId: string;
@@ -111,6 +126,9 @@ interface ReducedToolOutcome {
 	toolName: string;
 	isError: boolean;
 	content: CanonicalToolResultContent[];
+	timestamp: string;
+	output?: unknown;
+	durationMs?: number;
 }
 
 interface ReducedConversationStateBase {
@@ -151,11 +169,31 @@ export type ReducedConversationState = ReducedConversationStateBase &
 		  }
 	);
 
+/**
+ * Where and as-what one applied record entered the log. `offset` is the durable
+ * batch offset the record was applied at (an O(1) log fetch handle for any
+ * future by-id body read); `hash` is a content fingerprint preserving the
+ * redelivery contract without keeping the body resident: same id + same hash ⇒
+ * idempotent skip, same id + different hash ⇒ invariant failure (RUN-5210).
+ */
+export interface AppliedRecordIndex {
+	offset: string;
+	hash: string;
+}
+
 export interface ReducedInstanceState {
 	recordsThroughOffset: string;
 	conversations: Map<string, ReducedConversationState>;
 	conversationScopes: Map<string, string>;
-	recordsById: Map<string, ConversationRecord>;
+	/** Every applied record's offset + content fingerprint — never the body. */
+	recordIndex: Map<string, AppliedRecordIndex>;
+	/**
+	 * Settlement records stay resident whole: they are tiny (one per
+	 * submission), and they are the only historical record bodies consumers
+	 * read back after application (settlement projection and the coordinators'
+	 * pending-settlement canonical comparison).
+	 */
+	settledSubmissions: Map<string, Extract<ConversationRecord, { type: 'submission_settled' }>>;
 }
 
 /**
@@ -180,7 +218,8 @@ export function createReducedInstanceState(): ReducedInstanceState {
 		recordsThroughOffset: '-1',
 		conversations: new Map(),
 		conversationScopes: new Map(),
-		recordsById: new Map(),
+		recordIndex: new Map(),
+		settledSubmissions: new Map(),
 	};
 }
 
@@ -190,7 +229,7 @@ export function reduceConversationRecords(
 	offset = state.recordsThroughOffset,
 ): ReducedInstanceState {
 	const next = cloneReducedInstanceState(state);
-	for (const record of records) applyConversationRecord(next, record);
+	for (const record of records) applyConversationRecord(next, record, offset);
 	next.recordsThroughOffset = offset;
 	return next;
 }
@@ -199,7 +238,8 @@ function cloneReducedInstanceState(state: ReducedInstanceState): ReducedInstance
 	return {
 		recordsThroughOffset: state.recordsThroughOffset,
 		conversationScopes: new Map(state.conversationScopes),
-		recordsById: new Map(state.recordsById),
+		recordIndex: new Map(state.recordIndex),
+		settledSubmissions: new Map(state.settledSubmissions),
 		conversations: new Map(
 			[...state.conversations].map(([id, conversation]) => [
 				id,
@@ -248,13 +288,82 @@ function cloneReducedInstanceState(state: ReducedInstanceState): ReducedInstance
 	};
 }
 
+/**
+ * Content fingerprint for the redelivery contract: two independent 32-bit
+ * mixes over a full structural walk of the record. Allocation-free by design —
+ * unlike `JSON.stringify` it never materializes a copy of a multi-megabyte
+ * record on the reduce path, which is exactly where this module fights heap
+ * pressure (RUN-5210). Walk order and undefined-handling mirror JSON
+ * semantics (object keys in insertion order, undefined properties skipped,
+ * undefined array slots as null), so a record that round-trips through the
+ * store hashes identically. Defense-in-depth behind the store's
+ * producer-sequence dedup, not a cryptographic identity.
+ */
+function recordContentHash(record: ConversationRecord): string {
+	const h: { h1: number; h2: number } = { h1: 0x811c9dc5, h2: 0xc2b2ae35 };
+	hashUnknown(record, h);
+	return `${h.h1.toString(36)}.${h.h2.toString(36)}`;
+}
+
+function hashCode(h: { h1: number; h2: number }, code: number): void {
+	h.h1 = Math.imul(h.h1 ^ code, 0x01000193) >>> 0;
+	h.h2 = (Math.imul(h.h2 ^ code, 0x85ebca6b) + 0x9e3779b9) >>> 0;
+}
+
+function hashString(h: { h1: number; h2: number }, value: string): void {
+	hashCode(h, value.length);
+	for (let i = 0; i < value.length; i++) hashCode(h, value.charCodeAt(i));
+}
+
+function hashUnknown(value: unknown, h: { h1: number; h2: number }): void {
+	if (value === null || value === undefined) {
+		hashCode(h, 0);
+		return;
+	}
+	switch (typeof value) {
+		case 'string':
+			hashCode(h, 1);
+			hashString(h, value);
+			return;
+		case 'number':
+			hashCode(h, 2);
+			hashString(h, String(value));
+			return;
+		case 'boolean':
+			hashCode(h, value ? 3 : 4);
+			return;
+		case 'object': {
+			if (Array.isArray(value)) {
+				hashCode(h, 5);
+				hashCode(h, value.length);
+				for (const item of value) hashUnknown(item, h);
+				return;
+			}
+			hashCode(h, 6);
+			for (const key of Object.keys(value)) {
+				const property = (value as Record<string, unknown>)[key];
+				if (property === undefined) continue;
+				hashString(h, key);
+				hashUnknown(property, h);
+			}
+			return;
+		}
+		default:
+			// function/symbol/bigint never appear in canonical records; JSON
+			// drops the first two and rejects the third.
+			hashCode(h, 7);
+	}
+}
+
 export function applyConversationRecord(
 	state: ReducedInstanceState,
 	record: ConversationRecord,
+	offset = state.recordsThroughOffset,
 ): void {
-	const accepted = state.recordsById.get(record.id);
+	const hash = recordContentHash(record);
+	const accepted = state.recordIndex.get(record.id);
 	if (accepted) {
-		if (JSON.stringify(accepted) === JSON.stringify(record)) return;
+		if (accepted.hash === hash) return;
 		fail(record, `Record id "${record.id}" was reused with different content.`);
 	}
 	if (record.v !== 1) fail(record, `Record version "${String(record.v)}" is unsupported.`);
@@ -281,7 +390,7 @@ export function applyConversationRecord(
 			childConversations: new Map(),
 		});
 		state.conversationScopes.set(scopeKey, record.conversationId);
-		state.recordsById.set(record.id, record);
+		state.recordIndex.set(record.id, { offset, hash });
 		return;
 	}
 
@@ -447,6 +556,9 @@ export function applyConversationRecord(
 				toolName: record.toolName,
 				isError: record.isError,
 				content: record.content.map((block) => ({ ...block })),
+				timestamp: record.timestamp,
+				...(record.output !== undefined ? { output: record.output } : {}),
+				...(record.durationMs !== undefined ? { durationMs: record.durationMs } : {}),
 			});
 			break;
 		}
@@ -466,23 +578,27 @@ export function applyConversationRecord(
 			if (record.outcomeIds.length !== calls.length || new Set(record.outcomeIds).size !== calls.length) {
 				fail(record, `Committed tool results must reference every assistant tool call exactly once.`);
 			}
+			// The pending outcome is the retained source of truth for the commit:
+			// it was scope-validated into THIS conversation when its record
+			// applied, so conversation/harness/session equality is implied by
+			// residency; the recordId equality below still pins the commit to the
+			// exact outcome record it references (RUN-5210).
 			const outcomes = record.outcomeIds.map((outcomeId, index) => {
-				const outcomeRecord = state.recordsById.get(outcomeId);
 				const call = calls[index];
+				const pending = call
+					? conversation.toolOutcomes.get(toolOutcomeKey(record.assistantMessageId, call.id))
+					: undefined;
 				if (
-					outcomeRecord?.type !== 'tool_outcome' ||
 					!call ||
-					outcomeRecord.conversationId !== record.conversationId ||
-					outcomeRecord.harness !== record.harness ||
-					outcomeRecord.session !== record.session ||
-					outcomeRecord.assistantMessageId !== record.assistantMessageId ||
-					outcomeRecord.toolCallId !== call.id ||
-					outcomeRecord.toolName !== call.name ||
-					conversation.toolOutcomes.get(toolOutcomeKey(record.assistantMessageId, call.id))?.recordId !== outcomeId
+					!pending ||
+					pending.recordId !== outcomeId ||
+					pending.assistantMessageId !== record.assistantMessageId ||
+					pending.toolCallId !== call.id ||
+					pending.toolName !== call.name
 				) {
 					fail(record, `Committed tool outcome references do not match assistant tool-call order.`);
 				}
-				return outcomeRecord;
+				return pending;
 			});
 			let parentId = record.parentId;
 			for (const outcome of outcomes) {
@@ -500,6 +616,11 @@ export function applyConversationRecord(
 					...(outcome.durationMs !== undefined ? { toolDurationMs: outcome.durationMs } : {}),
 				});
 				parentId = entryId;
+			}
+			// The commit consumed its outcomes: the content now lives on the
+			// tool-result entries, so the pending copies are deleted (RUN-5210).
+			for (const outcome of outcomes) {
+				conversation.toolOutcomes.delete(toolOutcomeKey(record.assistantMessageId, outcome.toolCallId));
 			}
 			break;
 		}
@@ -529,6 +650,7 @@ export function applyConversationRecord(
 				details: record.details,
 				usage: record.usage,
 			});
+			evictCompactedContent(conversation, record.sourceLeafId, record.firstKeptEntryId);
 			break;
 		case 'child_session_retained': {
 			validateChildReference(record);
@@ -558,9 +680,10 @@ export function applyConversationRecord(
 			break;
 		}
 		case 'submission_settled':
+			state.settledSubmissions.set(record.id, record);
 			break;
 	}
-	state.recordsById.set(record.id, record);
+	state.recordIndex.set(record.id, { offset, hash });
 }
 
 function validateConversationCreation(
@@ -849,6 +972,56 @@ function pathToLeaf(
 	return path.reverse();
 }
 
+export const EVICTED_CONTENT_PLACEHOLDER = '[content evicted after compaction]';
+
+/**
+ * Evict heavy content from the entries a compaction just summarized: every
+ * message entry on the compacted path strictly before `firstKeptEntryId`
+ * (RUN-5210). The model context is built from the compaction summary plus
+ * entries from `firstKeptEntryId` onward, so evicted content is never
+ * projected into a prompt; new tool outcomes can only reference the active
+ * leaf's assistant, which is always after the latest compaction. Structure —
+ * ids, parents, timestamps, usage, attachment refs — is retained so leaf
+ * resolution and linear-append validation are untouched. The byte-faithful
+ * content remains in the durable log.
+ */
+function evictCompactedContent(
+	conversation: ReducedConversationState,
+	sourceLeafId: string,
+	firstKeptEntryId: string,
+): void {
+	const path = pathToLeaf(conversation, sourceLeafId);
+	const firstKeptIndex = path.findIndex((entry) => entry.id === firstKeptEntryId);
+	if (firstKeptIndex === -1) return;
+	for (const entry of path.slice(0, firstKeptIndex)) {
+		if (entry.type !== 'message' || entry.contentEvicted) continue;
+		entry.contentEvicted = true;
+		delete entry.toolOutput;
+		entry.message = evictMessageContent(entry.message);
+	}
+}
+
+function evictMessageContent(message: AgentMessage): AgentMessage {
+	const value = message as AgentMessage & { content?: unknown };
+	// Signal messages carry their content as a plain string.
+	if (typeof value.content === 'string') {
+		return { ...message, content: EVICTED_CONTENT_PLACEHOLDER } as AgentMessage;
+	}
+	if (!Array.isArray(value.content)) return message;
+	const content = value.content.map((block: unknown) => {
+		if (block === null || typeof block !== 'object') return block;
+		const candidate = block as Record<string, unknown>;
+		if (typeof candidate.text === 'string') return { ...candidate, text: EVICTED_CONTENT_PLACEHOLDER };
+		if (typeof candidate.thinking === 'string') {
+			return { ...candidate, thinking: EVICTED_CONTENT_PLACEHOLDER };
+		}
+		if (candidate.type === 'toolCall') return { ...candidate, arguments: {} };
+		// Image/attachment blocks carry attachment ids, not bytes — retained.
+		return block;
+	});
+	return { ...message, content } as AgentMessage;
+}
+
 function getInProgress(
 	conversation: ReducedConversationState,
 	record: ConversationRecord,
@@ -979,7 +1152,10 @@ function userMessage(content: CanonicalUserContent[], timestamp: string): AgentM
 }
 
 function toolResultMessage(
-	record: Extract<ConversationRecord, { type: 'tool_outcome' }>,
+	record: Pick<
+		Extract<ConversationRecord, { type: 'tool_outcome' }>,
+		'toolCallId' | 'toolName' | 'isError' | 'content' | 'timestamp'
+	>,
 ): AgentMessage {
 	return {
 		role: 'toolResult',

--- a/packages/runtime/src/conversation-snapshot.ts
+++ b/packages/runtime/src/conversation-snapshot.ts
@@ -1,0 +1,151 @@
+import type {
+	AttachmentRef,
+	CanonicalChildSessionRef,
+	ConversationRecord,
+} from './conversation-records.ts';
+import type {
+	AppliedRecordIndex,
+	ReducedConversationState,
+	ReducedEntry,
+	ReducedInstanceState,
+} from './conversation-reducer.ts';
+
+/**
+ * Versioned codec for persisting `ReducedInstanceState` as a derived-state
+ * checkpoint (RUN-5218, slice 2 of `plans/2026-07-17-bounded-conversation-view.md`).
+ *
+ * The checkpoint is a CACHE of state derivable from the canonical record log —
+ * never truth. Consumers must treat any decode failure or version mismatch as
+ * a cache miss and rebuild from the log. Consequently the contract here is
+ * deliberately strict and dumb:
+ *
+ * - `SNAPSHOT_VERSION` MUST be bumped by any change to the reducer's state
+ *   shape (`ReducedInstanceState` or anything reachable from it). An old
+ *   snapshot then reads as a miss and the log rebuilds the new shape.
+ * - `decodeReducedState` throws on anything unexpected rather than guessing.
+ */
+export const SNAPSHOT_VERSION = 1;
+
+interface WireEntry {
+	entry: ReducedEntry;
+	attachmentRefs?: [string, AttachmentRef][];
+}
+
+interface WireConversation {
+	conversation: Omit<
+		ReducedConversationState,
+		'entries' | 'inProgressMessages' | 'toolOutcomes' | 'childConversations'
+	>;
+	entries: [string, WireEntry][];
+	inProgressMessages: [string, unknown][];
+	toolOutcomes: [string, unknown][];
+	childConversations: [string, CanonicalChildSessionRef][];
+}
+
+interface WireState {
+	recordsThroughOffset: string;
+	conversationScopes: [string, string][];
+	recordIndex: [string, AppliedRecordIndex][];
+	settledSubmissions: [string, ConversationRecord][];
+	conversations: [string, WireConversation][];
+}
+
+export function encodeReducedState(state: ReducedInstanceState): string {
+	const wire: WireState = {
+		recordsThroughOffset: state.recordsThroughOffset,
+		conversationScopes: [...state.conversationScopes],
+		recordIndex: [...state.recordIndex],
+		settledSubmissions: [...state.settledSubmissions],
+		conversations: [...state.conversations].map(([id, conversation]) => {
+			const { entries, inProgressMessages, toolOutcomes, childConversations, ...rest } =
+				conversation;
+			return [
+				id,
+				{
+					conversation: rest,
+					entries: [...entries].map(([entryId, entry]) => {
+						if (entry.type === 'message' && entry.attachmentRefs) {
+							const { attachmentRefs, ...entryRest } = entry;
+							return [entryId, { entry: entryRest, attachmentRefs: [...attachmentRefs] }];
+						}
+						return [entryId, { entry }];
+					}),
+					inProgressMessages: [...inProgressMessages].map(([messageId, message]) => [
+						messageId,
+						{
+							...message,
+							blocks: [...message.blocks],
+							blockIndexes: [...message.blockIndexes],
+						},
+					]),
+					toolOutcomes: [...toolOutcomes],
+					childConversations: [...childConversations],
+				},
+			];
+		}),
+	};
+	return JSON.stringify(wire);
+}
+
+function assertArray(value: unknown, what: string): asserts value is unknown[] {
+	if (!Array.isArray(value)) throw new Error(`[flue] Snapshot decode: ${what} is not an array.`);
+}
+
+export function decodeReducedState(data: string): ReducedInstanceState {
+	const wire = JSON.parse(data) as WireState;
+	if (typeof wire.recordsThroughOffset !== 'string') {
+		throw new Error('[flue] Snapshot decode: recordsThroughOffset missing.');
+	}
+	assertArray(wire.conversationScopes, 'conversationScopes');
+	assertArray(wire.recordIndex, 'recordIndex');
+	assertArray(wire.settledSubmissions, 'settledSubmissions');
+	assertArray(wire.conversations, 'conversations');
+	return {
+		recordsThroughOffset: wire.recordsThroughOffset,
+		conversationScopes: new Map(wire.conversationScopes),
+		recordIndex: new Map(wire.recordIndex),
+		settledSubmissions: new Map(wire.settledSubmissions as [string, never][]),
+		conversations: new Map(
+			wire.conversations.map(([id, wireConversation]) => {
+				const { conversation, entries, inProgressMessages, toolOutcomes, childConversations } =
+					wireConversation as WireConversation;
+				assertArray(entries, `entries of ${String(id)}`);
+				assertArray(inProgressMessages, `inProgressMessages of ${String(id)}`);
+				assertArray(toolOutcomes, `toolOutcomes of ${String(id)}`);
+				assertArray(childConversations, `childConversations of ${String(id)}`);
+				return [
+					id as string,
+					{
+						...(conversation as ReducedConversationState),
+						entries: new Map(
+							entries.map((pair) => {
+								const [entryId, wireEntry] = pair as [string, WireEntry];
+								if (wireEntry.attachmentRefs && wireEntry.entry.type === 'message') {
+									return [
+										entryId,
+										{ ...wireEntry.entry, attachmentRefs: new Map(wireEntry.attachmentRefs) },
+									];
+								}
+								return [entryId, wireEntry.entry];
+							}),
+						),
+						inProgressMessages: new Map(
+							(inProgressMessages as [string, Record<string, unknown>][]).map(
+								([messageId, message]) => [
+									messageId,
+									{
+										...message,
+										blocks: new Map(message.blocks as [string, never][]),
+										blockIndexes: new Set(message.blockIndexes as number[]),
+									} as never,
+								],
+							),
+						),
+						toolOutcomes: new Map(toolOutcomes as [string, never][]),
+						childConversations: new Map(childConversations),
+					} as ReducedConversationState,
+				];
+			}),
+		),
+	};
+}

--- a/packages/runtime/src/conversation-writer.ts
+++ b/packages/runtime/src/conversation-writer.ts
@@ -8,6 +8,7 @@ import type {
 } from './conversation-records.ts';
 import type { ReducedInstanceState } from './conversation-reducer.ts';
 import { reduceConversationRecords } from './conversation-reducer.ts';
+import { encodeReducedState, SNAPSHOT_VERSION } from './conversation-snapshot.ts';
 import type {
 	ConversationProducerClaim,
 	ConversationStreamIdentity,
@@ -43,6 +44,26 @@ type WriterLifecycle =
  */
 const CANONICAL_FLUSH_DELAY_MS = 1000;
 
+/**
+ * Derived-state checkpoint cadence, in durable batches (RUN-5218). A turn
+ * writes a handful of batches, so this checkpoints every few turns; cold-start
+ * tail replay is bounded by this many batches. The checkpoint write is awaited
+ * inline (deterministic in Workers — a floating promise may be dropped at
+ * event end) and its failure is logged, never propagated: the checkpoint is a
+ * cache, and an append must not fail because a cache write did.
+ */
+const CHECKPOINT_EVERY_BATCHES = 16;
+
+/**
+ * Offset stamped on records during the optimistic pre-append reduce, before
+ * the durable offset exists. Restamped to the real offset after the append
+ * commits. Never a real offset (real ones are numeric strings), so restamping
+ * exactly the records this batch applied is unambiguous — an idempotent
+ * re-apply of an old record keeps its original offset (RUN-5218 offset
+ * fidelity: `recordIndex` offsets are tail-replay/fetch handles).
+ */
+const PENDING_APPEND_OFFSET = 'pending-append';
+
 export class ConversationRecordWriter {
 	private lifecycle: WriterLifecycle = { status: 'active' };
 	private tail: Promise<void> = Promise.resolve();
@@ -55,6 +76,7 @@ export class ConversationRecordWriter {
 	private flushing: Promise<{ offset: string }> | undefined;
 	private resolvePending: ((result: { offset: string }) => void) | undefined;
 	private rejectPending: ((error: unknown) => void) | undefined;
+	private batchesSinceCheckpoint = 0;
 
 	private constructor(
 		private readonly store: ConversationStreamStore,
@@ -93,6 +115,29 @@ export class ConversationRecordWriter {
 
 	async hasConversationEntry(conversationId: string, entryId: string): Promise<boolean> {
 		return (await this.loadReducedState()).conversations.get(conversationId)?.entries.has(entryId) ?? false;
+	}
+
+	/**
+	 * Persist the current reduced state as the stream's derived checkpoint
+	 * (RUN-5218). Best-effort by contract: the checkpoint is a cache, so a
+	 * failed write is logged and the counter still resets (no hot-looping a
+	 * failing cache write on every subsequent append); the append that
+	 * triggered it succeeds regardless. No-op when the store does not
+	 * implement the optional snapshot capability.
+	 */
+	private async saveDerivedCheckpoint(): Promise<void> {
+		this.batchesSinceCheckpoint = 0;
+		if (!this.reducedState || !this.store.saveDerivedSnapshot) return;
+		try {
+			await this.store.saveDerivedSnapshot(this.path, {
+				version: SNAPSHOT_VERSION,
+				incarnation: this.claim.incarnation,
+				offset: this.reducedState.recordsThroughOffset,
+				data: encodeReducedState(this.reducedState),
+			});
+		} catch (error) {
+			console.error('[flue:conversation-checkpoint]', { path: this.path }, error);
+		}
 	}
 
 	async hasRecord(recordId: string): Promise<boolean> {
@@ -225,7 +270,7 @@ export class ConversationRecordWriter {
 		const operation = this.tail.then(async () => {
 			this.assertActive();
 			const reduced = this.reducedState
-				? reduceConversationRecords(this.reducedState, records, this.reducedState.recordsThroughOffset)
+				? reduceConversationRecords(this.reducedState, records, PENDING_APPEND_OFFSET)
 				: undefined;
 			const producerSequence = this.nextProducerSequence;
 			const input = {
@@ -251,7 +296,17 @@ export class ConversationRecordWriter {
 				this.nextProducerSequence = producerSequence + 1;
 				if (reduced) {
 					reduced.recordsThroughOffset = result.offset;
+					for (const record of records) {
+						const indexed = reduced.recordIndex.get(record.id);
+						if (indexed?.offset === PENDING_APPEND_OFFSET) {
+							reduced.recordIndex.set(record.id, { offset: result.offset, hash: indexed.hash });
+						}
+					}
 					this.reducedState = reduced;
+					this.batchesSinceCheckpoint += 1;
+					if (this.batchesSinceCheckpoint >= CHECKPOINT_EVERY_BATCHES) {
+						await this.saveDerivedCheckpoint();
+					}
 				}
 				return result;
 			} catch (error) {

--- a/packages/runtime/src/conversation-writer.ts
+++ b/packages/runtime/src/conversation-writer.ts
@@ -96,11 +96,19 @@ export class ConversationRecordWriter {
 	}
 
 	async hasRecord(recordId: string): Promise<boolean> {
-		return (await this.loadReducedState()).recordsById.has(recordId);
+		return (await this.loadReducedState()).recordIndex.has(recordId);
 	}
 
+	/**
+	 * Only settlement records stay resident whole (RUN-5210); they are the only
+	 * historical bodies read back after application (settlement projection and
+	 * the coordinators' pending-settlement canonical comparison). Any other
+	 * record id resolves to `undefined` here — its body lives in the durable
+	 * log, fetchable by the offset in `recordIndex` when a future caller needs
+	 * it. Use {@link hasRecord} for existence.
+	 */
 	async getRecord(recordId: string): Promise<import('./conversation-records.ts').ConversationRecord | undefined> {
-		return (await this.loadReducedState()).recordsById.get(recordId);
+		return (await this.loadReducedState()).settledSubmissions.get(recordId);
 	}
 
 	async getConversation(conversationId: string) {

--- a/packages/runtime/src/errors.ts
+++ b/packages/runtime/src/errors.ts
@@ -998,6 +998,20 @@ export class OperationFailedError extends FlueError {
 	}
 }
 
+/** Canonical submission input could not be made durably runnable after admission. */
+export class SubmissionCanonicalReadinessError extends FlueError {
+	constructor({ submissionId }: { submissionId: string }) {
+		super({
+			type: 'submission_canonical_readiness',
+			message: 'A durable submission could not be prepared for processing.',
+			details: 'The submission was not made runnable.',
+			dev: `Submission "${submissionId}" disappeared before canonical readiness was recorded.`,
+			meta: { submissionId },
+		});
+		this.name = 'SubmissionCanonicalReadinessError';
+	}
+}
+
 /**
  * A durable submission was interrupted (process crash, restart, or shutdown)
  * and recovery settled it as failed because resuming or replaying the work

--- a/packages/runtime/src/harness.ts
+++ b/packages/runtime/src/harness.ts
@@ -241,6 +241,7 @@ export class Harness implements FlueHarness {
 			model: taskModel,
 			thinkingLevel: taskAgent?.thinkingLevel ?? this.config.thinkingLevel,
 			compaction: taskAgent?.compaction ?? this.config.compaction,
+			imageMemory: taskAgent?.imageMemory ?? this.config.imageMemory,
 		};
 		const harnessScope = this.scopeName ? `${this.name}:${this.scopeName}` : this.name;
 		// Reattach (recovery) reuses the existing child conversation: its

--- a/packages/runtime/src/harness.ts
+++ b/packages/runtime/src/harness.ts
@@ -386,7 +386,7 @@ function normalizeSessionName(name: string | undefined): string {
 	return name ?? DEFAULT_SESSION_NAME;
 }
 
-function createConversationIdentity(): {
+export function createConversationIdentity(): {
 	conversationId: string;
 	affinityKey: string;
 	createdAt: string;

--- a/packages/runtime/src/harness.ts
+++ b/packages/runtime/src/harness.ts
@@ -212,7 +212,12 @@ export class Harness implements FlueHarness {
 		// defaults. Agent-less tasks reuse the parent's full config.
 		const instructions = taskAgent ? taskAgent.instructions : this.config.instructions;
 		const definitionSkills = taskAgent ? taskAgent.skills : this.config.definitionSkills;
-		const localContext = await discoverSessionContext(taskEnv, instructions, definitionSkills);
+		const localContext = await discoverSessionContext(
+			taskEnv,
+			instructions,
+			definitionSkills,
+			taskAgent ? taskAgent.promptFrame : this.config.promptFrame,
+		);
 		const taskModel = taskAgent?.model !== undefined
 			? this.config.resolveModel(taskAgent.model)
 			: this.config.model;

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -12,6 +12,12 @@ export type {
 } from './action.ts';
 export { defineAction } from './action.ts';
 export { createAgent, defineAgent, defineAgentProfile } from './agent-definition.ts';
+/**
+ * Expose the framework's default sandbox tool surface (read/write/edit/bash/
+ * grep/glob). A custom `tools` factory otherwise *replaces* that surface, so an
+ * app that wants to add one tool has no way to compose the defaults back in.
+ */
+export { createTools, type CreateToolsOptions } from './agent.ts';
 export {
 	ActionInputValidationError,
 	ActionOutputSerializationError,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -112,6 +112,7 @@ export type {
 	FlueObservation,
 	FlueSession,
 	FlueSessions,
+	ImageMemoryConfig,
 	LlmAssistantMessage,
 	LlmImageContent,
 	LlmMessage,

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -182,3 +182,8 @@ export function resolveModel(model: string): Model<Api> {
 	}
 	return resolved;
 }
+
+export {
+	type AgentConversationSignalInput,
+	appendAgentConversationSignal,
+} from './cloudflare/app-signals.ts';

--- a/packages/runtime/src/internal.ts
+++ b/packages/runtime/src/internal.ts
@@ -55,11 +55,20 @@ export { InMemoryRunStore } from './node/run-store.ts';
 export type { AgentSubmissionInput } from './runtime/agent-submissions.ts';
 export type { AttachmentStore } from './runtime/attachment-store.ts';
 export { InMemoryAttachmentStore } from './runtime/attachment-store.ts';
-export type { ConversationStreamStore } from './runtime/conversation-stream-store.ts';
+export type {
+	ConversationStreamStore,
+	DerivedConversationSnapshot,
+} from './runtime/conversation-stream-store.ts';
 export {
 	InMemoryConversationStreamStore,
 	SqliteConversationStreamStore,
 } from './runtime/conversation-stream-store.ts';
+export { loadReducedConversationState } from './conversation-reader.ts';
+export {
+	decodeReducedState,
+	encodeReducedState,
+	SNAPSHOT_VERSION,
+} from './conversation-snapshot.ts';
 export type { AgentInteractionStart } from './runtime/dev-lifecycle-logger.ts';
 export { installDevLifecycleLogger } from './runtime/dev-lifecycle-logger.ts';
 export type { DispatchInput, DispatchQueue } from './runtime/dispatch-queue.ts';

--- a/packages/runtime/src/node/agent-coordinator.ts
+++ b/packages/runtime/src/node/agent-coordinator.ts
@@ -10,7 +10,6 @@ import {
 	type AttachedAgentSubmissionAdmission,
 	agentSubmissionDispatchId,
 	createDirectAgentSubmissionInput,
-	createDispatchAgentSubmissionInput,
 	materializeAgentSubmissionSession,
 	processSubmission,
 	reconcileInterruptedSubmission,
@@ -18,7 +17,7 @@ import {
 } from '../runtime/agent-submissions.ts';
 import { SUBMISSION_HARNESS_NAME, SUBMISSION_SESSION_NAME } from '../adapter-helpers.ts';
 import { createSessionStorageKey } from '../session-identity.ts';
-import { SubmissionAbortedError } from '../errors.ts';
+import { SubmissionAbortedError, SubmissionCanonicalReadinessError } from '../errors.ts';
 import type { AttachmentStore } from '../runtime/attachment-store.ts';
 import type { ConversationStreamStore } from '../runtime/conversation-stream-store.ts';
 import type { AgentInteractionStart } from '../runtime/dev-lifecycle-logger.ts';
@@ -115,6 +114,7 @@ export function createNodeAgentCoordinator(options: {
 	const { submissions, agents, createContext, conversationStreamStore, attachmentStore, onInteractionStart, activityGate } = options;
 	const conversationWriters = new Map<string, Promise<ConversationRecordWriter>>();
 	const conversationMaterializations = new Map<string, Promise<void>>();
+	const canonicalPreparations = new Map<string, Promise<AgentSubmission>>();
 
 	// ── Lease ownership ──────────────────────────────────────────────────
 
@@ -133,7 +133,41 @@ export function createNodeAgentCoordinator(options: {
 
 	/** Submissions currently being processed, keyed by submissionId. */
 	const activeSubmissions = new Map<string, { task: Promise<void>; abort: AbortController }>();
-	const activityLeases = new Map<string, RuntimeActivityLease>();
+	/** Concurrent admissions may share an id; retain each lease until that submission settles. */
+	const activityLeases = new Map<string, Set<RuntimeActivityLease>>();
+
+	function retainSubmissionActivityLease(
+		submission: AgentSubmission,
+		activityLease?: RuntimeActivityLease,
+	): void {
+		if (!activityLease) return;
+		if (submission.status === 'settled') {
+			activityLease.release();
+			return;
+		}
+		const retained = activityLeases.get(submission.submissionId);
+		if (retained) retained.add(activityLease);
+		else activityLeases.set(submission.submissionId, new Set([activityLease]));
+	}
+
+	function releaseSubmissionActivityLease(
+		submissionId: string,
+		activityLease?: RuntimeActivityLease,
+	): void {
+		if (!activityLease) return;
+		activityLease.release();
+		const retained = activityLeases.get(submissionId);
+		if (!retained) return;
+		retained.delete(activityLease);
+		if (retained.size === 0) activityLeases.delete(submissionId);
+	}
+
+	function releaseSubmissionActivityLeases(submissionId: string): void {
+		const retained = activityLeases.get(submissionId);
+		if (!retained) return;
+		activityLeases.delete(submissionId);
+		for (const activityLease of retained) activityLease.release();
+	}
 
 	/**
 	 * Wake signal. The claim loop sleeps on `wakePromise` when there is
@@ -241,6 +275,33 @@ export function createNodeAgentCoordinator(options: {
 		return materialized;
 	}
 
+	async function ensureSubmissionCanonicalReady(
+		submission: AgentSubmission,
+		agent: AgentDefinition,
+	): Promise<AgentSubmission> {
+		if (submission.canonicalReadyAt !== null) return submission;
+		const existing = canonicalPreparations.get(submission.submissionId);
+		if (existing) return existing;
+		const preparing = (async () => {
+			await materializeSubmissionConversation(submission.input, agent);
+			const ready = await submissions.markSubmissionCanonicalReady(submission.submissionId);
+			if (ready) return ready;
+			const current = await submissions.getSubmission(submission.submissionId);
+			if (current?.canonicalReadyAt !== null && current?.canonicalReadyAt !== undefined) {
+				return current;
+			}
+			throw new SubmissionCanonicalReadinessError({ submissionId: submission.submissionId });
+		})();
+		canonicalPreparations.set(submission.submissionId, preparing);
+		try {
+			return await preparing;
+		} finally {
+			if (canonicalPreparations.get(submission.submissionId) === preparing) {
+				canonicalPreparations.delete(submission.submissionId);
+			}
+		}
+	}
+
 	function resolveAgent(name: string): AgentDefinition {
 		const agent = agents.find((record) => record.name === name)?.definition;
 		if (!agent) throw new Error(`[flue] submission target agent "${name}" has no agent definition.`);
@@ -284,8 +345,7 @@ export function createNodeAgentCoordinator(options: {
 			})
 			.finally(() => {
 				activeSubmissions.delete(claimed.submissionId);
-				activityLeases.get(claimed.submissionId)?.release();
-				activityLeases.delete(claimed.submissionId);
+				releaseSubmissionActivityLeases(claimed.submissionId);
 				wake();
 			});
 		activeSubmissions.set(claimed.submissionId, { task, abort: controller });
@@ -578,18 +638,14 @@ export function createNodeAgentCoordinator(options: {
 					return admission;
 				}
 				let submission = admission.submission;
-				if (submission.canonicalReadyAt === null) {
-					await materializeSubmissionConversation(createDispatchAgentSubmissionInput(input), agent);
-					submission =
-						(await submissions.markSubmissionCanonicalReady(submission.submissionId)) ?? submission;
-				}
+				retainSubmissionActivityLease(submission, activityLease);
+				submission = await ensureSubmissionCanonicalReady(submission, agent);
 
-				if (activityLease) activityLeases.set(submission.submissionId, activityLease);
 				ensureClaimLoop();
 				wake();
 				return { kind: 'submission', submission };
 			} catch (error) {
-				activityLease?.release();
+				releaseSubmissionActivityLease(input.dispatchId, activityLease);
 				throw error;
 			}
 		},
@@ -628,6 +684,7 @@ export function createNodeAgentCoordinator(options: {
 		createAdmission(agentName: string, instanceId: string): AttachedAgentSubmissionAdmission {
 			return async (
 				message: DeliveredMessage,
+				submissionId?: string,
 				traceCarrier?: import('../execution-interceptor.ts').FlueTraceCarrier,
 			) => {
 				if (stopping) throw new Error('[flue] Coordinator is shutting down.');
@@ -639,6 +696,7 @@ export function createNodeAgentCoordinator(options: {
 				}
 
 				const input = createDirectAgentSubmissionInput({
+					submissionId,
 					agent: agentName,
 					id: instanceId,
 					message,
@@ -646,20 +704,16 @@ export function createNodeAgentCoordinator(options: {
 				});
 
 				try {
-					const admitted = await submissions.admitDirect(input);
-					if (admitted.canonicalReadyAt === null) {
-						await materializeSubmissionConversation(input, agent);
-						const ready = await submissions.markSubmissionCanonicalReady(input.submissionId);
-						if (!ready) throw new Error('[flue] Direct admission disappeared before canonical readiness.');
-					}
-					const writer = await getConversationWriter(input);
+					let admitted = await submissions.admitDirect(input);
+					retainSubmissionActivityLease(admitted, activityLease);
+					admitted = await ensureSubmissionCanonicalReady(admitted, agent);
+					const writer = await getConversationWriter(admitted.input);
 					const offset = writer?.offset ?? '-1';
-					if (activityLease) activityLeases.set(input.submissionId, activityLease);
 					ensureClaimLoop();
 					wake();
-					return { submissionId: input.submissionId, offset };
+					return { submissionId: admitted.submissionId, offset };
 				} catch (error) {
-					activityLease?.release();
+					releaseSubmissionActivityLease(input.submissionId, activityLease);
 					throw error;
 				}
 			};

--- a/packages/runtime/src/persisted-image-placement.ts
+++ b/packages/runtime/src/persisted-image-placement.ts
@@ -59,12 +59,19 @@ export function matchesPersistedSubmissionAttachments(
 ): boolean {
 	try {
 		return (
-			JSON.stringify(hydratePersistedSubmissionAttachments(persistedInput, rows)) ===
-			JSON.stringify(input)
+			JSON.stringify(submissionCommand(hydratePersistedSubmissionAttachments(persistedInput, rows))) ===
+			JSON.stringify(submissionCommand(input))
 		);
 	} catch {
 		return false;
 	}
+}
+
+function submissionCommand(input: AgentSubmissionInput) {
+	// Admission time and trace context describe the request that first carried
+	// a command; retries may legitimately carry fresh values for both.
+	const { acceptedAt: _acceptedAt, traceCarrier: _traceCarrier, ...command } = input;
+	return command;
 }
 
 function reassemblePersistedChunks(

--- a/packages/runtime/src/runtime/agent-submissions.ts
+++ b/packages/runtime/src/runtime/agent-submissions.ts
@@ -104,6 +104,7 @@ interface AttachedAgentSubmissionReceipt {
 
 export type AttachedAgentSubmissionAdmission = (
 	message: DeliveredMessage,
+	submissionId?: string,
 	traceCarrier?: FlueTraceCarrier,
 ) => Promise<AttachedAgentSubmissionReceipt>;
 
@@ -122,11 +123,16 @@ export function createDirectAgentSubmissionInput(options: {
 	agent: string;
 	id: string;
 	message: DeliveredMessage;
+	/**
+	 * Reuse a client-supplied id instead of minting one, so a retried send
+	 * resolves to the submission the first attempt already admitted.
+	 */
+	submissionId?: string;
 	traceCarrier?: FlueTraceCarrier;
 }): AgentSubmissionInput {
 	return {
 		kind: 'direct',
-		submissionId: crypto.randomUUID(),
+		submissionId: options.submissionId ?? crypto.randomUUID(),
 		agent: options.agent,
 		id: options.id,
 		message: options.message,

--- a/packages/runtime/src/runtime/conversation-stream-store.ts
+++ b/packages/runtime/src/runtime/conversation-stream-store.ts
@@ -72,6 +72,28 @@ export interface ConversationStreamStore {
 	getMeta(path: string): Promise<ConversationStreamMeta | null>;
 	delete(path: string): Promise<void>;
 	subscribe(path: string, listener: () => void): () => void;
+	/**
+	 * OPTIONAL derived-state checkpoint beside the log (RUN-5218). The snapshot
+	 * is a cache of state derivable from the records — never truth: a store may
+	 * drop it at any time, `delete(path)` must drop it with the stream, and
+	 * readers treat absence, version mismatch, or decode failure as a cache
+	 * miss (full replay). Adapters that do not implement these serve full
+	 * replays; correctness is unaffected.
+	 */
+	saveDerivedSnapshot?(path: string, snapshot: DerivedConversationSnapshot): Promise<void>;
+	loadDerivedSnapshot?(path: string): Promise<DerivedConversationSnapshot | null>;
+}
+
+/** One persisted derived-state checkpoint row, stored beside the log. */
+export interface DerivedConversationSnapshot {
+	/** Codec version of `data`; mismatch ⇒ cache miss. */
+	version: number;
+	/** Stream incarnation the snapshot derives from; a recreated stream must not reuse it. */
+	incarnation: string;
+	/** The last batch offset reduced into the snapshot; tail replay starts after it. */
+	offset: string;
+	/** Serialized reduced state (`encodeReducedState`). */
+	data: string;
 }
 
 const CREATE_STREAMS_TABLE = `
@@ -83,6 +105,15 @@ CREATE TABLE IF NOT EXISTS flue_conversation_streams (
   producer_epoch INTEGER NOT NULL DEFAULT 0,
   next_producer_sequence INTEGER NOT NULL DEFAULT 0,
   incarnation TEXT NOT NULL
+)`;
+
+const CREATE_DERIVED_SNAPSHOTS_TABLE = `
+CREATE TABLE IF NOT EXISTS flue_conversation_derived_snapshots (
+  path TEXT PRIMARY KEY,
+  version INTEGER NOT NULL,
+  incarnation TEXT NOT NULL,
+  offset TEXT NOT NULL,
+  data TEXT NOT NULL
 )`;
 
 const CREATE_BATCHES_TABLE = `
@@ -138,6 +169,7 @@ export function ensureSqlConversationStreamTables(sql: SqlStorage): void {
 	migrateFlueSqlSchema(sql, () => {
 		sql.exec(CREATE_STREAMS_TABLE);
 		sql.exec(CREATE_BATCHES_TABLE);
+		sql.exec(CREATE_DERIVED_SNAPSHOTS_TABLE);
 	});
 }
 
@@ -161,6 +193,7 @@ interface InMemoryConversationStream {
 
 export class InMemoryConversationStreamStore implements ConversationStreamStore {
 	private streams = new Map<string, InMemoryConversationStream>();
+	private snapshots = new Map<string, DerivedConversationSnapshot>();
 	private listeners = new StreamListenerRegistry();
 
 	async createStream(path: string, identity: ConversationStreamIdentity): Promise<void> {
@@ -297,11 +330,21 @@ export class InMemoryConversationStreamStore implements ConversationStreamStore 
 
 	async delete(path: string): Promise<void> {
 		this.streams.delete(path);
+		this.snapshots.delete(path);
 		this.listeners.notify(path);
 	}
 
 	subscribe(path: string, listener: () => void): () => void {
 		return this.listeners.subscribe(path, listener);
+	}
+
+	async saveDerivedSnapshot(path: string, snapshot: DerivedConversationSnapshot): Promise<void> {
+		this.snapshots.set(path, { ...snapshot });
+	}
+
+	async loadDerivedSnapshot(path: string): Promise<DerivedConversationSnapshot | null> {
+		const snapshot = this.snapshots.get(path);
+		return snapshot ? { ...snapshot } : null;
 	}
 
 	private assertSubmissionOwnership(
@@ -523,8 +566,42 @@ export class SqliteConversationStreamStore implements ConversationStreamStore {
 		this.runTransaction(() => {
 			this.sql.exec('DELETE FROM flue_conversation_stream_batches WHERE path = ?', path);
 			this.sql.exec('DELETE FROM flue_conversation_streams WHERE path = ?', path);
+			this.sql.exec('DELETE FROM flue_conversation_derived_snapshots WHERE path = ?', path);
 		});
 		this.listeners.notify(path);
+	}
+
+	async saveDerivedSnapshot(path: string, snapshot: DerivedConversationSnapshot): Promise<void> {
+		this.sql.exec(
+			`INSERT INTO flue_conversation_derived_snapshots (path, version, incarnation, offset, data)
+			 VALUES (?, ?, ?, ?, ?)
+			 ON CONFLICT(path) DO UPDATE SET
+			   version = excluded.version,
+			   incarnation = excluded.incarnation,
+			   offset = excluded.offset,
+			   data = excluded.data`,
+			path,
+			snapshot.version,
+			snapshot.incarnation,
+			snapshot.offset,
+			snapshot.data,
+		);
+	}
+
+	async loadDerivedSnapshot(path: string): Promise<DerivedConversationSnapshot | null> {
+		const row = this.sql
+			.exec(
+				'SELECT version, incarnation, offset, data FROM flue_conversation_derived_snapshots WHERE path = ?',
+				path,
+			)
+			.toArray()[0];
+		if (!row) return null;
+		return {
+			version: row.version as number,
+			incarnation: row.incarnation as string,
+			offset: row.offset as string,
+			data: row.data as string,
+		};
 	}
 
 	subscribe(path: string, listener: () => void): () => void {

--- a/packages/runtime/src/runtime/handle-agent.ts
+++ b/packages/runtime/src/runtime/handle-agent.ts
@@ -23,7 +23,7 @@ import { type EventStreamStore, runStreamPath } from './event-stream-store.ts';
 import { generateWorkflowRunId } from './ids.ts';
 import { isBufferedRunEvent, isStreamExcludedEvent, type RunStore } from './run-store.ts';
 import type { RuntimeActivityGate, RuntimeActivityLease } from './runtime-activity-gate.ts';
-import { parseDeliveredMessage } from './schemas.ts';
+import { parseDirectAgentRequest } from './schemas.ts';
 
 export function assertWorkflowDefinition(value: unknown, name: string): asserts value is WorkflowDefinition {
 	if (!isWorkflowDefinition(value)) {
@@ -165,10 +165,10 @@ export async function handleAgentRequest(opts: HandleAgentOptions): Promise<Resp
 		// The wire body IS a DeliveredMessage — the same validated shape a
 		// `dispatch()` call admits, so both transports share one schema and
 		// produce the same structured InvalidRequestError on bad input.
-		const message = parseDeliveredMessage(await parseJsonBody(request));
+		const { message, submissionId } = parseDirectAgentRequest(await parseJsonBody(request));
 		const traceCarrier = extractTraceCarrier(request.headers);
 		const streamUrl = invocationStreamUrl(request);
-		const receipt = await opts.admitAttachedSubmission(message, traceCarrier);
+		const receipt = await opts.admitAttachedSubmission(message, submissionId, traceCarrier);
 		return admissionResponse(
 			{ streamUrl, offset: receipt.offset, submissionId: receipt.submissionId },
 			streamUrl,

--- a/packages/runtime/src/runtime/handle-conversation-routes.ts
+++ b/packages/runtime/src/runtime/handle-conversation-routes.ts
@@ -6,7 +6,7 @@ import {
 	loadReducedConversationPrefix,
 	loadReducedConversationState,
 } from '../conversation-reader.ts';
-import { reduceConversationRecords } from '../conversation-reducer.ts';
+import { applyConversationRecord } from '../conversation-reducer.ts';
 import {
 	AttachmentNotFoundError,
 	InvalidRequestError,
@@ -107,6 +107,15 @@ export async function handleAgentConversationHead(
 	});
 }
 
+/**
+ * Default and ceiling for one history window, in active-path entries
+ * (RUN-5220). Bounds the projection and response of an arbitrarily long
+ * session; older pages ride the `beforeEntry` cursor the response's
+ * `truncatedBefore` hands out.
+ */
+const DEFAULT_HISTORY_ENTRY_LIMIT = 1000;
+const MAX_HISTORY_ENTRY_LIMIT = 10_000;
+
 async function historyResponse(options: {
 	store: ConversationStreamStore;
 	path: string;
@@ -118,13 +127,30 @@ async function historyResponse(options: {
 			new InvalidRequestError({ reason: 'History reads do not accept offset, tail, or live parameters.' }),
 		);
 	}
+	const rawLimit = url.searchParams.get('entryLimit');
+	let entryLimit = DEFAULT_HISTORY_ENTRY_LIMIT;
+	if (rawLimit !== null) {
+		const parsed = Number(rawLimit);
+		if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > MAX_HISTORY_ENTRY_LIMIT) {
+			return errorResponse(
+				new InvalidRequestError({
+					reason: `entryLimit must be an integer between 1 and ${MAX_HISTORY_ENTRY_LIMIT}.`,
+				}),
+			);
+		}
+		entryLimit = parsed;
+	}
+	const beforeEntry = url.searchParams.get('beforeEntry') ?? undefined;
 	const meta = await options.store.getMeta(options.path);
 	if (!meta) return errorResponse(new StreamNotFoundError({ path: options.path }));
 	const state = await loadReducedConversationState({
 		store: options.store,
 		path: options.path,
 	});
-	const snapshot = projectAgentConversationSnapshot(state);
+	const snapshot = projectAgentConversationSnapshot(state, {
+		entryLimit,
+		...(beforeEntry !== undefined ? { beforeEntry } : {}),
+	});
 	if (!snapshot) return errorResponse(new StreamNotFoundError({ path: options.path }));
 	return Response.json(snapshot, {
 		headers: {
@@ -178,12 +204,18 @@ function projectRead(
 	const items: unknown[] = [];
 	let offset = initialState.recordsThroughOffset;
 	for (const batch of read.batches) {
-		const previousState = state;
-		state = reduceConversationRecords(state, batch.records, batch.offset);
+		// The prefix state is private to this request, so records apply in
+		// place — the previous defensive clone per batch was O(entries) map
+		// churn on every projected page (RUN-5220). The projection's
+		// previousState is only a root-selection fallback; the post-batch state
+		// serves both roles (a batch that lacks a root after application lacked
+		// one before it too).
+		for (const record of batch.records) applyConversationRecord(state, record, batch.offset);
+		state.recordsThroughOffset = batch.offset;
 		items.push(
 			...projectAgentConversationBatch({
 				state,
-				previousState,
+				previousState: state,
 				records: batch.records,
 				batchOrdinal: parseOffset(batch.offset),
 			}),

--- a/packages/runtime/src/runtime/schemas.ts
+++ b/packages/runtime/src/runtime/schemas.ts
@@ -55,6 +55,19 @@ export const DeliveredMessageSchema = v.variant('kind', [
 	DeliveredSignalMessageSchema,
 ]);
 
+const DirectSubmissionIdSchema = v.optional(v.pipe(v.string(), v.nonEmpty()));
+
+const DirectAgentRequestSchema = v.variant('kind', [
+	v.object({
+		...DeliveredUserMessageSchema.entries,
+		submissionId: DirectSubmissionIdSchema,
+	}),
+	v.object({
+		...DeliveredSignalMessageSchema.entries,
+		submissionId: DirectSubmissionIdSchema,
+	}),
+]);
+
 /**
  * Validate a raw value as a {@link DeliveredMessage}. Shared by `dispatch()`
  * admission and the direct HTTP route so both transports produce the same
@@ -72,6 +85,34 @@ export function parseDeliveredMessage(value: unknown): DeliveredMessage {
 			'Delivered messages must be { kind: "user", body: string, attachments?: attachment[] } ' +
 				'or { kind: "signal", type: string, body: string, attributes?: Record<string, string>, tagName?: string }.',
 	});
+}
+
+/** Parse a direct HTTP admission and separate its transport id from the message. */
+export function parseDirectAgentRequest(value: unknown): {
+	readonly message: DeliveredMessage;
+	readonly submissionId?: string;
+} {
+	const parsed = v.safeParse(DirectAgentRequestSchema, value);
+	if (!parsed.success) {
+		// Malformed message bodies take the shared parse's InvalidRequestError
+		// (HTTP 400), exactly as before.
+		const message = parseDeliveredMessage(value);
+		// The message itself parsed, so the strict failure was the submissionId.
+		// A body that names a submissionId must never fall through with the id
+		// dropped: the server would mint a fresh id per retry, admitting the
+		// duplicate turn the stable client-supplied id exists to prevent.
+		if (typeof value === 'object' && value !== null && 'submissionId' in value) {
+			throw new InvalidRequestError({
+				reason: 'The "submissionId" field must be a non-empty string when present.',
+			});
+		}
+		return { message };
+	}
+	const { submissionId, ...message } = parsed.output;
+	return {
+		message,
+		...(submissionId === undefined ? {} : { submissionId }),
+	};
 }
 
 export const WorkflowRouteParamSchema = v.object({ name: v.string() });

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -67,6 +67,7 @@ import {
 import {
 	getActiveConversationPath,
 	type InProgressAssistantMessage,
+	type ProjectedAttachment,
 	type ReducedConversationState,
 	toolOutcomeKey,
 	toolResultEntryId,
@@ -2656,11 +2657,37 @@ export class Session implements FlueSession, AgentSubmissionSession {
 		return conversation;
 	}
 
+	private resolveImageMemorySettings(): { maxImages: number } {
+		const DEFAULT_MAX_IMAGES = 3;
+		return { maxImages: this.config.imageMemory?.maxImages ?? DEFAULT_MAX_IMAGES };
+	}
+
 	private async resolveCanonicalContextAttachments(
 		conversation: ReducedConversationState,
-	): Promise<Map<string, PromptImage>> {
-		const resolved = new Map<string, PromptImage>();
-		for (const attachment of this.visibleCanonicalAttachments(conversation).values()) {
+	): Promise<Map<string, ProjectedAttachment>> {
+		// `visibleCanonicalAttachments` yields refs in conversation order
+		// (oldest → newest). Keep the newest `maxImages` resolved to bytes and
+		// evict the rest to a placeholder, so an older image's base64 is never
+		// loaded into the isolate — the image-memory OOM guard. Both the rebuild
+		// and compaction passes flow through here, so both are bounded.
+		//
+		// Two consequences of evicting oldest-first, both intended:
+		//  - Compaction summarizes the OLDEST turns, which are exactly the evicted
+		//    ones, so a summary sees placeholders, not image bytes. Loading every
+		//    image to summarize would defeat the guard; the summary is image-blind
+		//    for evicted images by design.
+		//  - Evicted refs skip the store read, so a genuinely-missing OLD
+		//    attachment renders as a placeholder rather than raising. Only a KEPT
+		//    image still surfaces `AttachmentNotAvailableError` on a missing byte.
+		const { maxImages } = this.resolveImageMemorySettings();
+		const visible = [...this.visibleCanonicalAttachments(conversation).values()];
+		const firstKeptIndex = Math.max(0, visible.length - maxImages);
+		const resolved = new Map<string, ProjectedAttachment>();
+		for (const [index, attachment] of visible.entries()) {
+			if (index < firstKeptIndex) {
+				resolved.set(attachment.id, { evicted: true });
+				continue;
+			}
 			const stored = await this.attachmentStore.get({
 				streamPath: this.conversationWriter.path,
 				conversationId: this.conversationId,
@@ -2668,7 +2695,6 @@ export class Session implements FlueSession, AgentSubmissionSession {
 			});
 			if (!stored) throw new AttachmentNotAvailableError({ attachmentId: attachment.id });
 			resolved.set(attachment.id, {
-				type: 'image',
 				data: encodeBase64(stored.bytes),
 				mimeType: stored.attachment.mimeType,
 			});

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -1881,7 +1881,7 @@ export class Session implements FlueSession, AgentSubmissionSession {
 					throw new Error('unreachable');
 				},
 			};
-			return this.wrapModelTool(tool, 'custom', (_toolCallId, params, signal) => {
+			return this.wrapModelTool(tool, 'custom', (toolCallId, params, signal) => {
 				if (preparedToolAdapter) {
 					return {
 						args: params,
@@ -1901,7 +1901,10 @@ export class Session implements FlueSession, AgentSubmissionSession {
 				return {
 					args: parsed.input,
 					run: async () => {
-						const output = validateToolOutput(toolDef, await toolDef.run(parsed.context));
+						const output = validateToolOutput(
+							toolDef,
+							await toolDef.run({ ...parsed.context, toolCallId }),
+						);
 						return {
 							content: [
 								{

--- a/packages/runtime/src/submission-state.ts
+++ b/packages/runtime/src/submission-state.ts
@@ -294,7 +294,11 @@ export function findTrailingPartialToolBatch(
 
 export function isRetryableModelError(message: AssistantMessage): boolean {
 	if (message.stopReason !== 'error' || !message.errorMessage) return false;
-	return /overloaded|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|network.?error|connection.?(?:reset|refused|lost)|socket hang up|fetch failed|timed? out|timeout|terminated/i.test(
+	// A provider that dies mid-generation surfaces as a bare
+	// "Provider finish_reason: error" — transient upstream failure, so it earns
+	// the same backoff retries as a 5xx. The lookahead keeps qualified reasons
+	// (`error_quota`, `error-content-filter`, …) terminal.
+	return /overloaded|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|network.?error|connection.?(?:reset|refused|lost)|socket hang up|fetch failed|timed? out|timeout|terminated|provider finish_reason:\s*error(?![-\w])/i.test(
 		message.errorMessage,
 	);
 }

--- a/packages/runtime/src/test-utils/define-store-contract-tests.ts
+++ b/packages/runtime/src/test-utils/define-store-contract-tests.ts
@@ -196,6 +196,29 @@ export function defineStoreContractTests(label: string, backend: StoreContractTe
 		// ── Direct admission ───────────────────────────────────────────────
 
 		describe('direct admission', () => {
+			it('replays a direct submission when request metadata changes', async () => {
+				const store = await create();
+				const first = directInput({
+					acceptedAt: '2026-06-03T00:00:00.000Z',
+					traceCarrier: {
+						traceparent: '00-11111111111111111111111111111111-1111111111111111-01',
+					},
+				});
+				const admitted = await admitDirectReady(store, first);
+
+				const replay = await admitDirectReady(
+					store,
+					directInput({
+						acceptedAt: '2026-06-03T00:00:01.000Z',
+						traceCarrier: {
+							traceparent: '00-22222222222222222222222222222222-2222222222222222-01',
+						},
+					}),
+				);
+
+				expect(replay.input).toEqual(admitted.input);
+			});
+
 			it('round-trips direct submission images', async () => {
 				const store = await create();
 				const input = directInput({

--- a/packages/runtime/src/tool-types.ts
+++ b/packages/runtime/src/tool-types.ts
@@ -6,6 +6,11 @@ export type ToolOutputSchema = v.GenericSchema<any, NonNullable<unknown> | null>
 
 export type ToolContext<S extends ToolInputSchema | undefined> = {
 	readonly signal?: AbortSignal;
+	/**
+	 * Id of the model's tool call this run is servicing. A tool that emits its
+	 * own records needs it to attribute them back to the call that caused them.
+	 */
+	readonly toolCallId: string;
 } & (S extends ToolInputSchema
 	? { readonly input: v.InferOutput<S> }
 	: Record<never, never>);

--- a/packages/runtime/src/tool.ts
+++ b/packages/runtime/src/tool.ts
@@ -13,6 +13,17 @@ import type {
 	ToolOutputSchema,
 } from './tool-types.ts';
 
+type ParsedToolContext<TTool extends ToolDefinition> = Omit<
+	Parameters<TTool['run']>[0],
+	'toolCallId'
+>;
+
+interface ValidateAndRunToolOptions {
+	readonly input?: unknown;
+	readonly signal?: AbortSignal;
+	readonly toolCallId: string;
+}
+
 export function defineTool<
 	const TInput extends ToolInputSchema | undefined = undefined,
 	const TOutput extends ToolOutputSchema | undefined = undefined,
@@ -65,15 +76,22 @@ export function parseToolInput<TTool extends ToolDefinition>(
 	tool: TTool,
 	input?: unknown,
 	signal?: AbortSignal,
-): { context: Parameters<TTool['run']>[0]; input: unknown } {
-	if (!tool.input)
-		return { context: { signal } as Parameters<TTool['run']>[0], input: undefined };
+): { context: ParsedToolContext<TTool>; input: unknown } {
+	if (!tool.input) {
+		// SAFETY: A definition without an input schema has only the shared signal
+		// field before the caller attaches the required tool-call identity.
+		const context = { signal } as ParsedToolContext<TTool>;
+		return { context, input: undefined };
+	}
 	const parsedInput = parseValibot(tool.input, input === undefined ? {} : input);
 	if (!parsedInput.success) {
 		throw new ToolInputValidationError({ tool: tool.name, issues: parsedInput.issues });
 	}
+	// SAFETY: parseValibot established the definition's declared input schema;
+	// toolCallId is intentionally attached only at the execution boundary.
+	const context = { input: parsedInput.output, signal } as unknown as ParsedToolContext<TTool>;
 	return {
-		context: { input: parsedInput.output, signal } as Parameters<TTool['run']>[0],
+		context,
 		input: parsedInput.output,
 	};
 }
@@ -101,11 +119,13 @@ export function validateToolOutput<TTool extends ToolDefinition>(
 
 export async function validateAndRunTool<TTool extends ToolDefinition>(
 	tool: TTool,
-	input?: unknown,
-	signal?: AbortSignal,
+	options: ValidateAndRunToolOptions,
 ): Promise<ToolOutput<TTool>> {
-	const parsed = parseToolInput(tool, input, signal);
-	return validateToolOutput(tool, await tool.run(parsed.context));
+	const parsed = parseToolInput(tool, options.input, options.signal);
+	return validateToolOutput(
+		tool,
+		await tool.run({ ...parsed.context, toolCallId: options.toolCallId }),
+	);
 }
 
 function assertNonEmptyString(value: unknown, label: string): asserts value is string {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -328,6 +328,23 @@ export interface DurabilityConfig {
 	timeoutMs?: number;
 }
 
+// ─── Image Memory ───────────────────────────────────────────────────────────
+
+export interface ImageMemoryConfig {
+	/**
+	 * Maximum number of the most-recent images whose bytes are materialized in
+	 * memory and sent to the model at once. When a session's visible images
+	 * exceed this, the oldest are evicted to a text placeholder
+	 * (`<image id="..." mimeType="..." evicted />`) and their base64 is never
+	 * loaded into the isolate. Defaults to 3.
+	 *
+	 * This bounds image *count*, not bytes: worst case is `maxImages` times the
+	 * per-image ingress cap (`MAX_IMAGE_DATA_LENGTH`). Lower it for tighter
+	 * memory headroom on constrained isolates.
+	 */
+	maxImages?: number;
+}
+
 // ─── Agent Config (internal, passed to the harness at runtime) ──────────────
 
 /**
@@ -370,6 +387,8 @@ export interface AgentConfig {
 	compaction?: false | CompactionConfig;
 	/** Durability settings resolved from the agent profile. */
 	durability?: DurabilityConfig;
+	/** Image-memory eviction settings resolved from the agent profile. */
+	imageMemory?: ImageMemoryConfig;
 }
 
 // ─── Agent Profile and Runtime Creation ─────────────────────────────────────
@@ -409,6 +428,12 @@ export interface AgentProfile {
 	 * independent durability configuration of its own.
 	 */
 	durability?: DurabilityConfig;
+	/**
+	 * Image-memory eviction. Bounds how many of the most-recent images are held
+	 * in memory and sent to the model at once; older visible images are evicted
+	 * to a text placeholder. Defaults to keeping 3.
+	 */
+	imageMemory?: ImageMemoryConfig;
 }
 
 /** Configuration returned by a {@link defineAgent} initializer. */
@@ -443,6 +468,12 @@ export interface AgentRuntimeConfig {
 	 * recovery attempt limits and submission timeouts.
 	 */
 	durability?: DurabilityConfig;
+	/**
+	 * Image-memory eviction. Bounds how many of the most-recent images are held
+	 * in memory and sent to the model at once; older visible images are evicted
+	 * to a text placeholder. Defaults to keeping 3.
+	 */
+	imageMemory?: ImageMemoryConfig;
 	/** Working directory inside the initialized sandbox. */
 	cwd?: string;
 	/** Sandbox factory used to construct the initialized environment. */

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -330,6 +330,16 @@ export interface DurabilityConfig {
 
 // ─── Agent Config (internal, passed to the harness at runtime) ──────────────
 
+/**
+ * How much of the system prompt the framework owns.
+ *
+ * `'full'` (default) prepends the discovered workspace frame — headless
+ * preamble, AGENTS.md, skills catalog, date, cwd, directory listing — ahead of
+ * the agent's instructions. `'none'` contributes nothing: the instructions are
+ * the entire system prompt and the application owns every byte of it.
+ */
+export type PromptFrame = 'full' | 'none';
+
 export interface AgentConfig {
 	/** Discovered at runtime from AGENTS.md + .agents/skills/ in the session's cwd. */
 	systemPrompt: string;
@@ -337,6 +347,7 @@ export interface AgentConfig {
 	instructions?: string;
 	/** Agent-definition skills merged into each discovered skill catalog. */
 	definitionSkills?: Skill[];
+	promptFrame?: PromptFrame;
 	/** Discovered at runtime from .agents/skills/ in the session's cwd. */
 	skills: Record<string, Skill>;
 	subagents?: Record<string, AgentProfile>;
@@ -381,6 +392,8 @@ export interface AgentProfile {
 	subagents?: AgentProfile[];
 	/** Default reasoning effort. Individual operations may override this value. */
 	thinkingLevel?: ThinkingLevel;
+	/** How much of the system prompt the framework owns. Defaults to `"full"`. */
+	promptFrame?: PromptFrame;
 	/**
 	 * Automatic conversation-compaction configuration. `false` disables
 	 * threshold compaction; overflow recovery and explicit `session.compact()`
@@ -417,6 +430,8 @@ export interface AgentRuntimeConfig {
 	subagents?: AgentProfile[];
 	/** Default reasoning effort. Individual operations may override this value. */
 	thinkingLevel?: ThinkingLevel;
+	/** How much of the system prompt the framework owns. Defaults to `"full"`. */
+	promptFrame?: PromptFrame;
 	/**
 	 * Automatic conversation-compaction configuration. `false` disables
 	 * threshold compaction; overflow recovery and explicit `session.compact()`

--- a/packages/runtime/test/agent-definition.test.ts
+++ b/packages/runtime/test/agent-definition.test.ts
@@ -222,6 +222,26 @@ describe('defineAgentProfile()', () => {
 		expect(() => defineAgentProfile({ durability: { timeoutMs: -1 } })).toThrow('positive integer');
 	});
 
+	it('accepts valid imageMemory config on a profile', () => {
+		expect(() => defineAgentProfile({ imageMemory: { maxImages: 5 } })).not.toThrow();
+		expect(() => defineAgentProfile({ imageMemory: {} })).not.toThrow();
+	});
+
+	it('rejects imageMemory config with unknown fields', () => {
+		expect(() =>
+			defineAgentProfile({ imageMemory: { maxImages: 5, unknown: true } } as never),
+		).toThrow('unknown field "unknown"');
+	});
+
+	it('rejects imageMemory config with non-positive maxImages', () => {
+		expect(() => defineAgentProfile({ imageMemory: { maxImages: 0 } })).toThrow(
+			'imageMemory.maxImages',
+		);
+		expect(() => defineAgentProfile({ imageMemory: { maxImages: 1.5 } })).toThrow(
+			'positive integer',
+		);
+	});
+
 	it('rejects durability config when declared on a subagent profile', () => {
 		expect(() =>
 			defineAgentProfile({

--- a/packages/runtime/test/cloudflare-app-signals.test.ts
+++ b/packages/runtime/test/cloudflare-app-signals.test.ts
@@ -1,0 +1,231 @@
+import { DatabaseSync } from 'node:sqlite';
+import { describe, expect, it } from 'vitest';
+import { createCloudflareAgentRuntime } from '../src/cloudflare/agent-coordinator.ts';
+import type { ConversationRecord } from '../src/conversation-records.ts';
+import { ConversationRecordWriter } from '../src/conversation-writer.ts';
+import { appendAgentConversationSignal } from '../src/internal.ts';
+import type { ConversationStreamStore } from '../src/runtime/conversation-stream-store.ts';
+import { agentStreamPath } from '../src/runtime/event-stream-store.ts';
+
+function queryExpectsRows(query: string): boolean {
+	const trimmed = query.trimStart().toUpperCase();
+	if (trimmed.startsWith('SELECT') || trimmed.startsWith('WITH')) return true;
+	if (/\bRETURNING\b/i.test(query)) return true;
+	return false;
+}
+
+function makeFakeSql() {
+	const db = new DatabaseSync(':memory:');
+	return {
+		db,
+		storage: {
+			sql: {
+				exec(query: string, ...bindings: unknown[]) {
+					const stmt = db.prepare(query);
+					let rows: unknown[];
+					if (queryExpectsRows(query)) {
+						rows = stmt.all(...(bindings as never[]));
+					} else {
+						stmt.run(...(bindings as never[]));
+						rows = [];
+					}
+					return {
+						toArray() {
+							return rows as Record<string, unknown>[];
+						},
+					};
+				},
+			},
+			transactionSync<T>(closure: () => T): T {
+				db.exec('BEGIN');
+				try {
+					const result = closure();
+					db.exec('COMMIT');
+					return result;
+				} catch (error) {
+					db.exec('ROLLBACK');
+					throw error;
+				}
+			},
+		},
+	};
+}
+
+function makeInstance(storage: ReturnType<typeof makeFakeSql>['storage']) {
+	return {
+		name: 'agent-1',
+		env: {},
+		ctx: {
+			id: { toString: () => 'do-1' },
+			storage,
+		},
+		async __unsafe_ensureInitialized() {},
+		async schedule() {},
+		async runFiber() {},
+	};
+}
+
+/**
+ * Bind an agent instance the way the generated runtime does: prepare the
+ * sqlite-backed stores and attach the coordinator, which registers the
+ * instance for appendAgentConversationSignal().
+ */
+function attachInstance() {
+	const { storage } = makeFakeSql();
+	const runtime = createCloudflareAgentRuntime({
+		agents: [],
+		createContext: () => {
+			throw new Error('Unexpected context creation.');
+		},
+		runWithInstanceContext(_instance, _agentName, callback) {
+			return callback();
+		},
+	});
+	const instance = makeInstance(storage);
+	const prepared = runtime.prepare({
+		storage,
+		className: 'FlueAssistantAgent',
+		agentName: 'assistant',
+	});
+	runtime.attach(instance, prepared);
+	return { instance, conversationStreamStore: prepared.conversationStreamStore };
+}
+
+async function readCanonicalRecords(
+	store: ConversationStreamStore,
+): Promise<ConversationRecord[]> {
+	const read = await store.read(agentStreamPath('assistant', 'agent-1'));
+	return read.batches.flatMap((batch) => batch.records);
+}
+
+describe('appendAgentConversationSignal()', () => {
+	it('creates the root conversation when a signal precedes the first submission', async () => {
+		const { instance, conversationStreamStore } = attachInstance();
+
+		await appendAgentConversationSignal(instance, {
+			kind: 'signal',
+			type: 'external_note',
+			tagName: 'external-note',
+			body: 'The nightly build finished.',
+			attributes: { source: 'ci' },
+		});
+
+		const records = await readCanonicalRecords(conversationStreamStore);
+		const created = records.filter((record) => record.type === 'conversation_created');
+		expect(created).toHaveLength(1);
+		expect(created[0]).toMatchObject({ kind: 'root', harness: 'default', session: 'default' });
+		const signals = records.filter((record) => record.type === 'signal');
+		expect(signals).toHaveLength(1);
+		expect(signals[0]).toMatchObject({
+			conversationId: created[0]?.conversationId,
+			signalType: 'external_note',
+			tagName: 'external-note',
+			content: 'The nightly build finished.',
+			attributes: { source: 'ci' },
+			parentId: null,
+		});
+		expect(signals[0]?.id).toMatch(/^record_app_signal_/);
+		if (signals[0]?.type !== 'signal') throw new Error('Expected a signal record.');
+		expect(signals[0].messageId).toMatch(/^entry_app_signal_/);
+	});
+
+	it('appends linearly to the existing root conversation', async () => {
+		const { instance, conversationStreamStore } = attachInstance();
+
+		await appendAgentConversationSignal(instance, {
+			kind: 'signal',
+			type: 'note',
+			body: 'First.',
+		});
+		await appendAgentConversationSignal(instance, {
+			kind: 'signal',
+			type: 'note',
+			body: 'Second.',
+		});
+
+		const records = await readCanonicalRecords(conversationStreamStore);
+		// The first signal created the root conversation; the second reuses it.
+		expect(records.filter((record) => record.type === 'conversation_created')).toHaveLength(1);
+		const signals = records.filter(
+			(record): record is Extract<ConversationRecord, { type: 'signal' }> =>
+				record.type === 'signal',
+		);
+		expect(signals).toHaveLength(2);
+		expect(signals[1]?.parentId).toBe(signals[0]?.messageId);
+		// tagName and attributes stay optional — absent, not defaulted.
+		expect(signals[0]).not.toHaveProperty('tagName');
+		expect(signals[0]).not.toHaveProperty('attributes');
+	});
+
+	it('throws while an assistant message is in progress', async () => {
+		const { instance, conversationStreamStore } = attachInstance();
+		// Seed the canonical stream mid-turn: a user message whose assistant
+		// reply has started but not completed.
+		const seed = await ConversationRecordWriter.create({
+			store: conversationStreamStore,
+			path: agentStreamPath('assistant', 'agent-1'),
+			identity: { agentName: 'assistant', instanceId: 'agent-1' },
+			producerId: 'seed-producer',
+		});
+		await seed.ensureConversation({
+			kind: 'root',
+			conversationId: 'conversation-1',
+			harness: 'default',
+			session: 'default',
+			affinityKey: 'affinity-1',
+			createdAt: '2026-01-01T00:00:00.000Z',
+		});
+		await seed.append([
+			{
+				v: 1,
+				id: 'record_user_1',
+				type: 'user_message',
+				conversationId: 'conversation-1',
+				harness: 'default',
+				session: 'default',
+				timestamp: '2026-01-01T00:00:01.000Z',
+				messageId: 'entry_user_1',
+				parentId: null,
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+			{
+				v: 1,
+				id: 'record_assistant_started_1',
+				type: 'assistant_message_started',
+				conversationId: 'conversation-1',
+				harness: 'default',
+				session: 'default',
+				timestamp: '2026-01-01T00:00:02.000Z',
+				messageId: 'entry_assistant_1',
+				parentId: 'entry_user_1',
+				modelInfo: { api: 'test', provider: 'test', model: 'test-model' },
+			},
+		]);
+
+		await expect(
+			appendAgentConversationSignal(instance, {
+				kind: 'signal',
+				type: 'note',
+				body: 'Too late.',
+			}),
+		).rejects.toMatchObject({
+			name: 'ConversationRecordInvariantError',
+			meta: {
+				reason: 'Cannot advance the conversation while an assistant message is in progress.',
+			},
+		});
+	});
+
+	it('rejects an instance without an attached coordinator', async () => {
+		await expect(
+			appendAgentConversationSignal(
+				{},
+				{
+					kind: 'signal',
+					type: 'note',
+					body: 'Nope.',
+				},
+			),
+		).rejects.toThrow(/coordinator is not attached/);
+	});
+});

--- a/packages/runtime/test/conversation-checkpoint.test.ts
+++ b/packages/runtime/test/conversation-checkpoint.test.ts
@@ -285,6 +285,33 @@ describe('writer checkpointing (RUN-5218)', () => {
 		}
 	});
 
+	it('prefix loads at or past the checkpoint replay only the tail (RUN-5220)', async () => {
+		const store = new InMemoryConversationStreamStore();
+		const writer = await writerWith(store);
+		for (const record of chainedRecords(20)) await writer.append([record]);
+		const snapshot = await store.loadDerivedSnapshot(PATH);
+		expect(snapshot).not.toBeNull();
+		const meta = await store.getMeta(PATH);
+		const head = meta!.nextOffset;
+
+		const reads: string[] = [];
+		const originalRead = store.read.bind(store);
+		store.read = (path, options) => {
+			reads.push(options?.offset ?? '-1');
+			return originalRead(path, options);
+		};
+		const { loadReducedConversationPrefix } = await import('../src/conversation-reader.ts');
+		const accelerated = await loadReducedConversationPrefix({ store, path: PATH, offset: head });
+		expect(reads.every((offset) => offset !== '-1')).toBe(true);
+		expect(accelerated.recordsThroughOffset).toBe(head);
+
+		// An offset BEFORE the checkpoint cannot use it: clean full replay.
+		reads.length = 0;
+		const early = await loadReducedConversationPrefix({ store, path: PATH, offset: '0000000000000000_0000000000000002' });
+		expect(reads[0]).toBe('-1');
+		expect(early.recordsThroughOffset).toBe('0000000000000000_0000000000000002');
+	});
+
 	it('a failing snapshot write never fails the append', async () => {
 		const store = new InMemoryConversationStreamStore();
 		store.saveDerivedSnapshot = async () => {

--- a/packages/runtime/test/conversation-checkpoint.test.ts
+++ b/packages/runtime/test/conversation-checkpoint.test.ts
@@ -1,0 +1,307 @@
+import { describe, expect, it } from 'vitest';
+import { loadReducedConversationState } from '../src/conversation-reader.ts';
+import type { ConversationRecord } from '../src/conversation-records.ts';
+import { applyConversationRecord, createReducedInstanceState } from '../src/conversation-reducer.ts';
+import {
+	decodeReducedState,
+	encodeReducedState,
+	SNAPSHOT_VERSION,
+} from '../src/conversation-snapshot.ts';
+import { ConversationRecordWriter } from '../src/conversation-writer.ts';
+import { InMemoryConversationStreamStore } from '../src/runtime/conversation-stream-store.ts';
+
+const PATH = 'agents/assistant/instance-1';
+const IDENTITY = { agentName: 'assistant', instanceId: 'instance-1' };
+
+function userRecord(id: string): ConversationRecord {
+	return {
+		v: 1,
+		id,
+		type: 'user_message',
+		conversationId: 'conversation-1',
+		harness: 'default',
+		session: 'default',
+		timestamp: '2026-01-01T00:00:00.000Z',
+		messageId: `entry_${id}`,
+		parentId: null,
+		content: [{ type: 'text', text: `payload for ${id}` }],
+	};
+}
+
+function creationRecord(): ConversationRecord {
+	return {
+		v: 1,
+		id: 'record-created',
+		type: 'conversation_created',
+		conversationId: 'conversation-1',
+		harness: 'default',
+		session: 'default',
+		timestamp: '2026-01-01T00:00:00.000Z',
+		affinityKey: 'aff-1',
+		createdAt: '2026-01-01T00:00:00.000Z',
+		kind: 'root',
+	};
+}
+
+// A linear chain: each user message extends the previous one.
+function chainedRecords(count: number): ConversationRecord[] {
+	const records: ConversationRecord[] = [creationRecord()];
+	let parentId: string | null = null;
+	for (let index = 0; index < count; index++) {
+		const record = userRecord(`record-${index}`) as Extract<
+			ConversationRecord,
+			{ type: 'user_message' }
+		>;
+		record.parentId = parentId;
+		parentId = record.messageId;
+		records.push(record);
+	}
+	return records;
+}
+
+async function writerWith(store: InMemoryConversationStreamStore) {
+	const writer = await ConversationRecordWriter.create({
+		store,
+		path: PATH,
+		identity: IDENTITY,
+		producerId: 'producer-1',
+	});
+	// The writer maintains (and therefore checkpoints) its reduced state only
+	// once loaded — which every production session does at turn start.
+	await writer.loadReducedState();
+	return writer;
+}
+
+describe('reduced-state snapshot codec', () => {
+	it('round-trips: decode(encode(state)) re-encodes identically and reduces identically', () => {
+		const records = chainedRecords(5);
+		const state = createReducedInstanceState();
+		for (const record of records) applyConversationRecord(state, record, '4');
+
+		const encoded = encodeReducedState(state);
+		const decoded = decodeReducedState(encoded);
+		expect(encodeReducedState(decoded)).toBe(encoded);
+
+		// Continued reduction over the decoded state matches the original.
+		const tail = userRecord('record-tail') as Extract<
+			ConversationRecord,
+			{ type: 'user_message' }
+		>;
+		tail.parentId = 'entry_record-4';
+		applyConversationRecord(state, tail, '5');
+		applyConversationRecord(decoded, tail, '5');
+		expect(encodeReducedState(decoded)).toBe(encodeReducedState(state));
+	});
+
+	// The codec paths that actually do Map/Set gymnastics — an in-progress
+	// assistant (blocks Map + blockIndexes Set), attachment refs, pending tool
+	// outcomes, settlements, and a compaction entry. A symmetric codec bug
+	// would round-trip byte-identically yet diverge from a full replay, so the
+	// decisive assertion is continued-reduction equivalence over the whole zoo.
+	function complexRecords(): ConversationRecord[] {
+		const scope = {
+			v: 1 as const,
+			conversationId: 'conversation-1',
+			harness: 'default',
+			session: 'default',
+			timestamp: '2026-01-01T00:00:00.000Z',
+		};
+		const attachment = { id: 'att-1', mimeType: 'image/png', size: 1234, filename: 'shot.png' };
+		return [
+			creationRecord(),
+			{
+				...scope,
+				id: 'r-user',
+				type: 'user_message',
+				messageId: 'entry_user',
+				parentId: null,
+				content: [
+					{ type: 'text', text: 'look at this' },
+					{ type: 'attachment', attachment },
+				],
+			},
+			{ ...scope, id: 'r-a1-start', type: 'assistant_message_started', messageId: 'entry_a1', parentId: 'entry_user', turnId: 'turn-1', modelInfo: { api: 'test', provider: 'test', model: 'm' } },
+			{ ...scope, id: 'r-a1-text-start', type: 'assistant_text_started', messageId: 'entry_a1', blockId: 'b-text', blockIndex: 0 },
+			{ ...scope, id: 'r-a1-delta', type: 'assistant_text_delta', messageId: 'entry_a1', blockId: 'b-text', sequence: 0, delta: 'thinking done' },
+			{ ...scope, id: 'r-a1-text-done', type: 'assistant_text_completed', messageId: 'entry_a1', blockId: 'b-text', deltaCount: 1 },
+			{ ...scope, id: 'r-a1-tool', type: 'assistant_tool_call', messageId: 'entry_a1', blockId: 'b-tool', blockIndex: 1, toolCallId: 'call-1', name: 'lookup', arguments: { q: 1 } },
+			{ ...scope, id: 'r-a1-done', type: 'assistant_message_completed', messageId: 'entry_a1', stopReason: 'toolUse', usage: { input: 1, output: 1 } },
+			{
+				...scope,
+				id: 'r-outcome',
+				type: 'tool_outcome',
+				assistantMessageId: 'entry_a1',
+				toolCallId: 'call-1',
+				toolName: 'lookup',
+				isError: false,
+				content: [
+					{ type: 'text', text: 'result' },
+					{ type: 'attachment', attachment },
+				],
+				output: { answer: 42 },
+				durationMs: 7,
+			},
+			{ ...scope, id: 'r-commit', type: 'tool_results_committed', assistantMessageId: 'entry_a1', parentId: 'entry_a1', outcomeIds: ['r-outcome'] },
+			{ ...scope, id: 'r-settled', type: 'submission_settled', submissionId: 'submission-1', outcome: 'completed' },
+			{
+				...scope,
+				id: 'r-compaction',
+				type: 'compaction',
+				entryId: 'entry_compaction',
+				parentId: 'entry_tool_result_ZW50cnlfYTE_Y2FsbC0x',
+				sourceLeafId: 'entry_tool_result_ZW50cnlfYTE_Y2FsbC0x',
+				firstKeptEntryId: 'entry_a1',
+				summary: 'earlier context',
+				tokensBefore: 10,
+				usage: { input: 1, output: 1 },
+			},
+			// A second assistant left MID-STREAM: in-progress blocks Map, delta
+			// arrays, and blockIndexes Set survive the checkpoint boundary.
+			{ ...scope, id: 'r-a2-start', type: 'assistant_message_started', messageId: 'entry_a2', parentId: 'entry_compaction', turnId: 'turn-2', modelInfo: { api: 'test', provider: 'test', model: 'm' } },
+			{ ...scope, id: 'r-a2-think-start', type: 'assistant_reasoning_started', messageId: 'entry_a2', blockId: 'b-think', blockIndex: 0 },
+			{ ...scope, id: 'r-a2-think-delta', type: 'assistant_reasoning_delta', messageId: 'entry_a2', blockId: 'b-think', sequence: 0, delta: 'hmm ' },
+			{ ...scope, id: 'r-a2-text-start', type: 'assistant_text_started', messageId: 'entry_a2', blockId: 'b-text2', blockIndex: 1 },
+			{ ...scope, id: 'r-a2-text-delta', type: 'assistant_text_delta', messageId: 'entry_a2', blockId: 'b-text2', sequence: 0, delta: 'partial answer' },
+		] as ConversationRecord[];
+	}
+
+	it('round-trips the complex paths and stays reduction-equivalent (in-progress blocks, outcomes, attachments, compaction)', () => {
+		const state = createReducedInstanceState();
+		for (const record of complexRecords()) applyConversationRecord(state, record, '3');
+
+		// The zoo is actually present.
+		const conversation = state.conversations.get('conversation-1')!;
+		expect(conversation.inProgressMessages.size).toBe(1);
+		expect(conversation.inProgressMessages.get('entry_a2')?.blocks.size).toBe(2);
+		expect(state.settledSubmissions.size).toBe(1);
+		expect(conversation.entries.get('entry_user')).toMatchObject({ contentEvicted: true });
+
+		const encoded = encodeReducedState(state);
+		const decoded = decodeReducedState(encoded);
+		expect(encodeReducedState(decoded)).toBe(encoded);
+
+		// Continue the in-progress stream to completion on BOTH states — the
+		// decisive divergence check for a symmetric codec bug.
+		const tail: ConversationRecord[] = [
+			{ v: 1, conversationId: 'conversation-1', harness: 'default', session: 'default', timestamp: '2026-01-01T00:00:01.000Z', id: 'r-a2-think-done', type: 'assistant_reasoning_completed', messageId: 'entry_a2', blockId: 'b-think', deltaCount: 1 },
+			{ v: 1, conversationId: 'conversation-1', harness: 'default', session: 'default', timestamp: '2026-01-01T00:00:01.000Z', id: 'r-a2-text-done', type: 'assistant_text_completed', messageId: 'entry_a2', blockId: 'b-text2', deltaCount: 1 },
+			{ v: 1, conversationId: 'conversation-1', harness: 'default', session: 'default', timestamp: '2026-01-01T00:00:01.000Z', id: 'r-a2-done', type: 'assistant_message_completed', messageId: 'entry_a2', stopReason: 'stop', usage: { input: 1, output: 1 } },
+		] as ConversationRecord[];
+		for (const record of tail) {
+			applyConversationRecord(state, record, '4');
+			applyConversationRecord(decoded, record, '4');
+		}
+		expect(encodeReducedState(decoded)).toBe(encodeReducedState(state));
+	});
+
+	it('cold load through a mid-turn checkpoint equals a full replay of the complex stream', async () => {
+		const store = new InMemoryConversationStreamStore();
+		const writer = await writerWith(store);
+		// One record per batch so the 16-batch cadence lands a checkpoint while
+		// the second assistant is still mid-stream. The settle record is
+		// reducer-only here: the store rightly rejects submission-scoped records
+		// appended outside an admitted submission (settledSubmissions codec
+		// coverage lives in the round-trip test above).
+		for (const record of complexRecords()) {
+			if (record.type === 'submission_settled') continue;
+			await writer.append([record]);
+		}
+		const snapshot = await store.loadDerivedSnapshot(PATH);
+		expect(snapshot).not.toBeNull();
+
+		const viaSnapshot = await loadReducedConversationState({ store, path: PATH });
+		await store.saveDerivedSnapshot(PATH, { ...snapshot!, incarnation: 'invalidated' });
+		const viaFullReplay = await loadReducedConversationState({ store, path: PATH });
+		expect(encodeReducedState(viaSnapshot)).toBe(encodeReducedState(viaFullReplay));
+	});
+
+	it('throws on malformed data instead of guessing', () => {
+		expect(() => decodeReducedState('not json')).toThrow();
+		expect(() => decodeReducedState('{"recordsThroughOffset":"1"}')).toThrow();
+	});
+});
+
+describe('writer checkpointing (RUN-5218)', () => {
+	it('stamps recordIndex with the real durable batch offset', async () => {
+		const store = new InMemoryConversationStreamStore();
+		const writer = await writerWith(store);
+		const [creation, first, second] = chainedRecords(2);
+		const { offset: offsetA } = await writer.append([creation!, first!]);
+		const { offset: offsetB } = await writer.append([second!]);
+
+		const state = await writer.loadReducedState();
+		expect(state.recordIndex.get('record-created')?.offset).toBe(offsetA);
+		expect(state.recordIndex.get('record-0')?.offset).toBe(offsetA);
+		expect(state.recordIndex.get('record-1')?.offset).toBe(offsetB);
+	});
+
+	it('persists a checkpoint after enough batches, and cold load replays only the tail', async () => {
+		const store = new InMemoryConversationStreamStore();
+		const writer = await writerWith(store);
+		const records = chainedRecords(20);
+		await writer.append([records[0]!]);
+		for (const record of records.slice(1)) await writer.append([record]);
+
+		const snapshot = await store.loadDerivedSnapshot(PATH);
+		expect(snapshot).not.toBeNull();
+		expect(snapshot?.version).toBe(SNAPSHOT_VERSION);
+
+		// Cold load through the snapshot equals a full replay...
+		const viaSnapshot = await loadReducedConversationState({ store, path: PATH });
+		await store.saveDerivedSnapshot(PATH, { ...snapshot!, version: SNAPSHOT_VERSION + 1 });
+		const viaFullReplay = await loadReducedConversationState({ store, path: PATH });
+		expect(encodeReducedState(viaSnapshot)).toBe(encodeReducedState(viaFullReplay));
+
+		// ...and only reads batches after the snapshot offset.
+		await store.saveDerivedSnapshot(PATH, snapshot!);
+		const reads: string[] = [];
+		const originalRead = store.read.bind(store);
+		store.read = (path, options) => {
+			reads.push(options?.offset ?? '-1');
+			return originalRead(path, options);
+		};
+		await loadReducedConversationState({ store, path: PATH });
+		expect(reads.length).toBeGreaterThan(0);
+		expect(reads.every((offset) => offset !== '-1')).toBe(true);
+		expect(reads[0]).toBe(snapshot!.offset);
+	});
+
+	it('falls back to a full replay on corrupt data, version mismatch, or stale incarnation', async () => {
+		const store = new InMemoryConversationStreamStore();
+		const writer = await writerWith(store);
+		for (const record of chainedRecords(20)) await writer.append([record]);
+		const snapshot = await store.loadDerivedSnapshot(PATH);
+		expect(snapshot).not.toBeNull();
+		const clean = encodeReducedState(await loadReducedConversationState({ store, path: PATH }));
+
+		for (const tampered of [
+			{ ...snapshot!, data: '{"broken":' },
+			{ ...snapshot!, version: SNAPSHOT_VERSION + 1 },
+			{ ...snapshot!, incarnation: 'someone-else' },
+		]) {
+			await store.saveDerivedSnapshot(PATH, tampered);
+			const loaded = await loadReducedConversationState({ store, path: PATH });
+			expect(encodeReducedState(loaded)).toBe(clean);
+		}
+	});
+
+	it('a failing snapshot write never fails the append', async () => {
+		const store = new InMemoryConversationStreamStore();
+		store.saveDerivedSnapshot = async () => {
+			throw new Error('snapshot storage down');
+		};
+		const writer = await writerWith(store);
+		for (const record of chainedRecords(20)) {
+			await expect(writer.append([record])).resolves.toBeDefined();
+		}
+	});
+
+	it('delete drops the snapshot with the stream', async () => {
+		const store = new InMemoryConversationStreamStore();
+		const writer = await writerWith(store);
+		for (const record of chainedRecords(20)) await writer.append([record]);
+		expect(await store.loadDerivedSnapshot(PATH)).not.toBeNull();
+		await store.delete(PATH);
+		expect(await store.loadDerivedSnapshot(PATH)).toBeNull();
+	});
+});

--- a/packages/runtime/test/conversation-reducer.test.ts
+++ b/packages/runtime/test/conversation-reducer.test.ts
@@ -1039,6 +1039,41 @@ describe('reduceConversationRecords()', () => {
 		}]);
 	});
 
+	it('projects an evicted attachment as a text placeholder instead of image bytes', () => {
+		const created = required(canonicalConversation()[0]);
+		const attachment = { id: 'att_01', mimeType: 'image/png', size: 42, digest: 'sha256:test' };
+		const state = reduceConversationRecords(createReducedInstanceState(), [created, {
+			...scope,
+			id: 'record_attachment_user',
+			type: 'user_message',
+			timestamp: '2026-06-25T00:00:01.000Z',
+			messageId: 'entry_attachment',
+			parentId: null,
+			content: [
+				{ type: 'text', text: 'Inspect this image.' },
+				{ type: 'attachment', attachment },
+			],
+		}], '2');
+		const conversation = required(state.conversations.get('conv_01'));
+
+		expect(
+			buildConversationContext(conversation, {
+				resolveAttachment: () => ({ evicted: true }),
+			}),
+		).toMatchObject([{
+			role: 'user',
+			content: [
+				// The manifest marks the image evicted too, so it never claims an
+				// image is present while the inline block says it was evicted.
+				{
+					type: 'text',
+					text: 'Inspect this image.\n\n<attachments>\n<image id="att_01" mimeType="image/png" evicted />\n</attachments>',
+				},
+				{ type: 'text', text: '<image id="att_01" mimeType="image/png" evicted />' },
+			],
+		}]);
+	});
+
 	it('rejects implicit branching when an entry parent is not the active leaf', () => {
 		const state = reduceConversationRecords(createReducedInstanceState(), canonicalConversation(), '8');
 

--- a/packages/runtime/test/conversation-reducer.test.ts
+++ b/packages/runtime/test/conversation-reducer.test.ts
@@ -12,6 +12,7 @@ import {
 	applyConversationRecord,
 	buildConversationContext,
 	createReducedInstanceState,
+	EVICTED_CONTENT_PLACEHOLDER,
 	getActiveConversationPath,
 	reduceConversationRecords,
 } from '../src/conversation-reducer.ts';
@@ -503,7 +504,7 @@ describe('reduceConversationRecords()', () => {
 		expect(() => reduceConversationRecords(state, [accepted, invalid], '6')).toThrow(
 			ConversationRecordInvariantError,
 		);
-		expect(state.recordsById.has(accepted.id)).toBe(false);
+		expect(state.recordIndex.has(accepted.id)).toBe(false);
 		expect(
 			state.conversations.get('conv_01')?.inProgressMessages.get('entry_assistant')?.blocks.get(
 				'block_text',
@@ -1091,4 +1092,209 @@ describe('reduceConversationRecords()', () => {
 		).toThrow(ConversationRecordInvariantError);
 	});
 
+});
+
+describe('bounded conversation view (RUN-5210)', () => {
+	function toolConversation() {
+		const records = canonicalConversation();
+		const state = reduceConversationRecords(createReducedInstanceState(), records.slice(0, 4), '4');
+		applyConversationRecord(state, {
+			...scope,
+			id: 'record_tool_call',
+			type: 'assistant_tool_call',
+			timestamp: '2026-06-25T00:00:02.150Z',
+			messageId: 'entry_assistant',
+			blockId: 'block_tool',
+			blockIndex: 1,
+			toolCallId: 'call_expected',
+			name: 'lookup',
+			arguments: { query: 'weather' },
+		});
+		applyConversationRecord(state, {
+			...scope,
+			id: 'record_empty_text_complete',
+			type: 'assistant_text_completed',
+			timestamp: '2026-06-25T00:00:02.200Z',
+			messageId: 'entry_assistant',
+			blockId: 'block_text',
+			deltaCount: 0,
+		});
+		applyConversationRecord(state, {
+			...scope,
+			id: 'record_tool_assistant_complete',
+			type: 'assistant_message_completed',
+			timestamp: '2026-06-25T00:00:02.300Z',
+			messageId: 'entry_assistant',
+			stopReason: 'toolUse',
+			usage,
+		});
+		applyConversationRecord(state, {
+			...scope,
+			id: 'record_tool_outcome',
+			type: 'tool_outcome',
+			timestamp: '2026-06-25T00:00:02.400Z',
+			assistantMessageId: 'entry_assistant',
+			toolCallId: 'call_expected',
+			toolName: 'lookup',
+			isError: false,
+			content: [{ type: 'text', text: 'durable result' }],
+			durationMs: 42,
+		});
+		return state;
+	}
+
+	it('keeps no record bodies resident: the index carries offset + fingerprint only', () => {
+		const state = reduceConversationRecords(createReducedInstanceState(), canonicalConversation(), '8');
+
+		expect(state.recordIndex.size).toBe(8);
+		for (const entry of state.recordIndex.values()) {
+			expect(entry).toEqual({ offset: '8', hash: expect.any(String) });
+		}
+	});
+
+	it('skips an identical redelivery and rejects an id reused with different content', () => {
+		const records = canonicalConversation();
+		const state = reduceConversationRecords(createReducedInstanceState(), records, '8');
+		const user = required(records[1]);
+
+		expect(() => applyConversationRecord(state, user)).not.toThrow();
+		expect(() =>
+			applyConversationRecord(state, {
+				...user,
+				content: [{ type: 'text', text: 'Tampered' }],
+			} as ConversationRecord),
+		).toThrowError(
+			expect.objectContaining({
+				meta: expect.objectContaining({
+					reason: 'Record id "record_user" was reused with different content.',
+				}),
+			}),
+		);
+	});
+
+	it('consumes pending tool outcomes when their commit materializes the entries', () => {
+		const state = toolConversation();
+		const conversation = required(state.conversations.get('conv_01'));
+		expect(conversation.toolOutcomes.size).toBe(1);
+
+		const commit = {
+			...scope,
+			id: 'record_tool_commit',
+			type: 'tool_results_committed' as const,
+			timestamp: '2026-06-25T00:00:02.500Z',
+			assistantMessageId: 'entry_assistant',
+			parentId: 'entry_assistant',
+			outcomeIds: ['record_tool_outcome'],
+		};
+		applyConversationRecord(state, commit);
+		// Redelivery of the consumed commit stays idempotent via the index.
+		applyConversationRecord(state, commit);
+
+		expect(conversation.toolOutcomes.size).toBe(0);
+		expect(buildConversationContext(conversation)).toMatchObject([
+			{ role: 'user' },
+			{ role: 'assistant', stopReason: 'toolUse' },
+			{ role: 'toolResult', toolCallId: 'call_expected', content: [{ type: 'text', text: 'durable result' }] },
+		]);
+	});
+
+	it('retains settlement records whole for settlement reads', () => {
+		const state = reduceConversationRecords(createReducedInstanceState(), canonicalConversation(), '8');
+		const settled = {
+			...scope,
+			id: 'record_settled',
+			type: 'submission_settled' as const,
+			timestamp: '2026-06-25T00:00:03.000Z',
+			submissionId: 'submission_01',
+			outcome: 'completed' as const,
+		};
+		applyConversationRecord(state, settled);
+
+		expect(state.settledSubmissions.get('record_settled')).toEqual(settled);
+		expect(state.recordIndex.has('record_settled')).toBe(true);
+	});
+
+	it('evicts content before the compaction boundary and spares kept entries', () => {
+		const state = reduceConversationRecords(createReducedInstanceState(), canonicalConversation(), '8');
+		applyConversationRecord(state, {
+			...scope,
+			id: 'record_compaction',
+			type: 'compaction',
+			timestamp: '2026-06-25T00:00:03.000Z',
+			entryId: 'entry_compaction',
+			parentId: 'entry_assistant',
+			sourceLeafId: 'entry_assistant',
+			firstKeptEntryId: 'entry_assistant',
+			summary: 'Earlier context',
+			tokensBefore: 12,
+			usage,
+		});
+		const conversation = required(state.conversations.get('conv_01'));
+
+		const user = required(conversation.entries.get('entry_user'));
+		expect(user).toMatchObject({
+			type: 'message',
+			contentEvicted: true,
+			message: { content: [{ type: 'text', text: EVICTED_CONTENT_PLACEHOLDER }] },
+		});
+		const assistant = required(conversation.entries.get('entry_assistant'));
+		expect(assistant.type === 'message' && assistant.contentEvicted).toBeFalsy();
+		expect(assistant).toMatchObject({
+			message: { content: [{ type: 'text', text: 'Hi there' }] },
+		});
+		// The model context never sees the evicted entry: summary + kept + after.
+		expect(
+			projectConversationModelContextEntries(conversation).map((entry) => entry.sourceEntry.id),
+		).toEqual(['entry_compaction', 'entry_assistant']);
+		// Structure survives: the DAG still walks to the root.
+		expect(getActiveConversationPath(conversation).map((entry) => entry.id)).toEqual([
+			'entry_user',
+			'entry_assistant',
+			'entry_compaction',
+		]);
+	});
+
+	it('evicts tool-call arguments and tool output while keeping call identity', () => {
+		const state = toolConversation();
+		applyConversationRecord(state, {
+			...scope,
+			id: 'record_tool_commit',
+			type: 'tool_results_committed',
+			timestamp: '2026-06-25T00:00:02.500Z',
+			assistantMessageId: 'entry_assistant',
+			parentId: 'entry_assistant',
+			outcomeIds: ['record_tool_outcome'],
+		});
+		const conversation = required(state.conversations.get('conv_01'));
+		const leaf = required(conversation.activeLeafId ?? undefined);
+		applyConversationRecord(state, {
+			...scope,
+			id: 'record_compaction',
+			type: 'compaction',
+			timestamp: '2026-06-25T00:00:03.000Z',
+			entryId: 'entry_compaction',
+			parentId: leaf,
+			sourceLeafId: leaf,
+			firstKeptEntryId: leaf,
+			summary: 'Earlier context',
+			tokensBefore: 12,
+			usage,
+		});
+
+		const assistant = required(conversation.entries.get('entry_assistant'));
+		expect(assistant).toMatchObject({
+			contentEvicted: true,
+			message: {
+				content: expect.arrayContaining([
+					expect.objectContaining({ type: 'toolCall', id: 'call_expected', name: 'lookup', arguments: {} }),
+				]),
+			},
+		});
+		// The first-kept entry itself is spared: eviction is strictly-before.
+		const toolResult = required(conversation.entries.get(leaf));
+		expect(toolResult.type === 'message' && toolResult.contentEvicted).toBeFalsy();
+		expect(toolResult).toMatchObject({
+			message: { content: [{ type: 'text', text: 'durable result' }] },
+		});
+	});
 });

--- a/packages/runtime/test/conversation-window.test.ts
+++ b/packages/runtime/test/conversation-window.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import type { ConversationRecord } from '../src/conversation-records.ts';
+import { applyConversationRecord, createReducedInstanceState } from '../src/conversation-reducer.ts';
+import { projectConversationUi } from '../src/conversation-projections.ts';
+
+const scope = {
+	v: 1 as const,
+	conversationId: 'conv-1',
+	harness: 'default',
+	session: 'default',
+	timestamp: '2026-01-01T00:00:00.000Z',
+};
+
+// N user turns; turn `k` optionally becomes an assistant tool-use turn whose
+// tool result folds into it (group-boundary coverage).
+function conversationWith(turns: number, toolTurn?: number): ReturnType<typeof createReducedInstanceState> {
+	const state = createReducedInstanceState();
+	const records: ConversationRecord[] = [
+		{ ...scope, id: 'r-created', type: 'conversation_created', kind: 'root', affinityKey: 'a', createdAt: scope.timestamp },
+	];
+	let parentId: string | null = null;
+	for (let turn = 0; turn < turns; turn++) {
+		if (turn === toolTurn) {
+			records.push(
+				{ ...scope, id: `r-a-${turn}`, type: 'assistant_message_started', messageId: `entry_a_${turn}`, parentId, modelInfo: { api: 't', provider: 't', model: 'm' } },
+				{ ...scope, id: `r-a-${turn}-text-start`, type: 'assistant_text_started', messageId: `entry_a_${turn}`, blockId: 'b0', blockIndex: 0 },
+				{ ...scope, id: `r-a-${turn}-text-done`, type: 'assistant_text_completed', messageId: `entry_a_${turn}`, blockId: 'b0', deltaCount: 0 },
+				{ ...scope, id: `r-a-${turn}-call`, type: 'assistant_tool_call', messageId: `entry_a_${turn}`, blockId: 'b1', blockIndex: 1, toolCallId: `call-${turn}`, name: 'lookup', arguments: {} },
+				{ ...scope, id: `r-a-${turn}-done`, type: 'assistant_message_completed', messageId: `entry_a_${turn}`, stopReason: 'toolUse', usage: { input: 1, output: 1 } },
+				{ ...scope, id: `r-o-${turn}`, type: 'tool_outcome', assistantMessageId: `entry_a_${turn}`, toolCallId: `call-${turn}`, toolName: 'lookup', isError: false, content: [{ type: 'text', text: 'ok' }] },
+				{ ...scope, id: `r-c-${turn}`, type: 'tool_results_committed', assistantMessageId: `entry_a_${turn}`, parentId: `entry_a_${turn}`, outcomeIds: [`r-o-${turn}`] },
+			);
+			parentId = `entry_tool_result_${Buffer.from(`entry_a_${turn}`).toString('base64url')}_${Buffer.from(`call-${turn}`).toString('base64url')}`;
+			continue;
+		}
+		records.push({
+			...scope,
+			id: `r-u-${turn}`,
+			type: 'user_message',
+			messageId: `entry_u_${turn}`,
+			parentId,
+			content: [{ type: 'text', text: `turn ${turn}` }],
+		});
+		parentId = `entry_u_${turn}`;
+	}
+	for (const record of records) applyConversationRecord(state, record as ConversationRecord, '1');
+	return state;
+}
+
+function conversation(state: ReturnType<typeof createReducedInstanceState>) {
+	const value = state.conversations.get('conv-1');
+	if (!value) throw new Error('missing conversation');
+	return value;
+}
+
+describe('windowed history projection (RUN-5220)', () => {
+	it('serves the newest entries with a truncatedBefore cursor, and pages to genesis', () => {
+		const state = conversationWith(10);
+		const head = projectConversationUi(conversation(state), '9', { entryLimit: 4 });
+		expect(head.messages.map((m) => m.id)).toEqual([
+			'entry_u_6',
+			'entry_u_7',
+			'entry_u_8',
+			'entry_u_9',
+		]);
+		expect(head.truncatedBefore).toBe('entry_u_6');
+
+		const older = projectConversationUi(conversation(state), '9', {
+			entryLimit: 4,
+			beforeEntry: head.truncatedBefore,
+		});
+		expect(older.messages.map((m) => m.id)).toEqual([
+			'entry_u_2',
+			'entry_u_3',
+			'entry_u_4',
+			'entry_u_5',
+		]);
+		expect(older.truncatedBefore).toBe('entry_u_2');
+
+		const oldest = projectConversationUi(conversation(state), '9', {
+			entryLimit: 4,
+			beforeEntry: older.truncatedBefore,
+		});
+		expect(oldest.messages.map((m) => m.id)).toEqual(['entry_u_0', 'entry_u_1']);
+		expect(oldest.truncatedBefore).toBeUndefined();
+	});
+
+	it('never splits a tool-result run from its assistant: the boundary walks back', () => {
+		// Turn 5 is assistant+tool-result (2 path entries). A window that would
+		// start ON the tool-result entry must extend back to the assistant, and
+		// the folded tool output must be resolved inside the window.
+		const state = conversationWith(10, 5);
+		// Path: u0..u4, a5, toolresult5, u6..u9 = 11 entries. entryLimit 5 would
+		// start at toolresult5 — extension pulls in a5.
+		const head = projectConversationUi(conversation(state), '9', { entryLimit: 5 });
+		expect(head.messages.map((m) => m.id)).toEqual([
+			'entry_a_5',
+			'entry_u_6',
+			'entry_u_7',
+			'entry_u_8',
+			'entry_u_9',
+		]);
+		const assistant = head.messages[0];
+		const toolPart = assistant?.parts.find((part) => part.type === 'dynamic-tool');
+		expect(toolPart).toMatchObject({ state: 'output-available' });
+		expect(head.truncatedBefore).toBe('entry_a_5');
+	});
+
+	it('projects in-progress messages only on the head window', () => {
+		const state = conversationWith(6);
+		applyConversationRecord(state, {
+			...scope,
+			id: 'r-live',
+			type: 'assistant_message_started',
+			messageId: 'entry_live',
+			parentId: 'entry_u_5',
+			modelInfo: { api: 't', provider: 't', model: 'm' },
+		} as ConversationRecord, '2');
+
+		const head = projectConversationUi(conversation(state), '9', { entryLimit: 3 });
+		expect(head.messages.some((m) => m.id === 'entry_live')).toBe(true);
+
+		const older = projectConversationUi(conversation(state), '9', {
+			entryLimit: 3,
+			beforeEntry: head.truncatedBefore,
+		});
+		expect(older.messages.some((m) => m.id === 'entry_live')).toBe(false);
+	});
+
+	it('an unknown beforeEntry yields an empty terminal page, not an error', () => {
+		const state = conversationWith(4);
+		const page = projectConversationUi(conversation(state), '9', {
+			entryLimit: 3,
+			beforeEntry: 'entry_nonexistent',
+		});
+		expect(page.messages).toEqual([]);
+		expect(page.truncatedBefore).toBeUndefined();
+	});
+
+	it('an unwindowed projection is unchanged (back-compat)', () => {
+		const state = conversationWith(5);
+		const full = projectConversationUi(conversation(state), '9');
+		expect(full.messages).toHaveLength(5);
+		expect(full.truncatedBefore).toBeUndefined();
+	});
+});

--- a/packages/runtime/test/create-tools-export.test.ts
+++ b/packages/runtime/test/create-tools-export.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { createTools } from '../src/index.ts';
+import { createNoopSessionEnv } from './fixtures/session-env.ts';
+
+describe('createTools() root export', () => {
+	it('returns the standard sandbox tool surface without a task runner', () => {
+		const tools = createTools(createNoopSessionEnv());
+
+		expect(tools.map((tool) => tool.name)).toEqual([
+			'read',
+			'write',
+			'edit',
+			'bash',
+			'grep',
+			'glob',
+		]);
+	});
+
+	it('appends the task tool when the options provide a task runner', () => {
+		const tools = createTools(createNoopSessionEnv(), {
+			task: async () => ({ content: [], details: { taskId: 'task-1', session: 'session-1' } }),
+			subagents: {},
+		});
+
+		expect(tools.map((tool) => tool.name)).toEqual([
+			'read',
+			'write',
+			'edit',
+			'bash',
+			'grep',
+			'glob',
+			'task',
+		]);
+	});
+});

--- a/packages/runtime/test/direct-agent-request.test.ts
+++ b/packages/runtime/test/direct-agent-request.test.ts
@@ -1,0 +1,160 @@
+import {
+	type FauxProviderRegistration,
+	fauxAssistantMessage,
+	fauxToolCall,
+	registerFauxProvider,
+} from '@earendil-works/pi-ai/compat';
+import { afterEach, describe, expect, it } from 'vitest';
+import { InvalidRequestError } from '../src/errors.ts';
+import { defineAgent, defineTool } from '../src/index.ts';
+import { createFlueContext } from '../src/internal.ts';
+import { createDirectAgentSubmissionInput } from '../src/runtime/agent-submissions.ts';
+import { parseDirectAgentRequest } from '../src/runtime/schemas.ts';
+import { createNoopSessionEnv } from './fixtures/session-env.ts';
+
+function captureThrow(fn: () => unknown): unknown {
+	try {
+		fn();
+	} catch (error) {
+		return error;
+	}
+	throw new Error('Expected the call to throw.');
+}
+
+describe('parseDirectAgentRequest()', () => {
+	it('separates a client-supplied submissionId from a user message', () => {
+		const result = parseDirectAgentRequest({
+			kind: 'user',
+			body: 'Hello.',
+			submissionId: 'client-submission-1',
+		});
+
+		expect(result.submissionId).toBe('client-submission-1');
+		expect(result.message).toEqual({ kind: 'user', body: 'Hello.' });
+	});
+
+	it('separates a client-supplied submissionId from a signal message', () => {
+		const result = parseDirectAgentRequest({
+			kind: 'signal',
+			type: 'calendar_event',
+			body: 'The meeting moved.',
+			submissionId: 'client-submission-2',
+		});
+
+		expect(result.submissionId).toBe('client-submission-2');
+		expect(result.message).toEqual({
+			kind: 'signal',
+			type: 'calendar_event',
+			body: 'The meeting moved.',
+		});
+	});
+
+	it('omits submissionId entirely when the body does not carry one', () => {
+		const result = parseDirectAgentRequest({ kind: 'user', body: 'Hello.' });
+
+		expect(result.message).toEqual({ kind: 'user', body: 'Hello.' });
+		expect('submissionId' in result).toBe(false);
+	});
+
+	// An invalid submissionId must reject the request, not fall back to the
+	// plain message parse: silently dropping the id makes the server mint a
+	// fresh one per retry, admitting the duplicate turn the stable id prevents.
+	it('rejects an empty-string submissionId with the shared 400 error', () => {
+		const thrown = captureThrow(() =>
+			parseDirectAgentRequest({ kind: 'user', body: 'Hello.', submissionId: '' }),
+		);
+
+		expect(thrown).toBeInstanceOf(InvalidRequestError);
+		expect(thrown).toMatchObject({ status: 400, type: 'invalid_request' });
+	});
+
+	it('rejects a non-string submissionId with the shared 400 error', () => {
+		const thrown = captureThrow(() =>
+			parseDirectAgentRequest({ kind: 'user', body: 'Hello.', submissionId: 7 }),
+		);
+
+		expect(thrown).toBeInstanceOf(InvalidRequestError);
+		expect(thrown).toMatchObject({ status: 400, type: 'invalid_request' });
+	});
+
+	it('still rejects a malformed message body through the shared message parse', () => {
+		const thrown = captureThrow(() => parseDirectAgentRequest({ kind: 'user' }));
+
+		expect(thrown).toBeInstanceOf(InvalidRequestError);
+		expect(thrown).toMatchObject({ status: 400 });
+	});
+});
+
+describe('createDirectAgentSubmissionInput()', () => {
+	const message = { kind: 'user', body: 'Hello.' } as const;
+
+	it('uses the client-supplied submissionId verbatim', () => {
+		const input = createDirectAgentSubmissionInput({
+			agent: 'assistant',
+			id: 'instance-1',
+			message,
+			submissionId: 'client-submission-3',
+		});
+
+		expect(input.kind).toBe('direct');
+		expect(input.submissionId).toBe('client-submission-3');
+	});
+
+	it('mints a UUID when no submissionId is supplied', () => {
+		const input = createDirectAgentSubmissionInput({
+			agent: 'assistant',
+			id: 'instance-1',
+			message,
+		});
+
+		expect(input.submissionId).toMatch(
+			/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+		);
+	});
+});
+
+describe('custom tool run context', () => {
+	const providers: FauxProviderRegistration[] = [];
+
+	afterEach(() => {
+		for (const provider of providers.splice(0)) provider.unregister();
+	});
+
+	it("carries the model's tool-call id into the tool's run context", async () => {
+		const provider = registerFauxProvider({
+			provider: `direct-agent-request-test-${crypto.randomUUID()}`,
+		});
+		providers.push(provider);
+		const toolCallId = `tool:${crypto.randomUUID()}`;
+		provider.setResponses([
+			fauxAssistantMessage(fauxToolCall('lookup', {}, { id: toolCallId }), {
+				stopReason: 'toolUse',
+			}),
+			fauxAssistantMessage('Done.'),
+		]);
+		let receivedToolCallId: string | undefined;
+		const lookup = defineTool({
+			name: 'lookup',
+			description: 'Look up a value.',
+			run(context) {
+				receivedToolCallId = context.toolCallId;
+				return 'ok';
+			},
+		});
+		const harness = await createFlueContext({
+			id: 'direct-agent-request-instance',
+			env: {},
+			agentConfig: { resolveModel: () => provider.getModel() },
+			createDefaultEnv: async () => createNoopSessionEnv(),
+		}).initializeRootHarness(
+			defineAgent(() => ({
+				model: `${provider.getModel().provider}/${provider.getModel().id}`,
+				tools: [lookup],
+			})),
+		);
+
+		await (await harness.session()).prompt('Use the tool.');
+
+		expect(receivedToolCallId).toBe(toolCallId);
+	});
+});

--- a/packages/runtime/test/node-agent-coordinator.test.ts
+++ b/packages/runtime/test/node-agent-coordinator.test.ts
@@ -25,6 +25,10 @@ import { agentStreamPath } from '../src/runtime/event-stream-store.ts';
 import { handleAgentConversationRead } from '../src/runtime/handle-conversation-routes.ts';
 import type { CreateAgentContextFn } from '../src/runtime/handle-agent.ts';
 import { generateSessionAffinityKey } from '../src/runtime/ids.ts';
+import {
+	createRuntimeActivityGate,
+	type RuntimeActivityGate,
+} from '../src/runtime/runtime-activity-gate.ts';
 import { defineTool } from '../src/tool.ts';
 import { createNoopSessionEnv } from './fixtures/session-env.ts';
 
@@ -177,6 +181,7 @@ async function createFauxCoordinator(
 	dbPath: string,
 	provider: FauxProviderRegistration,
 	durability?: { maxAttempts?: number; timeoutMs?: number },
+	activityGate?: RuntimeActivityGate,
 ): Promise<{ coordinator: NodeAgentCoordinator; executionStore: AgentExecutionStore }> {
 	const adapter = sqlite(dbPath);
 	await adapter.migrate?.();
@@ -191,6 +196,7 @@ async function createFauxCoordinator(
 		createContext: makeFauxCreateContext(provider),
 		conversationStreamStore,
 		attachmentStore,
+		activityGate,
 	});
 	return { coordinator, executionStore };
 }
@@ -1696,6 +1702,68 @@ describe('NodeAgentCoordinator', () => {
 			// Admission is fire-and-forget; wait for both to settle durably.
 			await coordinator.waitForIdle();
 			expect(await executionStore.submissions.hasUnsettledSubmissions()).toBe(false);
+		});
+
+		it('releases activity leases when concurrent retries use the same submission id', async () => {
+			const dbPath = createTempDbPath();
+			const provider = createFauxProvider();
+			provider.setResponses([fauxAssistantMessage('One reply.')]);
+			const activityGate = createRuntimeActivityGate();
+			const { coordinator } = await createFauxCoordinator(
+				dbPath,
+				provider,
+				undefined,
+				activityGate,
+			);
+			const admit = coordinator.createAdmission('assistant', 'instance-1');
+
+			const [first, retry] = await Promise.all([
+				admit({ kind: 'user', body: 'Hello' }, 'stable-submission'),
+				admit({ kind: 'user', body: 'Hello' }, 'stable-submission'),
+			]);
+			await coordinator.waitForIdle();
+			activityGate.pause();
+			let idle = false;
+			const waiting = activityGate.waitForIdle().then(() => {
+				idle = true;
+			});
+			await Promise.resolve();
+
+			expect(first.submissionId).toBe('stable-submission');
+			expect(retry.submissionId).toBe('stable-submission');
+			expect(idle).toBe(true);
+			await waiting;
+		});
+
+		it('releases the activity lease when a settled submission is replayed', async () => {
+			const dbPath = createTempDbPath();
+			const provider = createFauxProvider();
+			provider.setResponses([fauxAssistantMessage('One reply.')]);
+			const activityGate = createRuntimeActivityGate();
+			const { coordinator } = await createFauxCoordinator(
+				dbPath,
+				provider,
+				undefined,
+				activityGate,
+			);
+			const admit = coordinator.createAdmission('assistant', 'instance-1');
+
+			await admit({ kind: 'user', body: 'Hello' }, 'settled-submission');
+			await coordinator.waitForIdle();
+			const replay = await admit(
+				{ kind: 'user', body: 'Hello' },
+				'settled-submission',
+			);
+			activityGate.pause();
+			let idle = false;
+			const waiting = activityGate.waitForIdle().then(() => {
+				idle = true;
+			});
+			await Promise.resolve();
+
+			expect(replay.submissionId).toBe('settled-submission');
+			expect(idle).toBe(true);
+			await waiting;
 		});
 	});
 

--- a/packages/runtime/test/prompt-frame.test.ts
+++ b/packages/runtime/test/prompt-frame.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+import { defineAgentProfile, resolveAgentProfile } from '../src/agent-definition.ts';
+import { discoverSessionContext } from '../src/context.ts';
+import type { SessionEnv } from '../src/types.ts';
+
+function createEnv({
+	cwd = '/repo',
+	files = {},
+}: { cwd?: string; files?: Record<string, string> } = {}): SessionEnv {
+	const normalize = (path: string) => {
+		const segments: string[] = [];
+		for (const segment of path.split('/')) {
+			if (!segment || segment === '.') continue;
+			if (segment === '..') segments.pop();
+			else segments.push(segment);
+		}
+		return `/${segments.join('/')}`;
+	};
+	const resolvePath = (path: string) => normalize(path.startsWith('/') ? path : `${cwd}/${path}`);
+
+	return {
+		cwd,
+		resolvePath,
+		exec: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
+		readFile: async (path) => {
+			const content = files[resolvePath(path)];
+			if (content === undefined) throw new Error(`missing file: ${path}`);
+			return content;
+		},
+		readFileBuffer: async () => new Uint8Array(),
+		writeFile: async () => {},
+		stat: async (path) => {
+			const resolved = resolvePath(path);
+			return {
+				isFile: Object.hasOwn(files, resolved),
+				isDirectory: Object.keys(files).some((file) => file.startsWith(`${resolved}/`)),
+				isSymbolicLink: false,
+				size: 0,
+				mtime: new Date(0),
+			};
+		},
+		readdir: async (path) => {
+			const resolved = resolvePath(path);
+			const entries = new Set<string>();
+			for (const file of Object.keys(files)) {
+				if (!file.startsWith(`${resolved}/`)) continue;
+				const entry = file.slice(resolved.length + 1).split('/')[0];
+				if (entry) entries.add(entry);
+			}
+			return [...entries];
+		},
+		exists: async (path) => {
+			const resolved = resolvePath(path);
+			return (
+				Object.hasOwn(files, resolved) ||
+				Object.keys(files).some((file) => file.startsWith(`${resolved}/`))
+			);
+		},
+		mkdir: async () => {},
+		rm: async () => {},
+	};
+}
+
+const workspaceFiles = {
+	'/repo/AGENTS.md': 'Repository conventions live here.',
+	'/repo/.agents/skills/review/SKILL.md':
+		'---\nname: review\ndescription: Review workspace changes.\n---\nRead the workspace checklist.',
+};
+
+describe('promptFrame profile resolution', () => {
+	it('accepts promptFrame: "none" in an agent profile', () => {
+		expect(defineAgentProfile({ promptFrame: 'none' }).promptFrame).toBe('none');
+	});
+
+	it('rejects an unknown promptFrame value', () => {
+		expect(() => defineAgentProfile({ promptFrame: 'minimal' as never })).toThrow(
+			/requires a valid agent profile/,
+		);
+	});
+
+	it('lets the runtime config promptFrame override the profile', () => {
+		const resolved = resolveAgentProfile({
+			promptFrame: 'none',
+			profile: { promptFrame: 'full' },
+		});
+
+		expect(resolved.promptFrame).toBe('none');
+	});
+
+	it('inherits the profile promptFrame when the runtime config omits it', () => {
+		const resolved = resolveAgentProfile({ profile: { promptFrame: 'none' } });
+
+		expect(resolved.promptFrame).toBe('none');
+	});
+
+	it('leaves promptFrame unset when neither layer supplies it', () => {
+		expect(resolveAgentProfile({}).promptFrame).toBeUndefined();
+	});
+});
+
+describe('discoverSessionContext() promptFrame', () => {
+	it('composes the full workspace frame by default', async () => {
+		const env = createEnv({ files: workspaceFiles });
+
+		const context = await discoverSessionContext(env, 'You are the app.');
+
+		// The default frame carries framework contributions beyond the
+		// instructions — this is the baseline 'none' must strip.
+		expect(context.systemPrompt).toContain('You are the app.');
+		expect(context.systemPrompt).toContain('Repository conventions live here.');
+		expect(context.systemPrompt).toContain('Available Skills');
+		expect(context.systemPrompt).not.toBe('You are the app.');
+	});
+
+	it("makes the instructions the entire system prompt under 'none' while still discovering skills", async () => {
+		const env = createEnv({ files: workspaceFiles });
+
+		const context = await discoverSessionContext(env, 'You are the app.', [], 'none');
+
+		// Nothing framework-owned may leak in: no preamble, AGENTS.md, skills
+		// catalog, date, cwd, or directory listing.
+		expect(context.systemPrompt).toBe('You are the app.');
+		// Skills stay discovered and registered so activate_skill keeps working.
+		expect(Object.keys(context.skills)).toEqual(['review']);
+	});
+
+	it("returns an empty system prompt under 'none' when the profile has no instructions", async () => {
+		const env = createEnv({ files: workspaceFiles });
+
+		const context = await discoverSessionContext(env, undefined, [], 'none');
+
+		expect(context.systemPrompt).toBe('');
+	});
+});

--- a/packages/runtime/test/retryable-model-error.test.ts
+++ b/packages/runtime/test/retryable-model-error.test.ts
@@ -1,0 +1,60 @@
+import type { AssistantMessage } from '@earendil-works/pi-ai';
+import { describe, expect, it } from 'vitest';
+import { isRetryableModelError } from '../src/submission-state.ts';
+
+function assistantError(
+	errorMessage: string,
+	stopReason: AssistantMessage['stopReason'] = 'error',
+): AssistantMessage {
+	return {
+		role: 'assistant',
+		content: [{ type: 'text', text: 'partial output' }],
+		api: 'test' as any,
+		provider: 'test',
+		model: 'test-model',
+		usage: {
+			input: 100,
+			output: 20,
+			cacheRead: 0,
+			cacheWrite: 0,
+			totalTokens: 0,
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+		},
+		stopReason,
+		errorMessage,
+		timestamp: Date.now(),
+	};
+}
+
+describe('isRetryableModelError()', () => {
+	it('treats a bare "Provider finish_reason: error" as retryable', () => {
+		expect(isRetryableModelError(assistantError('Provider finish_reason: error'))).toBe(true);
+	});
+
+	it('treats punctuation or a parenthetical after the bare reason as retryable', () => {
+		expect(isRetryableModelError(assistantError('Provider finish_reason: error.'))).toBe(true);
+		expect(
+			isRetryableModelError(assistantError('Provider finish_reason: error (upstream died)')),
+		).toBe(true);
+	});
+
+	it('matches the bare reason case-insensitively', () => {
+		expect(isRetryableModelError(assistantError('PROVIDER FINISH_REASON: ERROR'))).toBe(true);
+	});
+
+	it('keeps qualified finish reasons terminal', () => {
+		expect(isRetryableModelError(assistantError('Provider finish_reason: error_quota'))).toBe(
+			false,
+		);
+		expect(
+			isRetryableModelError(assistantError('Provider finish_reason: error-content-filter')),
+		).toBe(false);
+		expect(isRetryableModelError(assistantError('Provider finish_reason: errored'))).toBe(false);
+	});
+
+	it('never retries a message whose stopReason is not error', () => {
+		expect(
+			isRetryableModelError(assistantError('Provider finish_reason: error', 'stop')),
+		).toBe(false);
+	});
+});

--- a/packages/runtime/test/session-image-eviction.test.ts
+++ b/packages/runtime/test/session-image-eviction.test.ts
@@ -1,0 +1,108 @@
+import {
+	type FauxProviderRegistration,
+	fauxAssistantMessage,
+	registerFauxProvider,
+} from '@earendil-works/pi-ai/compat';
+import { afterEach, describe, expect, it } from 'vitest';
+import { defineAgent } from '../src/index.ts';
+import { createFlueContext } from '../src/internal.ts';
+import { createNoopSessionEnv } from './fixtures/session-env.ts';
+
+// The image bytes are incidental plumbing, not the behavior under test: each
+// image only needs distinct, valid base64 so we can tell which survived in the
+// provider request. `evicted` images have no bytes there at all.
+const bytes = (label: string): string => Buffer.from(label).toString('base64');
+
+const image = (label: string) =>
+	({ type: 'image' as const, data: bytes(label), mimeType: 'image/png' });
+
+const providers: FauxProviderRegistration[] = [];
+afterEach(() => {
+	for (const provider of providers.splice(0)) provider.unregister();
+});
+
+function createProvider(): FauxProviderRegistration {
+	const provider = registerFauxProvider({
+		provider: `session-image-eviction-test-${crypto.randomUUID()}`,
+		models: [{ id: 'reviewer' }],
+	});
+	providers.push(provider);
+	return provider;
+}
+
+function createContext(provider: FauxProviderRegistration) {
+	return createFlueContext({
+		id: 'session-image-eviction-instance',
+		env: {},
+		agentConfig: {
+			resolveModel: (specifier) =>
+				specifier ? provider.getModel(specifier.slice(specifier.indexOf('/') + 1)) : undefined,
+		},
+		createDefaultEnv: async () => createNoopSessionEnv(),
+	});
+}
+
+describe('image-memory eviction', () => {
+	it('evicts all but the newest maxImages images from the provider request when a session exceeds the cap', async () => {
+		const provider = createProvider();
+		let lastTurnMessages: unknown[] = [];
+		provider.setResponses([
+			fauxAssistantMessage('one'),
+			fauxAssistantMessage('two'),
+			(context) => {
+				lastTurnMessages = context.messages;
+				return fauxAssistantMessage('three');
+			},
+		]);
+		const harness = await createContext(provider).initializeRootHarness(
+			// compaction:false isolates eviction from token-driven image dropping.
+			defineAgent(() => ({
+				model: `${provider.getModel().provider}/reviewer`,
+				compaction: false,
+				imageMemory: { maxImages: 2 },
+			})),
+		);
+		const session = await harness.session();
+
+		await session.prompt('first', { images: [image('image-one')] });
+		await session.prompt('second', { images: [image('image-two')] });
+		await session.prompt('third', { images: [image('image-three')] });
+
+		const json = JSON.stringify(lastTurnMessages);
+		// Oldest image is evicted: its bytes are gone, replaced by a placeholder.
+		expect(json).not.toContain(bytes('image-one'));
+		expect(json).toContain('evicted />');
+		// The newest two images are still sent to the model as real bytes.
+		expect(json).toContain(bytes('image-two'));
+		expect(json).toContain(bytes('image-three'));
+	});
+
+	it('keeps the three newest images by default when no imageMemory cap is configured', async () => {
+		const provider = createProvider();
+		let lastTurnMessages: unknown[] = [];
+		provider.setResponses([
+			fauxAssistantMessage('1'),
+			fauxAssistantMessage('2'),
+			fauxAssistantMessage('3'),
+			(context) => {
+				lastTurnMessages = context.messages;
+				return fauxAssistantMessage('4');
+			},
+		]);
+		const harness = await createContext(provider).initializeRootHarness(
+			defineAgent(() => ({ model: `${provider.getModel().provider}/reviewer`, compaction: false })),
+		);
+		const session = await harness.session();
+
+		await session.prompt('a', { images: [image('img-a')] });
+		await session.prompt('b', { images: [image('img-b')] });
+		await session.prompt('c', { images: [image('img-c')] });
+		await session.prompt('d', { images: [image('img-d')] });
+
+		const json = JSON.stringify(lastTurnMessages);
+		expect(json).not.toContain(bytes('img-a')); // oldest evicted at the default cap of 3
+		expect(json).toContain(bytes('img-b'));
+		expect(json).toContain(bytes('img-c'));
+		expect(json).toContain(bytes('img-d'));
+	});
+});

--- a/packages/runtime/test/subagent-recovery.test.ts
+++ b/packages/runtime/test/subagent-recovery.test.ts
@@ -112,9 +112,18 @@ function assistantText(
 function taskOutcomes(
 	conversation: Awaited<ReturnType<ConversationRecordWriter['getConversation']>>,
 ) {
-	return [...(conversation?.toolOutcomes.values() ?? [])].filter(
-		(outcome) => outcome.toolName === 'task',
-	);
+	// Committed outcomes live on the materialized tool-result entries;
+	// `toolOutcomes` holds only outcomes still awaiting their commit (RUN-5210).
+	return [...(conversation?.entries.values() ?? [])].flatMap((entry) => {
+		if (entry.type !== 'message') return [];
+		const message = entry.message as {
+			role?: string;
+			toolName?: string;
+			isError?: boolean;
+			content: Array<{ type: string; text: string }>;
+		};
+		return message.role === 'toolResult' && message.toolName === 'task' ? [message] : [];
+	});
 }
 
 describe('subagent task recovery', () => {

--- a/packages/runtime/test/tool.test.ts
+++ b/packages/runtime/test/tool.test.ts
@@ -124,10 +124,13 @@ describe('defineTool()', () => {
 			run,
 		});
 
-		await expect(validateAndRunTool(tool, {})).resolves.toBe(10);
+		await expect(
+			validateAndRunTool(tool, { input: {}, toolCallId: 'tool-call-defaults' }),
+		).resolves.toBe(10);
 		expect(run).toHaveBeenCalledWith({
 			input: { limit: 10 },
 			signal: undefined,
+			toolCallId: 'tool-call-defaults',
 		});
 	});
 
@@ -145,7 +148,12 @@ describe('defineTool()', () => {
 			run,
 		});
 
-		await expect(validateAndRunTool(tool, { orderId: 'invoice_7' })).rejects.toMatchObject({
+		await expect(
+			validateAndRunTool(tool, {
+				input: { orderId: 'invoice_7' },
+				toolCallId: 'tool-call-invalid-input',
+			}),
+		).rejects.toMatchObject({
 			type: 'tool_input_validation',
 			meta: {
 				tool: 'lookup',
@@ -163,7 +171,9 @@ describe('defineTool()', () => {
 			run: async () => 2,
 		});
 
-		await expect(validateAndRunTool(tool, {})).resolves.toEqual({ count: 2 });
+		await expect(
+			validateAndRunTool(tool, { input: {}, toolCallId: 'tool-call-output-transform' }),
+		).resolves.toEqual({ count: 2 });
 	});
 
 	it('throws structured issues when output validation fails', async () => {
@@ -174,7 +184,9 @@ describe('defineTool()', () => {
 			run: async () => 'two' as never,
 		});
 
-		await expect(validateAndRunTool(tool, {})).rejects.toMatchObject({
+		await expect(
+			validateAndRunTool(tool, { input: {}, toolCallId: 'tool-call-invalid-output' }),
+		).rejects.toMatchObject({
 			type: 'tool_output_validation',
 			meta: { tool: 'count', issues: [expect.objectContaining({ message: expect.any(String) })] },
 		});
@@ -188,7 +200,9 @@ describe('defineTool()', () => {
 			run: async () => undefined as never,
 		});
 
-		await expect(validateAndRunTool(tool)).rejects.toMatchObject({
+		await expect(
+			validateAndRunTool(tool, { toolCallId: 'tool-call-undefined-output' }),
+		).rejects.toMatchObject({
 			type: 'tool_output_serialization',
 			meta: { tool: 'undefined_output' },
 		});
@@ -201,7 +215,9 @@ describe('defineTool()', () => {
 			run: async () => ({ kept: true, discarded: undefined }) as never,
 		});
 
-		await expect(validateAndRunTool(tool, {})).resolves.toEqual({ kept: true });
+		await expect(
+			validateAndRunTool(tool, { input: {}, toolCallId: 'tool-call-optional-property' }),
+		).resolves.toEqual({ kept: true });
 	});
 
 	it('returns a detached JSON snapshot of output', async () => {
@@ -212,7 +228,10 @@ describe('defineTool()', () => {
 			run: async () => output,
 		});
 
-		const result = await validateAndRunTool(tool, {});
+		const result = await validateAndRunTool(tool, {
+			input: {},
+			toolCallId: 'tool-call-detached-output',
+		});
 		output.nested.count = 2;
 
 		expect(result).toEqual({ nested: { count: 1 } });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -220,7 +220,11 @@ export function createFlueClient(options: CreateFlueClientOptions): FlueClient {
 				rewriteSnapshotAttachmentUrls(
 					await http.json<FlueConversationSnapshot>({
 						path: `/agents/${encodeURIComponent(name)}/${encodeURIComponent(id)}`,
-						query: { view: 'history' },
+						query: {
+							view: 'history',
+							...(opts.entryLimit !== undefined ? { entryLimit: String(opts.entryLimit) } : {}),
+							...(opts.beforeEntry !== undefined ? { beforeEntry: opts.beforeEntry } : {}),
+						},
 						signal: opts.signal,
 					}),
 					http,

--- a/packages/sdk/src/public/conversation.ts
+++ b/packages/sdk/src/public/conversation.ts
@@ -126,6 +126,12 @@ export interface FlueConversationSnapshot {
 	offset: string;
 	messages: FlueConversationMessage[];
 	settlements: FlueConversationSettlement[];
+	/**
+	 * Present when older history exists before this window: the server bounds
+	 * history responses to a window of the newest entries (RUN-5220). Fetch the
+	 * next older page with `history({ beforeEntry: truncatedBefore })`.
+	 */
+	truncatedBefore?: string;
 }
 
 /** Live materialized conversation maintained by `observe()`. */
@@ -138,4 +144,8 @@ export interface FlueConversationState {
 /** Options for one `client.agents.history()` read. */
 export interface FlueConversationHistoryOptions {
 	signal?: AbortSignal;
+	/** Window size in active-path entries; the server default is 1000 (RUN-5220). */
+	entryLimit?: number;
+	/** Older-page cursor: return history strictly before this entry id. */
+	beforeEntry?: string;
 }

--- a/packages/sdk/src/public/invoke.ts
+++ b/packages/sdk/src/public/invoke.ts
@@ -28,6 +28,12 @@ export type DeliveredMessage =
 /** Options for one direct-agent prompt. */
 export interface AgentPromptOptions {
 	message: DeliveredMessage;
+	/**
+	 * Client-minted idempotency key for this submission. The server admits it
+	 * insert-or-ignore, so replaying the same id with the same payload is a
+	 * no-op instead of a duplicate turn. Absent, the server mints its own.
+	 */
+	submissionId?: string;
 	signal?: AbortSignal;
 }
 
@@ -53,7 +59,11 @@ export async function sendAgent(
 	return http.json<AgentSendResult>({
 		method: 'POST',
 		path: `/agents/${encodeURIComponent(name)}/${encodeURIComponent(id)}`,
-		body: options.message,
+		// The wire wants submissionId as a top-level sibling of the message fields.
+		body:
+			options.submissionId === undefined
+				? options.message
+				: { ...options.message, submissionId: options.submissionId },
 		signal: options.signal,
 	});
 }

--- a/packages/sdk/test/client.test.ts
+++ b/packages/sdk/test/client.test.ts
@@ -57,6 +57,26 @@ describe('createFlueClient', () => {
 				attachments: [{ type: 'image', data: 'YWJj', mimeType: 'image/png' }],
 			});
 		});
+
+		it('threads a client-supplied submissionId as a sibling of the message fields', async () => {
+			const seen: Request[] = [];
+			const client = createFlueClient({
+				baseUrl: 'https://flue.test',
+				fetch: async (input, init) => {
+					seen.push(new Request(input, init));
+					return Response.json({ streamUrl: 'https://flue.test/stream', offset: '-1' });
+				},
+			});
+			await client.agents.send('hello', 'inst-1', {
+				message: { kind: 'user', body: 'Hello' },
+				submissionId: 'send-1',
+			});
+			expect(await seen[0]?.json()).toEqual({
+				kind: 'user',
+				body: 'Hello',
+				submissionId: 'send-1',
+			});
+		});
 	});
 
 	describe('agents.history() attachment urls', () => {

--- a/scripts/prepare-publish.mjs
+++ b/scripts/prepare-publish.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * Prepares publish artifacts for the core packages (`@flue/cli`,
- * `@flue/runtime`, and `@flue/sdk`):
+ * Prepares publish artifacts for the fork packages (`@flue/cli`,
+ * `@flue/runtime`, `@flue/sdk`, and `@flue/react`):
  * - Copies `apps/docs/src/content/docs` into `<package>/docs` for agent consumption.
  * - Syncs the root README.md into each package.
  * - Embeds the `flue docs` catalog into the installable Flue skill.
@@ -9,7 +9,8 @@
  * Run from anywhere: `node scripts/prepare-publish.mjs`
  */
 import { execFile } from 'node:child_process';
-import { copyFile, cp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { access, copyFile, cp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
@@ -22,7 +23,7 @@ const skillPath = join(repoRoot, 'skills/flue/SKILL.md');
 const catalogStart = '<!-- flue-docs-catalog:start -->';
 const catalogEnd = '<!-- flue-docs-catalog:end -->';
 
-const PUBLISH_ARTIFACT_PACKAGES = new Set(['@flue/cli', '@flue/runtime', '@flue/sdk']);
+const PUBLISH_ARTIFACT_PACKAGES = new Set(['@flue/cli', '@flue/runtime', '@flue/sdk', '@flue/react']);
 
 export function embedDocsCatalog(skillSource, catalog) {
 	const start = skillSource.indexOf(catalogStart);
@@ -62,7 +63,13 @@ export async function preparePublishArtifacts() {
 		}
 
 		await cp(docsSource, docsTarget, { recursive: true });
-		await copyFile(readmeSource, join(packageRoot, 'README.md'));
+
+		const packageReadme = join(packageRoot, 'README.md');
+		try {
+			await access(packageReadme, constants.F_OK);
+		} catch {
+			await copyFile(readmeSource, packageReadme);
+		}
 
 		console.error(`[flue] Prepared publish artifacts for ${manifest.name}`);
 	}

--- a/scripts/publish-fork.mjs
+++ b/scripts/publish-fork.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Publishes the four forked Flue packages to GitHub Packages under the
+ * @argonavis-labs scope.
+ *
+ * Run after `pnpm install`, `build`, `test`, and `prepare-publish`.
+ *
+ * The script rewrites each package's `name` to `@argonavis-labs/flue-*`,
+ * appends a fork prerelease suffix to the version, and rewrites internal
+ * `workspace:*` references to npm aliases that keep the original `@flue/*`
+ * import specifiers resolving inside consumers.
+ */
+import { execFile } from 'node:child_process';
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const registry = process.env.NPM_CONFIG_REGISTRY || 'https://npm.pkg.github.com';
+const forkScope = '@argonavis-labs';
+const forkPrefix = 'flue-';
+
+const packages = [
+	{ base: 'runtime', oldName: '@flue/runtime' },
+	{ base: 'sdk', oldName: '@flue/sdk' },
+	{ base: 'react', oldName: '@flue/react' },
+	{ base: 'cli', oldName: '@flue/cli' },
+];
+
+const oldNameToBase = new Map(packages.map((p) => [p.oldName, p.base]));
+const baseToNewName = new Map(packages.map((p) => [p.base, `${forkScope}/${forkPrefix}${p.base}`]));
+
+async function gitShortSha() {
+	const { stdout } = await execFileAsync('git', ['rev-parse', '--short=8', 'HEAD'], { cwd: repoRoot });
+	return stdout.trim();
+}
+
+function forkVersion(baseVersion, sha) {
+	// Strip any existing fork prerelease suffix so re-runs and manual bumps are
+	// deterministic and do not accumulate `...-argonavis.gsha-argonavis.gsha`.
+	const clean = baseVersion.replace(/-argonavis\.g?[a-f0-9]+$/i, '');
+	// Prefix the sha with git's conventional `g`: an all-digit sha with a
+	// leading zero would otherwise form a numeric prerelease identifier with a
+	// leading zero, which is invalid semver and rejected by npm.
+	return `${clean}-argonavis.g${sha}`;
+}
+
+async function isPublished(name, version) {
+	try {
+		await execFileAsync('npm', ['view', `${name}@${version}`, 'version', '--registry', registry], {
+			cwd: repoRoot,
+			env: { ...process.env, npm_config_registry: registry },
+		});
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+async function publishPackage(pkg, publishVersions) {
+	const packageDir = join(repoRoot, 'packages', pkg.base);
+	const manifestPath = join(packageDir, 'package.json');
+	const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+
+	if (manifest.name !== pkg.oldName) {
+		throw new Error(
+			`Expected ${packageDir}/package.json name to be ${pkg.oldName}, got ${manifest.name}`,
+		);
+	}
+
+	const newName = baseToNewName.get(pkg.base);
+	const publishVersion = publishVersions.get(pkg.base);
+
+	// Rewrite internal dependency references. Keep the original @flue/* keys so
+	// emitted dist files resolve inside consumers that install via npm aliases.
+	// Pin to the dependency's own fork version, not this package's: the base
+	// versions can drift apart, and a pin built from the dependent's version
+	// would then point at a version that was never published.
+	for (const depType of ['dependencies', 'peerDependencies']) {
+		const deps = manifest[depType];
+		if (!deps) continue;
+		for (const depName of Object.keys(deps)) {
+			const depBase = oldNameToBase.get(depName);
+			if (!depBase) continue;
+			if (depType === 'peerDependencies') {
+				// Preserve the original semver range; the fork prerelease version
+				// (e.g. 1.0.0-beta.9-argonavis.gabc1234) satisfies the existing
+				// `>=1.0.0-beta.3 <1.0.0` range.
+				continue;
+			}
+			const targetName = baseToNewName.get(depBase);
+			deps[depName] = `npm:${targetName}@${publishVersions.get(depBase)}`;
+		}
+	}
+
+	// Dev dependencies are not installed for consumers and may carry
+	// `workspace:*` references. Drop them to avoid leaking workspace state.
+	delete manifest.devDependencies;
+
+	manifest.name = newName;
+	manifest.version = publishVersion;
+	manifest.publishConfig = { registry, access: 'public' };
+	manifest.repository = {
+		type: 'git',
+		url: 'git+https://github.com/argonavis-labs/flue.git',
+		directory: `packages/${pkg.base}`,
+	};
+
+	await writeFile(manifestPath, `${JSON.stringify(manifest, null, '\t')}\n`);
+
+	if (await isPublished(newName, publishVersion)) {
+		console.error(`[publish-fork] ${newName}@${publishVersion} already published; skipping`);
+		return;
+	}
+
+	console.error(`[publish-fork] Publishing ${newName}@${publishVersion} ...`);
+	await execFileAsync('npm', ['publish', '--access', 'public', '--tag', 'latest'], {
+		cwd: packageDir,
+		env: { ...process.env, npm_config_registry: registry },
+	});
+	console.error(`[publish-fork] Published ${newName}@${publishVersion}`);
+}
+
+async function main() {
+	const sha = await gitShortSha();
+	console.error(`[publish-fork] Publishing fork build from ${sha}`);
+
+	// Resolve every package's fork version before any manifest is rewritten so
+	// internal dependency pins can reference the dependency's own version.
+	const publishVersions = new Map(
+		await Promise.all(
+			packages.map(async (pkg) => {
+				const manifest = JSON.parse(
+					await readFile(join(repoRoot, 'packages', pkg.base, 'package.json'), 'utf8'),
+				);
+				return [pkg.base, forkVersion(manifest.version, sha)];
+			}),
+		),
+	);
+
+	for (const pkg of packages) {
+		// eslint-disable-next-line no-await-in-loop
+		await publishPackage(pkg, publishVersions);
+	}
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
Re-ports the client half of the stable-submission-id patch that #12 deliberately dropped as unused: `SendMessageOptions.submissionId` (react) and `AgentPromptOptions.submissionId` (sdk), serialized as a top-level sibling of the `DeliveredMessage` fields — the shape `DirectAgentRequestSchema` has accepted server-side since #7 (insert-or-ignore, payload compare, idempotent replay).

Consumer: runner-next RUN-5213 (Conversation store) mints a stable `sendId` per submission attempt and threads it as the wire `submissionId`, making client retry after an ambiguous send failure an idempotent replay instead of a potential duplicate turn.

Tests: sdk wire-body threading (with and without the id); react store pass-through to `agents.send`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)