### PR TITLE
Insert edit-tool newText verbatim instead of as a replace pattern

### DIFF
--- a/packages/runtime/src/agent.ts
+++ b/packages/runtime/src/agent.ts
@@ -153,7 +153,9 @@ function createEditTool(env: SessionEnv): AgentTool<typeof EditParams> {
 			const content = await env.readFile(params.path);
 
 			if (params.replaceAll) {
-				const newContent = content.replaceAll(params.oldText, params.newText);
+				// A function replacer inserts newText verbatim; passing it as a string
+				// would interpret `$` tokens ($&, $`, $', $$) and corrupt the file.
+				const newContent = content.replaceAll(params.oldText, () => params.newText);
 				if (newContent === content) {
 					throw new Error(`Could not find the text in ${params.path}. No changes made.`);
 				}
@@ -177,7 +179,9 @@ function createEditTool(env: SessionEnv): AgentTool<typeof EditParams> {
 				);
 			}
 
-			const newContent = content.replace(params.oldText, params.newText);
+			// A function replacer inserts newText verbatim; passing it as a string
+			// would interpret `$` tokens ($&, $`, $', $$) and corrupt the file.
+			const newContent = content.replace(params.oldText, () => params.newText);
 			await env.writeFile(params.path, newContent);
 			return {
 				content: [{ type: 'text', text: `Successfully edited ${params.path}` }],

--- a/packages/runtime/test/edit-tool.test.ts
+++ b/packages/runtime/test/edit-tool.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { createTools } from '../src/agent.ts';
 import { createNoopSessionEnv } from './fixtures/session-env.ts';
 
@@ -10,6 +10,30 @@ describe('createTools()', () => {
 		await expect(
 			edit?.execute('call', { path: 'a.txt', oldText: '', newText: 'inserted' }),
 		).rejects.toThrow('oldText must be a non-empty string');
+	});
+
+	// newText is the replacement argument to String.prototype.replace, which
+	// interprets `$` tokens — `$` before a backtick means "the text before the
+	// match", so a newText carrying that sequence expands to the file's prefix
+	// instead of being inserted verbatim.
+	it('inserts newText verbatim when it contains a `$` replacement token', async () => {
+		const writeFile = vi.fn(async () => {});
+		const env = createNoopSessionEnv({
+			readFile: async () => 'first line\nsecond line\n\ntarget line',
+			writeFile,
+		});
+		const edit = createTools(env).find((tool) => tool.name === 'edit');
+
+		await edit?.execute('call', {
+			path: 'a.txt',
+			oldText: 'target line',
+			newText: 'target line with a $` token appended',
+		});
+
+		expect(writeFile).toHaveBeenCalledWith(
+			'a.txt',
+			'first line\nsecond line\n\ntarget line with a $` token appended',
+		);
 	});
 
 	it('returns the filesystem error when reading a directory', async () => {


### PR DESCRIPTION
Fixes #506.

the `edit` tool passed `newText` straight to `String.prototype.replace` / `replaceAll` as the replacement argument, which interprets `$` tokens (`$&`, `` $` ``, `$'`, `$$`). a `newText` carrying `` $` `` (a `$` right before a backtick) expanded to the text before the match and duplicated a slab of the file, while the tool still reported `Successfully edited`.

## Fix

use a function replacer on both paths, so the string is inserted verbatim (a function's return value is never scanned for `$` tokens):

```ts
content.replace(params.oldText, () => params.newText)
content.replaceAll(params.oldText, () => params.newText)
```

## Test

adds a regression test to `edit-tool.test.ts`: a `newText` containing a `` $` `` token must be written verbatim. it fails on the old code (prefix duplicated) and passes with the fix.
