### PR TITLE
feat: add target authoring SDK

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/deploy/rivet.md
+++ b/apps/docs/src/content/docs/ecosystem/deploy/rivet.md
@@ -1,0 +1,38 @@
+---
+title: Deploy to Rivet
+description: Build and run Flue agents with the Rivet target.
+---
+
+Use the Rivet target when you want Flue agents and workflows to run on Rivet actors instead of a single Node process or Cloudflare Durable Objects.
+
+## Install
+
+```bash
+pnpm add @rivetkit/flue rivetkit
+pnpm add -D @flue/cli
+```
+
+Configure Flue:
+
+```ts title="flue.config.ts"
+import { defineConfig } from '@flue/cli/config';
+import rivet from '@rivetkit/flue';
+
+export default defineConfig({
+  target: rivet,
+});
+```
+
+## Build
+
+```bash
+pnpm exec flue build
+```
+
+The build emits a server artifact that exposes Flue's front door and wires requests to Rivet-backed agent and workflow actors. The same artifact can be run standalone for local development, or imported by a host such as Next.js when using the Vercel route pattern.
+
+## Runtime Behavior
+
+Agent prompts and `dispatch(...)` inputs are durably admitted before execution. Workflow runs are indexed for `/runs/:runId` lookups and Durable Streams reads. On actor wake, Flue reconciles interrupted agent submissions and terminalizes interrupted workflow runs so callers do not wait forever on an active run that can no longer complete.
+
+For target-specific details, see [Rivet Target](/docs/guide/targets/rivet/).

--- a/apps/docs/src/content/docs/ecosystem/deploy/rivet.md
+++ b/apps/docs/src/content/docs/ecosystem/deploy/rivet.md
@@ -3,12 +3,12 @@ title: Deploy to Rivet
 description: Build and run Flue agents with the Rivet target.
 ---
 
-Use the Rivet target when you want Flue agents and workflows to run on Rivet actors instead of a single Node process or Cloudflare Durable Objects.
+Use the Rivet target when you want Flue agents and workflows to run on Rivet Actors instead of a single Node process or Cloudflare Durable Objects.
 
 ## Install
 
 ```bash
-pnpm add @rivetkit/flue rivetkit
+pnpm add @rivet-dev/flue
 pnpm add -D @flue/cli
 ```
 
@@ -16,7 +16,7 @@ Configure Flue:
 
 ```ts title="flue.config.ts"
 import { defineConfig } from '@flue/cli/config';
-import rivet from '@rivetkit/flue';
+import rivet from '@rivet-dev/flue';
 
 export default defineConfig({
   target: rivet,

--- a/apps/docs/src/content/docs/ecosystem/deploy/vercel.md
+++ b/apps/docs/src/content/docs/ecosystem/deploy/vercel.md
@@ -20,7 +20,7 @@ export const { GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS } = toNextHandler(re
 ```
 
 ```ts title="app/api/flue/[...all]/route.ts"
-import { toFlueNextHandler } from '@rivetkit/flue/next';
+import { toFlueNextHandler } from '@rivet-dev/flue/next';
 import { flueApp } from '../../../../dist/server.mjs';
 
 export const maxDuration = 300;

--- a/apps/docs/src/content/docs/ecosystem/deploy/vercel.md
+++ b/apps/docs/src/content/docs/ecosystem/deploy/vercel.md
@@ -1,0 +1,37 @@
+---
+title: Deploy to Vercel with Rivet
+description: Mount Flue and Rivet route handlers in a Next.js app deployed to Vercel.
+---
+
+Flue can run on Vercel through the Rivet Next.js driver. The app mounts two catch-all routes:
+
+- `/api/rivet/[...all]` is the Rivet actor gateway.
+- `/api/flue/[...all]` is Flue's public HTTP API for agents, workflows, and runs.
+
+## Routes
+
+```ts title="app/api/rivet/[...all]/route.ts"
+import { toNextHandler } from '@rivetkit/next-js';
+import { registry } from '../../../../dist/server.mjs';
+
+export const maxDuration = 300;
+
+export const { GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS } = toNextHandler(registry);
+```
+
+```ts title="app/api/flue/[...all]/route.ts"
+import { toFlueNextHandler } from '@rivetkit/flue/next';
+import { flueApp } from '../../../../dist/server.mjs';
+
+export const maxDuration = 300;
+
+export const { GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS } = toFlueNextHandler(flueApp);
+```
+
+Run `flue build` before starting or building the Next.js app so `dist/server.mjs` exists.
+
+## Serverless Limit
+
+Vercel functions are bounded by `maxDuration`. The examples use `300`, the practical upper bound for this hosting mode. If an agent turn runs longer than the function lifespan, Vercel can stop the invocation; Flue then relies on Rivet `onWake` recovery the next time the actor is invoked.
+
+Use this mode for chat, request/response agents, and short workflows. Use a standalone Rivet runner for long autonomous turns that should not be capped by a serverless function duration.

--- a/apps/docs/src/content/docs/guide/targets/rivet.md
+++ b/apps/docs/src/content/docs/guide/targets/rivet.md
@@ -3,17 +3,17 @@ title: Rivet
 description: Understand the Rivet target for Flue applications.
 ---
 
-The Rivet target runs Flue agents and workflows on Rivet actors. Each agent instance and workflow run is addressed by actor key, while Flue keeps the same public HTTP API for prompts, workflow starts, Durable Streams reads, and `dispatch(...)`.
+The Rivet target runs Flue agents and workflows on Rivet Actors. Each agent instance and workflow run is addressed by actor key, while Flue keeps the same public HTTP API for prompts, workflow starts, Durable Streams reads, and `dispatch(...)`.
 
 Install the Rivet target package and select it in your Flue config:
 
 ```bash
-pnpm add @rivetkit/flue rivetkit
+pnpm add @rivet-dev/flue
 ```
 
 ```ts title="flue.config.ts"
 import { defineConfig } from '@flue/cli/config';
-import rivet from '@rivetkit/flue';
+import rivet from '@rivet-dev/flue';
 
 export default defineConfig({
   target: rivet,
@@ -22,7 +22,7 @@ export default defineConfig({
 
 ## Runtime Model
 
-Rivet actors give each Flue agent instance one durable execution home. Direct HTTP prompts and `dispatch(...)` inputs enter the same durable admission path, so accepted work can recover after interruption through the actor `onWake` lifecycle.
+Rivet Actors give each Flue agent instance one durable execution home. Direct HTTP prompts and `dispatch(...)` inputs enter the same durable admission path, so accepted work can recover after interruption through the actor `onWake` lifecycle.
 
 Workflow runs are one actor per run. A restarted workflow actor does not replay the workflow body; if its stored run is still active, Flue marks the run as interrupted and closes its event stream. Start a new workflow run explicitly when retry is appropriate.
 

--- a/apps/docs/src/content/docs/guide/targets/rivet.md
+++ b/apps/docs/src/content/docs/guide/targets/rivet.md
@@ -1,0 +1,45 @@
+---
+title: Rivet
+description: Understand the Rivet target for Flue applications.
+---
+
+The Rivet target runs Flue agents and workflows on Rivet actors. Each agent instance and workflow run is addressed by actor key, while Flue keeps the same public HTTP API for prompts, workflow starts, Durable Streams reads, and `dispatch(...)`.
+
+Install the Rivet target package and select it in your Flue config:
+
+```bash
+pnpm add @rivetkit/flue rivetkit
+```
+
+```ts title="flue.config.ts"
+import { defineConfig } from '@flue/cli/config';
+import rivet from '@rivetkit/flue';
+
+export default defineConfig({
+  target: rivet,
+});
+```
+
+## Runtime Model
+
+Rivet actors give each Flue agent instance one durable execution home. Direct HTTP prompts and `dispatch(...)` inputs enter the same durable admission path, so accepted work can recover after interruption through the actor `onWake` lifecycle.
+
+Workflow runs are one actor per run. A restarted workflow actor does not replay the workflow body; if its stored run is still active, Flue marks the run as interrupted and closes its event stream. Start a new workflow run explicitly when retry is appropriate.
+
+## Local Development
+
+Use the standard Flue commands after selecting `target: rivet`:
+
+```bash
+pnpm exec flue dev
+pnpm exec flue build
+```
+
+The generated HTTP surface stays the same as the Node and Cloudflare targets:
+
+- `POST /agents/:name/:id`
+- `GET /agents/:name/:id`
+- `POST /workflows/:name`
+- `GET /runs/:runId`
+
+For deployment options, see [Deploy to Rivet](/docs/ecosystem/deploy/rivet/) and [Deploy to Vercel with Rivet](/docs/ecosystem/deploy/vercel/).

--- a/apps/docs/src/lib/docs-navigation.ts
+++ b/apps/docs/src/lib/docs-navigation.ts
@@ -65,6 +65,7 @@ export const docsSections: DocsSection[] = [
 				items: [
 					{ title: 'Cloudflare', slug: 'guide/targets/cloudflare' },
 					{ title: 'Node.js', slug: 'guide/targets/node' },
+					{ title: 'Rivet', slug: 'guide/targets/rivet' },
 				],
 			},
 		],
@@ -246,7 +247,9 @@ export const docsSections: DocsSection[] = [
 					{ title: 'Node.js', slug: 'ecosystem/deploy/node' },
 					{ title: 'Railway', slug: 'ecosystem/deploy/railway' },
 					{ title: 'Render', slug: 'ecosystem/deploy/render' },
+					{ title: 'Rivet', slug: 'ecosystem/deploy/rivet' },
 					{ title: 'SST', slug: 'ecosystem/deploy/sst' },
+					{ title: 'Vercel', slug: 'ecosystem/deploy/vercel' },
 				],
 			},
 			{

--- a/packages/cli/bin/flue.ts
+++ b/packages/cli/bin/flue.ts
@@ -29,6 +29,7 @@ import {
 	row,
 	success,
 } from '../src/lib/terminal.ts';
+import type { BuiltinFlueTarget, FlueTarget } from '../src/lib/types.ts';
 import { BLUEPRINTS, KIND_ROOTS } from './_blueprints.generated.ts';
 
 interface ApplicationConfigArgs {
@@ -1195,6 +1196,7 @@ async function devCommand(args: DevArgs) {
 			sourceRoot: cfg.sourceRoot,
 			output: cfg.output,
 			target: cfg.target,
+			devMode: resolveDevMode(cfg.target),
 			port: args.port || undefined,
 			envFile: envLoader.file,
 			envLoader,
@@ -1206,6 +1208,16 @@ async function devCommand(args: DevArgs) {
 		cliError(`Dev server failed: ${err instanceof Error ? err.message : String(err)}`);
 		process.exit(1);
 	}
+}
+
+function resolveDevMode(target: BuiltinFlueTarget | FlueTarget): 'node-like' | 'cloudflare-vite' {
+	if (target === 'cloudflare') return 'cloudflare-vite';
+	if (target === 'node') return 'node-like';
+	return target.build.bundle === 'vite-cloudflare' ? 'cloudflare-vite' : 'node-like';
+}
+
+function targetName(target: BuiltinFlueTarget | FlueTarget): string {
+	return typeof target === 'string' ? target : target.name;
 }
 
 function readConfigFileState(file: string): string | undefined {
@@ -1340,7 +1352,9 @@ async function buildLocalTarget(
 ) {
 	const { cfg, configPath, envLoader } = await resolveApplicationCommand(args);
 	const envFile = fs.existsSync(envLoader.file) ? envLoader.file : undefined;
-	if (cfg.target === 'cloudflare') return { cfg, configPath, envFile, serverPath: undefined };
+	if (resolveDevMode(cfg.target) === 'cloudflare-vite') {
+		return { cfg, configPath, envFile, serverPath: undefined };
+	}
 	try {
 		await build({
 			root: cfg.root,
@@ -1360,12 +1374,14 @@ async function buildLocalTarget(
 
 async function run(args: RunArgs) {
 	const built = await buildLocalTarget(args);
-	if (built.cfg.target === 'cloudflare') printCloudflareRunUnsupported(args.workflow, args.payload);
+	if (resolveDevMode(built.cfg.target) === 'cloudflare-vite') {
+		printCloudflareRunUnsupported(args.workflow, args.payload);
+	}
 	if (!built.serverPath)
 		throw new Error('[flue] Node local workflow build did not produce an executable artifact.');
 	brandRows('flue run', [
 		['workflow', args.workflow],
-		['target', built.cfg.target],
+		['target', targetName(built.cfg.target)],
 		['config', built.configPath ? displayPath(built.cfg.root, built.configPath) : undefined],
 		['env', built.envFile ? displayPath(built.cfg.root, built.envFile) : undefined],
 	]);
@@ -1405,7 +1421,7 @@ async function run(args: RunArgs) {
 
 async function connectCommand(args: ConnectArgs) {
 	const built = await buildLocalTarget(args);
-	if (built.cfg.target === 'cloudflare') printCloudflareConnectUnsupported();
+	if (resolveDevMode(built.cfg.target) === 'cloudflare-vite') printCloudflareConnectUnsupported();
 	if (!built.serverPath)
 		throw new Error('[flue] Node local agent build did not produce an executable artifact.');
 	console.error(brand(['flue connect', `${args.agent}/${args.instanceId}`, 'starting...']));

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,10 @@
 		"flue": "bin/flue.mjs"
 	},
 	"exports": {
+		".": {
+			"types": "./dist/index.d.mts",
+			"import": "./dist/index.mjs"
+		},
 		"./config": {
 			"types": "./dist/config.d.mts",
 			"import": "./dist/config.mjs"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,22 @@
+export {
+	discoverAgents,
+	discoverChannels,
+	discoverWorkflows,
+} from './lib/build.ts';
+export {
+	defineConfig,
+	type FlueConfig,
+	type UserFlueConfig,
+} from './lib/config.ts';
+export {
+	type AgentInfo,
+	type BuildContext,
+	type BuildOptions,
+	type BuildPlugin,
+	type BuiltinFlueTarget,
+	type ChannelInfo,
+	defineTarget,
+	type FlueTarget,
+	type ViteCloudflareInputs,
+	type WorkflowInfo,
+} from './lib/types.ts';

--- a/packages/cli/src/lib/build.ts
+++ b/packages/cli/src/lib/build.ts
@@ -13,6 +13,7 @@ import type {
 	BuildOptions,
 	BuildPlugin,
 	ChannelInfo,
+	FlueTarget,
 	WorkflowInfo,
 } from './types.ts';
 import { importAttributePlugin } from './vite-import-attribute-plugin.ts';
@@ -260,6 +261,8 @@ function resolvePlugin(options: BuildOptions): BuildPlugin {
 		);
 	}
 
+	if (isFlueTarget(options.target)) return options.target.build;
+
 	switch (options.target) {
 		case 'node':
 			return new NodePlugin();
@@ -270,6 +273,10 @@ function resolvePlugin(options: BuildOptions): BuildPlugin {
 				`[flue] Unknown target: "${options.target}". Supported targets: node, cloudflare`,
 			);
 	}
+}
+
+function isFlueTarget(value: BuildOptions['target']): value is FlueTarget {
+	return typeof value === 'object' && value !== null;
 }
 
 export function discoverAgents(sourceRoot: string): AgentInfo[] {

--- a/packages/cli/src/lib/config.ts
+++ b/packages/cli/src/lib/config.ts
@@ -11,6 +11,7 @@ import { pathToFileURL } from 'node:url';
 import * as v from 'valibot';
 import { CONFIG_BASENAMES } from './config-paths.ts';
 import { resolveSourceRoot } from './source-root.ts';
+import type { BuiltinFlueTarget, FlueTarget } from './types.ts';
 
 // ─── Authoring API (re-exported by the public `@flue/cli/config` subpath) ───
 
@@ -25,8 +26,9 @@ export interface UserFlueConfig {
 	 *
 	 * - `'node'` builds a Node.js server.
 	 * - `'cloudflare'` builds a Workers-compatible application.
+	 * - a target object from `defineTarget()` builds with an external adapter.
 	 */
-	target?: 'node' | 'cloudflare';
+	target?: BuiltinFlueTarget | FlueTarget;
 	/**
 	 * Project root. Must not be empty. Relative values loaded from a
 	 * configuration file resolve from the directory containing that file;
@@ -50,7 +52,7 @@ export interface UserFlueConfig {
 /** Fully resolved configuration consumed by the rest of the CLI. */
 export interface FlueConfig {
 	/** Selected build and development target. */
-	target: 'node' | 'cloudflare';
+	target: BuiltinFlueTarget | FlueTarget;
 	/** Absolute project-root path. */
 	root: string;
 	/** Absolute directory from which authored modules are discovered. */
@@ -77,15 +79,15 @@ export function defineConfig(config: UserFlueConfig): UserFlueConfig {
 
 // ─── Validation ─────────────────────────────────────────────────────────────
 
-const TargetSchema = v.picklist(['node', 'cloudflare'] as const);
-
 const NonEmptyPathSchema = v.pipe(v.string(), v.minLength(1, 'Path must not be empty.'));
 
 const UserFlueConfigSchema = v.strictObject({
-	target: v.optional(TargetSchema),
+	target: v.optional(v.unknown()),
 	root: v.optional(NonEmptyPathSchema),
 	output: v.optional(NonEmptyPathSchema),
 });
+
+type ParsedUserFlueConfig = Omit<UserFlueConfig, 'target'> & { target?: unknown };
 
 // ─── Discovery ──────────────────────────────────────────────────────────────
 
@@ -234,7 +236,7 @@ export async function resolveConfig(opts: ResolveConfigOptions): Promise<Resolve
 		if (!result.success) {
 			throw new Error(formatValidationError(configPath, result.issues));
 		}
-		fileConfig = result.output;
+		fileConfig = normalizeUserConfigTarget(configPath, result.output);
 	}
 
 	// The "config root" — the directory we resolve relative paths in the config
@@ -247,7 +249,7 @@ export async function resolveConfig(opts: ResolveConfigOptions): Promise<Resolve
 	if (!inlineResult.success) {
 		throw new Error(formatValidationError('inline options', inlineResult.issues));
 	}
-	const inline = inlineResult.output;
+	const inline = normalizeUserConfigTarget('inline options', inlineResult.output);
 
 	// Merge: per-field, inline > file. We don't merge nested structures because
 	// the surface is flat today.
@@ -310,6 +312,40 @@ function resolvePath(
 	if (value === undefined) return opts.fallback;
 	if (path.isAbsolute(value)) return value;
 	return path.resolve(opts.baseDir, value);
+}
+
+function normalizeUserConfigTarget(
+	source: string,
+	config: ParsedUserFlueConfig,
+): UserFlueConfig {
+	const target = config.target;
+	if (target === undefined || target === 'node' || target === 'cloudflare') {
+		return { ...config, target };
+	}
+	if (isFlueTarget(target)) return { ...config, target };
+	throw new Error(
+		`[flue] Invalid config in ${source}:\n` +
+			'  • target: Expected "node", "cloudflare", or a target object returned by defineTarget().',
+	);
+}
+
+function isFlueTarget(value: unknown): value is FlueTarget {
+	if (typeof value !== 'object' || value === null) return false;
+	const candidate = value as Partial<FlueTarget>;
+	const build = candidate.build as Partial<FlueTarget['build']> | undefined;
+	const routing = candidate.routing as Partial<FlueTarget['routing']> | undefined;
+	return (
+		typeof candidate.name === 'string' &&
+		candidate.name.length > 0 &&
+		typeof build === 'object' &&
+		build !== null &&
+		typeof build.name === 'string' &&
+		typeof build.generateEntryPoint === 'function' &&
+		(build.bundle === 'vite' || build.bundle === 'vite-cloudflare') &&
+		typeof routing === 'object' &&
+		routing !== null &&
+		typeof routing.forward === 'function'
+	);
 }
 
 function formatValidationError(

--- a/packages/cli/src/lib/dev.ts
+++ b/packages/cli/src/lib/dev.ts
@@ -26,7 +26,7 @@ import {
 } from './build.ts';
 import { createEnvLoader, type EnvLoader, selectEnvFile } from './env.ts';
 import { blue, brandRows, dim, error, note, red, section, success } from './terminal.ts';
-import type { BuildOptions } from './types.ts';
+import type { BuildOptions, BuiltinFlueTarget, FlueTarget } from './types.ts';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -38,7 +38,8 @@ export interface DevOptions {
 	 * See {@link BuildOptions.output} for details.
 	 */
 	output?: string;
-	target: 'node' | 'cloudflare';
+	target: BuiltinFlueTarget | FlueTarget;
+	devMode: 'node-like' | 'cloudflare-vite';
 	/** Defaults to 3583 ("FLUE" on a phone keypad). */
 	port?: number;
 	envFile?: string;
@@ -105,14 +106,14 @@ export async function dev(options: DevOptions): Promise<void> {
 		sourceRoot,
 		output,
 		target: options.target,
-		mode: options.target === 'cloudflare' ? 'development' : 'build',
+		mode: options.devMode === 'cloudflare-vite' ? 'development' : 'build',
 		log: 'silent',
 		configFile: options.configFile,
 		envFile: fs.existsSync(envFile) ? envFile : undefined,
 	};
 
 	try {
-		if (options.target === 'cloudflare') {
+		if (options.devMode === 'cloudflare-vite') {
 			await envLoader.withApplied(() => build(buildOptions));
 		} else {
 			await build(buildOptions);
@@ -121,16 +122,16 @@ export async function dev(options: DevOptions): Promise<void> {
 		throw new Error(`Initial build failed: ${err instanceof Error ? err.message : String(err)}`);
 	}
 
-	if (options.target === 'cloudflare') envLoader.restore();
+	if (options.devMode === 'cloudflare-vite') envLoader.restore();
 	const reloader: DevReloader =
-		options.target === 'node'
+		options.devMode === 'node-like'
 			? new NodeReloader({ root, output, port })
 			: new CloudflareReloader({ root, sourceRoot, port });
 
 	await reloader.start();
 
 	brandRows('flue dev', [
-		['target', options.target],
+		['target', targetName(options.target)],
 		['server', reloader.url],
 		['config', options.configFile ? displayPath(root, options.configFile) : undefined],
 		['env', fs.existsSync(envFile) ? displayPath(root, envFile) : undefined],
@@ -163,7 +164,7 @@ export async function dev(options: DevOptions): Promise<void> {
 	// ─── Watch loop ──────────────────────────────────────────────────────────
 
 	const rebuild =
-		options.target === 'cloudflare'
+		options.devMode === 'cloudflare-vite'
 			? () => envLoader.withApplied(() => build(buildOptions))
 			: () => build(buildOptions);
 	const rebuilder = createRebuilder(reloader, rebuild);
@@ -176,7 +177,7 @@ export async function dev(options: DevOptions): Promise<void> {
 		onChange: (relPath) => {
 			const isEnvFile = relPath === envFile;
 			if (!isEnvFile && !reloader.shouldRebuildOn(relPath)) return;
-			if (isEnvFile && options.target === 'node') {
+			if (isEnvFile && options.devMode === 'node-like') {
 				try {
 					envLoader.apply();
 				} catch (err) {
@@ -223,6 +224,10 @@ export async function dev(options: DevOptions): Promise<void> {
 
 	// Block forever until a signal handler exits the process.
 	await new Promise<void>(() => {});
+}
+
+function targetName(target: BuiltinFlueTarget | FlueTarget): string {
+	return typeof target === 'string' ? target : target.name;
 }
 
 function displayPath(root: string, filePath: string): string {

--- a/packages/cli/src/lib/types.ts
+++ b/packages/cli/src/lib/types.ts
@@ -7,6 +7,10 @@
  * build/dev tooling moved from `@flue/sdk` into `@flue/cli` so the runtime
  * package would stop carrying tooling types.
  */
+import type { FlueForwardRouter } from '@flue/runtime';
+
+export type BuiltinFlueTarget = 'node' | 'cloudflare';
+
 export interface AgentInfo {
 	name: string;
 	filePath: string;
@@ -114,6 +118,16 @@ export interface BuildPlugin {
 	viteInputs?(ctx: BuildContext): ViteCloudflareInputs | Promise<ViteCloudflareInputs>;
 }
 
+export interface FlueTarget {
+	name: string;
+	build: BuildPlugin;
+	routing: FlueForwardRouter;
+}
+
+export function defineTarget(target: FlueTarget): FlueTarget {
+	return target;
+}
+
 /** Generated inputs consumed by the official Cloudflare Vite integration. */
 export interface ViteCloudflareInputs {
 	/**
@@ -141,7 +155,7 @@ export interface BuildOptions {
 	 * time, not `root`.
 	 */
 	output?: string;
-	target?: 'node' | 'cloudflare';
+	target?: BuiltinFlueTarget | FlueTarget;
 	mode?: 'build' | 'development';
 	/** Controls human build progress output. Defaults to `normal`. */
 	log?: 'normal' | 'silent';

--- a/packages/cli/test/custom-target.test.mjs
+++ b/packages/cli/test/custom-target.test.mjs
@@ -1,0 +1,394 @@
+import assert from 'node:assert/strict';
+import { spawn, spawnSync } from 'node:child_process';
+import { once } from 'node:events';
+import * as fs from 'node:fs';
+import { createServer } from 'node:net';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const cli = new URL('../dist/flue.js', import.meta.url);
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const fixtureRoots = [];
+
+process.on('exit', () => {
+	for (const root of fixtureRoots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('builds and serves an external custom target with workflow and run forwarding', async () => {
+	const root = createFixtureRoot();
+	const port = await getAvailablePort();
+	writeHelloTargetPackage(root);
+	writeHelperPackage(root);
+	writeProject(root);
+
+	const syntax = spawnSync(process.execPath, ['--check', path.join(root, 'hello-target', 'index.mjs')], {
+		encoding: 'utf8',
+	});
+	assert.equal(syntax.status, 0, syntax.stderr);
+
+	const build = await runCli(root, ['build']);
+	assert.equal(build.code, 0, build.stderr);
+	assert.equal(fs.existsSync(path.join(root, 'dist', 'server.mjs')), true);
+	assert.match(fs.readFileSync(path.join(root, 'dist', 'server.mjs'), 'utf8'), /hello-target-helper/);
+
+	const dev = startDev(root, port);
+	try {
+		await waitForServer(port, dev.logs);
+		const admitted = await fetch(`http://127.0.0.1:${port}/workflows/echo`, {
+			method: 'POST',
+			headers: { 'content-type': 'application/json', 'x-gate': 'open' },
+			body: JSON.stringify({ name: 'Ada' }),
+		});
+		assert.equal(admitted.status, 202);
+		const admittedBody = await admitted.json();
+		assert.equal(typeof admittedBody.runId, 'string');
+
+		const blockedMeta = await fetch(`http://127.0.0.1:${port}/runs/${admittedBody.runId}?meta`);
+		assert.equal(blockedMeta.status, 401);
+
+		const meta = await fetch(`http://127.0.0.1:${port}/runs/${admittedBody.runId}?meta`, {
+			headers: { 'x-gate': 'open' },
+		});
+		assert.equal(meta.status, 200);
+		const record = await meta.json();
+		assert.equal(record.workflowName, 'echo');
+
+		const stream = await fetch(`http://127.0.0.1:${port}/runs/${admittedBody.runId}`, {
+			headers: { 'x-gate': 'open' },
+		});
+		assert.equal(stream.status, 200);
+		assert.match(await stream.text(), /run_start|run_end/);
+	} finally {
+		await dev.stop();
+	}
+});
+
+function createFixtureRoot() {
+	const root = fs.mkdtempSync(path.join(os.tmpdir(), 'flue-hello-target-'));
+	fixtureRoots.push(root);
+	const flueScope = path.join(root, 'node_modules', '@flue');
+	fs.mkdirSync(flueScope, { recursive: true });
+	fs.symlinkSync(
+		path.join(repositoryRoot, 'packages', 'runtime'),
+		path.join(flueScope, 'runtime'),
+		'dir',
+	);
+	fs.symlinkSync(path.join(repositoryRoot, 'packages', 'cli'), path.join(flueScope, 'cli'), 'dir');
+	return root;
+}
+
+function writeProject(root) {
+	fs.writeFileSync(
+		path.join(root, 'package.json'),
+		JSON.stringify({
+			type: 'module',
+			dependencies: {
+				'@flue/hello-target': 'link:./hello-target',
+				'@flue/runtime': 'link:../../packages/runtime',
+				'hello-target-helper': 'link:./hello-target-helper',
+			},
+		}),
+	);
+	fs.writeFileSync(
+		path.join(root, 'flue.config.mjs'),
+		`import { defineConfig } from '@flue/cli/config';\nimport helloTarget from '@flue/hello-target';\nexport default defineConfig({ target: helloTarget });\n`,
+	);
+	fs.mkdirSync(path.join(root, 'workflows'), { recursive: true });
+	fs.writeFileSync(
+		path.join(root, 'workflows', 'echo.mjs'),
+		`import { helperValue } from 'hello-target-helper';\nexport const route = async (c, next) => {\n  if (c.req.header('x-gate') !== 'open') return new Response('closed', { status: 401 });\n  await next();\n};\nexport async function run({ payload, log }) {\n  log.info('echo workflow', { helperValue });\n  return { ok: true, helperValue, name: payload.name };\n}\n`,
+	);
+}
+
+function writeHelperPackage(root) {
+	const helperRoot = path.join(root, 'hello-target-helper');
+	fs.mkdirSync(helperRoot, { recursive: true });
+	fs.writeFileSync(
+		path.join(helperRoot, 'package.json'),
+		JSON.stringify({
+			name: 'hello-target-helper',
+			version: '0.0.0',
+			type: 'module',
+			exports: { '.': './index.mjs' },
+		}),
+	);
+	fs.writeFileSync(path.join(helperRoot, 'index.mjs'), `export const helperValue = 'linked-helper';\n`);
+	fs.symlinkSync(helperRoot, path.join(root, 'node_modules', 'hello-target-helper'), 'dir');
+}
+
+function writeHelloTargetPackage(root) {
+	const targetRoot = path.join(root, 'hello-target');
+	fs.mkdirSync(targetRoot, { recursive: true });
+	fs.writeFileSync(
+		path.join(targetRoot, 'package.json'),
+		JSON.stringify({
+			name: '@flue/hello-target',
+			version: '0.0.0',
+			type: 'module',
+			exports: { '.': './index.mjs' },
+			dependencies: {
+				'@flue/cli': 'link:../../packages/cli',
+				'@flue/runtime': 'link:../../packages/runtime',
+				'hello-target-helper': 'link:../hello-target-helper',
+			},
+		}),
+	);
+	fs.writeFileSync(path.join(targetRoot, 'index.mjs'), helloTargetSource());
+	const scope = path.join(root, 'node_modules', '@flue');
+	fs.mkdirSync(scope, { recursive: true });
+	fs.symlinkSync(targetRoot, path.join(scope, 'hello-target'), 'dir');
+}
+
+function helloTargetSource() {
+	return String.raw`
+import { defineTarget } from '@flue/cli';
+
+let forwarder;
+let runIndex;
+
+export function installHelloTargetRuntime(runtime) {
+  forwarder = runtime.forward;
+  runIndex = runtime.runIndex;
+}
+
+const target = defineTarget({
+  name: 'hello-target',
+  build: {
+    name: 'hello-target',
+    bundle: 'vite',
+    generateEntryPoint(ctx) {
+      const workflowImports = ctx.workflows
+        .map((workflow, index) => 'import * as workflow' + index + ' from ' + JSON.stringify(workflow.filePath.replace(/\\\\/g, '/')) + ';')
+        .join('\n');
+      const workflowEntries = ctx.workflows
+        .map((workflow, index) => '  ' + JSON.stringify(workflow.name) + ': workflow' + index + ',')
+        .join('\n');
+      return [
+        '// Auto-generated by flue (target: hello-target)',
+        "import { createServer } from 'node:http';",
+        "import { helperValue } from 'hello-target-helper';",
+        "import helloTarget, { installHelloTargetRuntime } from '@flue/hello-target';",
+        "import { sqlite } from '@flue/runtime/node';",
+        "import {",
+        "  Bash,",
+        "  InMemoryFs,",
+        "  bashFactoryToSessionEnv,",
+        "  configureFlueRuntime,",
+        "  createDefaultFlueApp,",
+        "  createFlueContext,",
+        "  handleRunRouteRequest,",
+        "  handleStreamHead,",
+        "  handleStreamRead,",
+        "  handleWorkflowRequest,",
+        "  resolveModel,",
+        "} from '@flue/runtime/adapter-kit';",
+        workflowImports,
+        '',
+        'const workflowModules = {',
+        workflowEntries,
+        '};',
+        'const manifest = {',
+        '  agents: [],',
+        "  workflows: Object.keys(workflowModules).map((name) => ({ name, transports: { http: true } })),",
+        '};',
+        'const workflowHandlers = Object.fromEntries(',
+        '  Object.entries(workflowModules).map(([name, mod]) => [name, mod.run])',
+        ');',
+        'const workflowRouteMiddleware = Object.fromEntries(',
+        '  Object.entries(workflowModules)',
+        "    .filter(([, mod]) => typeof mod.route === 'function')",
+        '    .map(([name, mod]) => [name, mod.route])',
+        ');',
+        '',
+        'const adapter = sqlite();',
+        'if (adapter.migrate) await adapter.migrate();',
+        'const { executionStore, runStore, eventStreamStore } = await adapter.connect();',
+        'const packagedSkills = {};',
+        '',
+        'async function createDefaultEnv() {',
+        '  const fs = new InMemoryFs();',
+        '  return bashFactoryToSessionEnv(() => new Bash({ fs }));',
+        '}',
+        '',
+        'function createContextForRequest(id, runId, payload, req, initialEventIndex, dispatchId) {',
+        '  return createFlueContext({',
+        '    id,',
+        '    runId,',
+        '    dispatchId,',
+        '    payload,',
+        '    initialEventIndex,',
+        '    env: process.env,',
+        '    req,',
+        '    agentConfig: { packagedSkills, resolveModel },',
+        '    createDefaultEnv,',
+        '    defaultStore: executionStore.sessions,',
+        '    submissionStore: executionStore.submissions,',
+        '  });',
+        '}',
+        '',
+        'installHelloTargetRuntime({',
+        '  runIndex: runStore,',
+        '  async forward(request, target) {',
+        "    if (target.kind === 'workflow') {",
+        '      const handler = workflowHandlers[target.workflowName];',
+        '      if (!handler) return null;',
+        '      return handleWorkflowRequest({',
+        '        request,',
+        '        workflowName: target.workflowName,',
+        '        handler,',
+        '        createContext: createContextForRequest,',
+        '        runStore,',
+        '        eventStreamStore,',
+        '        runId: target.instanceId,',
+        '      });',
+        '    }',
+        "    if (target.kind === 'run') {",
+        '      const url = new URL(request.url);',
+        "      if (request.method === 'GET' && url.searchParams.has('meta')) {",
+        '        return handleRunRouteRequest({ runStore, workflowName: target.workflowName, runId: target.runId });',
+        '      }',
+        "      const path = 'runs/' + target.runId;",
+        "      if (request.method === 'HEAD') return handleStreamHead(eventStreamStore, path);",
+        "      if (request.method === 'GET') return handleStreamRead({ store: eventStreamStore, path, request });",
+        '    }',
+        '    return null;',
+        '  },',
+        '});',
+        '',
+        'configureFlueRuntime({',
+        '  target: helloTarget,',
+        "  devMode: process.env.FLUE_MODE === 'local',",
+        '  runtimeVersion: ' + JSON.stringify(ctx.runtimeVersion) + ',',
+        '  manifest,',
+        '  workflowRouteMiddleware,',
+        '});',
+        '',
+        'const app = createDefaultFlueApp();',
+        'const server = createServer(async (req, res) => {',
+        "  const origin = 'http://' + (req.headers.host ?? '127.0.0.1');",
+        '  const headers = new Headers();',
+        '  for (const [key, value] of Object.entries(req.headers)) {',
+        '    if (Array.isArray(value)) {',
+        '      for (const item of value) headers.append(key, item);',
+        '    } else if (value !== undefined) {',
+        '      headers.set(key, value);',
+        '    }',
+        '  }',
+        "  const request = new Request(new URL(req.url ?? '/', origin), {",
+        '    method: req.method,',
+        '    headers,',
+        "    body: req.method === 'GET' || req.method === 'HEAD' ? undefined : req,",
+        "    duplex: 'half',",
+        '  });',
+        '  const response = await app.fetch(request);',
+        '  res.writeHead(response.status, Object.fromEntries(response.headers));',
+        '  if (response.body) {',
+        '    for await (const chunk of response.body) res.write(chunk);',
+        '  }',
+        '  res.end();',
+        '});',
+        "server.listen(Number(process.env.PORT ?? 3583), '127.0.0.1', () => {",
+        "  console.log('[hello-target] listening with ' + helperValue);",
+        '});',
+        "process.on('SIGTERM', () => server.close(() => process.exit(0)));",
+      ].join('\n');
+    },
+  },
+  routing: {
+    async forward(request, target) {
+      if (!forwarder) throw new Error('[hello-target] runtime forwarder was not installed.');
+      return forwarder(request, target);
+    },
+    get runIndex() {
+      return runIndex;
+    },
+  },
+});
+
+export default target;
+`;
+}
+
+async function runCli(cwd, args) {
+	const child = spawn(process.execPath, [cli.pathname, ...args], {
+		cwd,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	let stdout = '';
+	let stderr = '';
+	child.stdout.setEncoding('utf8');
+	child.stderr.setEncoding('utf8');
+	child.stdout.on('data', (chunk) => {
+		stdout += chunk;
+	});
+	child.stderr.on('data', (chunk) => {
+		stderr += chunk;
+	});
+	const [code, signal] = await once(child, 'exit');
+	return { code, signal, stdout, stderr };
+}
+
+function startDev(cwd, port) {
+	const child = spawn(process.execPath, [cli.pathname, 'dev', '--port', String(port)], {
+		cwd,
+		stdio: ['ignore', 'pipe', 'pipe'],
+	});
+	let output = '';
+	for (const stream of [child.stdout, child.stderr]) {
+		stream.setEncoding('utf8');
+		stream.on('data', (chunk) => {
+			output += chunk;
+		});
+	}
+	return {
+		logs() {
+			return output;
+		},
+		async stop() {
+			if (child.exitCode !== null || child.signalCode !== null) return;
+			child.kill('SIGTERM');
+			await Promise.race([
+				once(child, 'exit'),
+				new Promise((_, reject) =>
+					setTimeout(() => reject(new Error(`Timed out stopping flue dev\n\n${output}`)), 5_000),
+				),
+			]);
+		},
+	};
+}
+
+async function getAvailablePort() {
+	const server = createServer();
+	server.listen(0, '127.0.0.1');
+	await once(server, 'listening');
+	const address = server.address();
+	assert(address && typeof address === 'object');
+	server.close();
+	await once(server, 'close');
+	return address.port;
+}
+
+async function waitForServer(port, logs = () => '') {
+	await waitFor(
+		async () => {
+			try {
+				const response = await fetch(`http://127.0.0.1:${port}/openapi.json`);
+				return response.ok;
+			} catch {
+				return false;
+			}
+		},
+		() => `Timed out waiting for server on port ${port}\n\n${logs()}`,
+	);
+}
+
+async function waitFor(predicate, message, timeout = 20_000) {
+	const deadline = Date.now() + timeout;
+	while (Date.now() < deadline) {
+		if (await predicate()) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error(typeof message === 'function' ? message() : message);
+}

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from 'tsdown';
 
 export default defineConfig({
 	entry: {
+		// Public target-authoring SDK surface.
+		index: 'src/index.ts',
 		// Bin entry, written to dist/flue.mjs (the build script renames to dist/flue.js).
 		flue: 'bin/flue.ts',
 		// `@flue/cli/config` subpath, written to dist/config.mjs.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,6 +18,10 @@
 			"types": "./dist/adapter.d.mts",
 			"import": "./dist/adapter.mjs"
 		},
+		"./adapter-kit": {
+			"types": "./dist/adapter-kit.d.mts",
+			"import": "./dist/adapter-kit.mjs"
+		},
 		"./routing": {
 			"types": "./dist/routing.d.mts",
 			"import": "./dist/routing.mjs"

--- a/packages/runtime/src/adapter-kit.ts
+++ b/packages/runtime/src/adapter-kit.ts
@@ -1,0 +1,126 @@
+/**
+ * Public target-authoring primitives for platform adapters.
+ *
+ * This subpath is for deployment targets that need to wire Flue's runtime
+ * coordinator pieces without importing target-private internals.
+ */
+
+export { Bash, InMemoryFs } from 'just-bash';
+
+export type {
+	AgentAttemptMarker,
+	AgentDispatchAdmission,
+	AgentDispatchReceipt,
+	AgentExecutionStore,
+	AgentSubmission,
+	AgentSubmissionStore,
+	AgentTurnJournal,
+	AgentTurnJournalPhase,
+	CreateTurnJournalInput,
+	PersistenceAdapter,
+	PersistenceStores,
+	SubmissionAttemptRef,
+	SubmissionClaimRef,
+	SubmissionDurability,
+} from './agent-execution-store.ts';
+
+export type { FlueContextConfig, FlueContextInternal } from './client.ts';
+export { createFlueContext } from './client.ts';
+export { resolveModel } from './internal.ts';
+export type {
+	AgentSubmissionInput,
+	AgentSubmissionInterruption,
+	AgentSubmissionObserver,
+	AgentSubmissionObserverRegistry,
+	AgentSubmissionSession,
+	AttachedAgentSubmissionAdmission,
+	createAgentSubmissionSessionHandler,
+	DirectAgentSubmissionInput,
+	DispatchAgentSubmissionInput,
+	ProcessAgentSubmissionOptions,
+	ProcessSubmissionOptions,
+} from './runtime/agent-submissions.ts';
+export {
+	createAgentSubmissionObserverRegistry,
+	createDirectAgentSubmissionInput,
+	processSubmission,
+	reconcileInterruptedSubmission,
+	submissionSyntheticRequest,
+} from './runtime/agent-submissions.ts';
+export type { DispatchInput } from './runtime/dispatch-queue.ts';
+export type {
+	EventStreamMeta,
+	EventStreamReadResult,
+	EventStreamStore,
+} from './runtime/event-stream-store.ts';
+export {
+	agentStreamPath,
+	DEFAULT_READ_LIMIT,
+	formatOffset,
+	MAX_READ_LIMIT,
+	parseOffset,
+	SqliteEventStreamStore,
+} from './runtime/event-stream-store.ts';
+export type {
+	FlueForwardRouter,
+	FlueForwardRunIndex,
+	FlueForwardTarget,
+	FlueRuntime,
+	FlueRuntimeTarget,
+	HandleRunRouteOptions,
+} from './runtime/flue-app.ts';
+export {
+	configureFlueRuntime,
+	createDefaultFlueApp,
+	handleRunRouteRequest,
+} from './runtime/flue-app.ts';
+export type {
+	CreateContextFn,
+	DirectAttachedOptions,
+	FailRecoveredRunOptions,
+	HandleAgentOptions,
+	HandleWorkflowOptions,
+	InvokeWorkflowAttachedOptions,
+	StartWorkflowAdmissionFn,
+	WorkflowAttachedInvocationResult,
+	WorkflowHandler,
+} from './runtime/handle-agent.ts';
+export {
+	assertAgentDispatchAdmissionInput,
+	failRecoveredRun,
+	handleAgentRequest,
+	handleWorkflowRequest,
+} from './runtime/handle-agent.ts';
+export { handleStreamHead, handleStreamRead } from './runtime/handle-stream-routes.ts';
+export { generateWorkflowRunId } from './runtime/ids.ts';
+export { hasRegisteredProvider } from './runtime/providers.ts';
+export type {
+	CreateRunInput,
+	EndRunInput,
+	ListRunsOpts,
+	ListRunsResponse,
+	RunPointer,
+	RunRecord,
+	RunStatus,
+	RunStore,
+} from './runtime/run-store.ts';
+export {
+	DEFAULT_LIST_LIMIT,
+	decodeRunCursor,
+	encodeRunCursor,
+	isStreamExcludedEvent,
+	MAX_LIST_LIMIT,
+} from './runtime/run-store.ts';
+
+export { bashFactoryToSessionEnv } from './sandbox.ts';
+
+export { deleteSessionTree } from './session.ts';
+export { createSqlRunStore } from './sql-run-store.ts';
+export type {
+	CompactionEntry,
+	MessageEntry,
+	SessionData,
+	SessionEntry,
+	SessionStore,
+	TaskSessionRef,
+} from './types.ts';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -27,7 +27,7 @@ export type { McpServerConnection, McpServerOptions, McpTransport } from './mcp.
 export { connectMcpServer } from './mcp.ts';
 export { ResultUnavailableError } from './result.ts';
 export { type FlueEventSubscriber, observe } from './runtime/events.ts';
-export type { AgentManifestEntry } from './runtime/flue-app.ts';
+export type { AgentManifestEntry, FlueForwardRouter } from './runtime/flue-app.ts';
 export { dispatch } from './runtime/flue-app.ts';
 export { getRun, listAgents, listRuns } from './runtime/inspect.ts';
 export {

--- a/packages/runtime/src/runtime/agent-submissions.ts
+++ b/packages/runtime/src/runtime/agent-submissions.ts
@@ -106,7 +106,7 @@ export interface AgentSubmissionSession {
 	recordSubmissionTerminal(input: AgentSubmissionInterruption): Promise<void>;
 }
 
-interface AgentSubmissionObserver {
+export interface AgentSubmissionObserver {
 	onEvent?: (event: AttachedAgentEvent) => Promise<void> | void;
 }
 
@@ -115,7 +115,7 @@ interface AgentSubmissionAttachment {
 	detach(): void;
 }
 
-interface AgentSubmissionObserverRegistry {
+export interface AgentSubmissionObserverRegistry {
 	attach(submissionId: string, observer: AgentSubmissionObserver): AgentSubmissionAttachment;
 	publish(submissionId: string, event: AttachedAgentEvent): Promise<void>;
 	complete(submissionId: string, result: unknown): void;

--- a/packages/runtime/src/runtime/flue-app.ts
+++ b/packages/runtime/src/runtime/flue-app.ts
@@ -37,7 +37,7 @@ import {
 } from './handle-agent.ts';
 import { handleStreamHead, handleStreamRead } from './handle-stream-routes.ts';
 import { generateWorkflowRunId } from './ids.ts';
-import type { RunPointer, RunStore } from './run-store.ts';
+import type { ListRunsOpts, ListRunsResponse, RunPointer, RunRecord, RunStore } from './run-store.ts';
 
 import {
 	AgentAdmissionResponseSchema,
@@ -52,7 +52,7 @@ import {
 } from './schemas.ts';
 
 export interface FlueRuntime {
-	target: 'node' | 'cloudflare';
+	target: 'node' | 'cloudflare' | FlueRuntimeTarget;
 	devMode?: boolean;
 
 	// ─── Node-only ──────────────────────────────────────────────────────────
@@ -137,8 +137,30 @@ export interface FlueRuntime {
 	resolveDispatchAgentName?: (agent: CreatedAgent) => string | undefined;
 }
 
+export type FlueForwardTarget =
+	| { kind: 'agent'; agentName: string; instanceId: string }
+	| { kind: 'workflow'; workflowName: string; instanceId: string }
+	| { kind: 'run'; workflowName: string; runId: string };
+
 /** Cross-deployment run lookup/listing surface of a {@link RunStore}. */
 export type RunListing = Pick<RunStore, 'lookupRun' | 'listRuns'>;
+
+/** Custom target run index surface. */
+export interface FlueForwardRunIndex {
+	lookupRun(id: string): Promise<RunPointer | null>;
+	getRun(id: string): Promise<RunRecord | null>;
+	listRuns(options?: ListRunsOpts): Promise<ListRunsResponse>;
+}
+
+export interface FlueForwardRouter {
+	forward(request: Request, target: FlueForwardTarget): Promise<Response | null>;
+	runIndex?: FlueForwardRunIndex;
+}
+
+export interface FlueRuntimeTarget {
+	name: string;
+	routing: FlueForwardRouter;
+}
 
 /** One built agent in the deployment manifest, as returned by `listAgents()`. */
 export interface AgentManifestEntry {
@@ -484,7 +506,7 @@ const workflowRouteHandler: MiddlewareHandler = async (c) => {
 	const request = c.req.raw.clone();
 
 	return runAttachedMiddleware(c, rt.workflowRouteMiddleware?.[name], async () => {
-		if (rt.target === 'node') {
+		if (isNodeTarget(rt)) {
 			const handler = rt.workflowHandlers?.[name];
 			const createContext = rt.createContext;
 			if (!handler || !createContext) {
@@ -500,16 +522,29 @@ const workflowRouteHandler: MiddlewareHandler = async (c) => {
 			});
 		}
 
-		if (!rt.routeWorkflowRequest) {
-			throw new Error('[flue] Cloudflare runtime is missing workflow route forwarding.');
+		if (isCloudflareTarget(rt)) {
+			if (!rt.routeWorkflowRequest) {
+				throw new Error('[flue] Cloudflare runtime is missing workflow route forwarding.');
+			}
+			// One workflow run = one workflow DO instance. The instanceId IS the
+			// runId; the DO it lands on then re-uses that value to seed its run
+			// record via handleWorkflowRequest({ runId: instanceId, ... }).
+			const response = await rt.routeWorkflowRequest(
+				normalizeAttachedRequest(request, `/workflows/${encodeURIComponent(name)}`),
+				c.env,
+				{
+					workflowName: name,
+					instanceId: generateWorkflowRunId(),
+				},
+			);
+			if (response) return response;
+			throw new RouteNotFoundError({ method: c.req.method, path: new URL(c.req.url).pathname });
 		}
-		// One workflow run = one workflow DO instance. The instanceId IS the
-		// runId; the DO it lands on then re-uses that value to seed its run
-		// record via handleWorkflowRequest({ runId: instanceId, ... }).
-		const response = await rt.routeWorkflowRequest(
+
+		const response = await requireCustomTarget(rt).routing.forward(
 			normalizeAttachedRequest(request, `/workflows/${encodeURIComponent(name)}`),
-			c.env,
 			{
+				kind: 'workflow',
 				workflowName: name,
 				instanceId: generateWorkflowRunId(),
 			},
@@ -545,15 +580,24 @@ const agentRouteHandler: MiddlewareHandler = async (c) => {
 		// DS stream read (GET/HEAD) — served directly for Node, forwarded for CF.
 		if (c.req.method === 'GET' || c.req.method === 'HEAD') {
 			const streamPath = agentStreamPath(name, id);
-			if (rt.target === 'node') {
+			if (isNodeTarget(rt)) {
 				return nodeStreamReadResponse(rt, c.req.method, streamPath, request);
 			}
 
-			// Cloudflare: forward to the agent DO.
-			if (!rt.routeAgentRequest) {
-				throw new Error('[flue] Cloudflare runtime is missing agent route forwarding.');
+			if (isCloudflareTarget(rt)) {
+				if (!rt.routeAgentRequest) {
+					throw new Error('[flue] Cloudflare runtime is missing agent route forwarding.');
+				}
+				const response = await rt.routeAgentRequest(request, c.env, {
+					agentName: name,
+					instanceId: id,
+				});
+				if (response) return response;
+				throw new RouteNotFoundError({ method: c.req.method, path: new URL(c.req.url).pathname });
 			}
-			const response = await rt.routeAgentRequest(request, c.env, {
+
+			const response = await requireCustomTarget(rt).routing.forward(request, {
+				kind: 'agent',
 				agentName: name,
 				instanceId: id,
 			});
@@ -561,7 +605,7 @@ const agentRouteHandler: MiddlewareHandler = async (c) => {
 			throw new RouteNotFoundError({ method: c.req.method, path: new URL(c.req.url).pathname });
 		}
 
-		if (rt.target === 'node') {
+		if (isNodeTarget(rt)) {
 			const admitAttachedSubmission = rt.createAdmission?.[name]?.(id);
 			if (!admitAttachedSubmission) {
 				throw new Error('[flue] Node runtime is missing agent admission configuration.');
@@ -575,10 +619,24 @@ const agentRouteHandler: MiddlewareHandler = async (c) => {
 			});
 		}
 
-		if (!rt.routeAgentRequest) {
-			throw new Error('[flue] Cloudflare runtime is missing agent route forwarding.');
+		if (isCloudflareTarget(rt)) {
+			if (!rt.routeAgentRequest) {
+				throw new Error('[flue] Cloudflare runtime is missing agent route forwarding.');
+			}
+			const response = await rt.routeAgentRequest(request, c.env, {
+				agentName: name,
+				instanceId: id,
+			});
+			if (response) return response;
+
+			throw new RouteNotFoundError({
+				method: c.req.method,
+				path: new URL(c.req.url).pathname,
+			});
 		}
-		const response = await rt.routeAgentRequest(request, c.env, {
+
+		const response = await requireCustomTarget(rt).routing.forward(request, {
+			kind: 'agent',
 			agentName: name,
 			instanceId: id,
 		});
@@ -692,14 +750,20 @@ const runStreamReadHandler: MiddlewareHandler = async (c) => {
 		// (`offset`, `live`) are ignored on this view.
 		const wantsMeta = method === 'GET' && new URL(c.req.url).searchParams.has('meta');
 
-		if (rt.target === 'node') {
+		if (isNodeTarget(rt)) {
 			if (wantsMeta) {
 				return handleRunRouteRequest({ runStore: rt.runStore, workflowName, runId });
 			}
 			return nodeStreamReadResponse(rt, method, runStreamPath(runId), c.req.raw);
 		}
 
-		const response = await rt.routeRunRequest?.(c.req.raw, c.env, { workflowName, runId });
+		const response = isCloudflareTarget(rt)
+			? await rt.routeRunRequest?.(c.req.raw, c.env, { workflowName, runId })
+			: await requireCustomTarget(rt).routing.forward(c.req.raw, {
+					kind: 'run',
+					workflowName,
+					runId,
+				});
 		if (response) return response;
 		throw new RouteNotFoundError({ method, path: new URL(c.req.url).pathname });
 	});
@@ -768,7 +832,7 @@ async function findRunPointer(
 	env: unknown,
 	runId: string,
 ): Promise<RunPointer | null> {
-	if (rt.target === 'cloudflare') {
+	if (isCloudflareTarget(rt)) {
 		if (!rt.createRunIndexForRequest || !rt.routeRunRequest) {
 			throw new RunStoreUnavailableError();
 		}
@@ -776,8 +840,28 @@ async function findRunPointer(
 		if (!index) throw new RunStoreUnavailableError();
 		return index.lookupRun(runId);
 	}
+	if (!isNodeTarget(rt)) {
+		const index = requireCustomTarget(rt).routing.runIndex;
+		if (!index) throw new RunStoreUnavailableError();
+		return index.lookupRun(runId);
+	}
 	if (!rt.runStore) throw new RunStoreUnavailableError();
 	return rt.runStore.lookupRun(runId);
+}
+
+function isNodeTarget(rt: FlueRuntime): rt is FlueRuntime & { target: 'node' } {
+	return rt.target === 'node';
+}
+
+function isCloudflareTarget(rt: FlueRuntime): rt is FlueRuntime & { target: 'cloudflare' } {
+	return rt.target === 'cloudflare';
+}
+
+function requireCustomTarget(rt: FlueRuntime): FlueRuntimeTarget {
+	if (rt.target === 'node' || rt.target === 'cloudflare') {
+		throw new Error('[flue] Internal target dispatch expected a custom target.');
+	}
+	return rt.target;
 }
 
 function isRegisteredWorkflow(rt: FlueRuntime, workflowName: string): boolean {

--- a/packages/runtime/src/runtime/inspect.ts
+++ b/packages/runtime/src/runtime/inspect.ts
@@ -10,6 +10,7 @@
 import { RunStoreUnavailableError } from '../errors.ts';
 import {
 	type AgentManifestEntry,
+	type FlueForwardRunIndex,
 	type FlueRuntime,
 	getFlueRuntime,
 	type RunListing,
@@ -36,6 +37,11 @@ export async function getRun(runId: string): Promise<RunRecord | null> {
 	if (rt.target === 'node') {
 		if (!rt.runStore) throw new RunStoreUnavailableError();
 		return rt.runStore.getRun(runId);
+	}
+
+	if (rt.target !== 'cloudflare') {
+		const index = requireForwardRunIndex(rt);
+		return index.getRun(runId);
 	}
 
 	// Cloudflare: full records live in the owning per-workflow Durable
@@ -82,6 +88,14 @@ function requireRunListing(rt: FlueRuntime): RunListing {
 		if (!index) throw new RunStoreUnavailableError();
 		return index;
 	}
+	if (rt.target !== 'node') return requireForwardRunIndex(rt);
 	if (!rt.runStore) throw new RunStoreUnavailableError();
 	return rt.runStore;
+}
+
+function requireForwardRunIndex(rt: FlueRuntime): FlueForwardRunIndex {
+	if (rt.target === 'node' || rt.target === 'cloudflare') throw new RunStoreUnavailableError();
+	const index = rt.target.routing.runIndex;
+	if (!index) throw new RunStoreUnavailableError();
+	return index;
 }

--- a/packages/runtime/test/adapter-kit-types.test.ts
+++ b/packages/runtime/test/adapter-kit-types.test.ts
@@ -1,0 +1,96 @@
+import {
+	type AgentExecutionStore,
+	type AgentSubmission,
+	type AgentSubmissionObserver,
+	type AgentSubmissionObserverRegistry,
+	type AgentSubmissionStore,
+	agentStreamPath,
+	assertAgentDispatchAdmissionInput,
+	Bash,
+	bashFactoryToSessionEnv,
+	type CreateRunInput,
+	configureFlueRuntime,
+	type createAgentSubmissionSessionHandler,
+	createDefaultFlueApp,
+	createDirectAgentSubmissionInput,
+	createFlueContext,
+	createSqlRunStore,
+	type DirectAgentSubmissionInput,
+	type EventStreamReadResult,
+	type EventStreamStore,
+	type FlueForwardRouter,
+	type FlueForwardRunIndex,
+	failRecoveredRun,
+	generateWorkflowRunId,
+	handleAgentRequest,
+	handleRunRouteRequest,
+	handleStreamHead,
+	handleStreamRead,
+	handleWorkflowRequest,
+	hasRegisteredProvider,
+	InMemoryFs,
+	isStreamExcludedEvent,
+	processSubmission,
+	type RunStore,
+	reconcileInterruptedSubmission,
+	resolveModel,
+	type SessionEntry,
+	type SessionStore,
+	SqliteEventStreamStore,
+	type SubmissionDurability,
+	submissionSyntheticRequest,
+} from '@flue/runtime/adapter-kit';
+import { describe, expect, it } from 'vitest';
+
+describe('adapter-kit type surface', () => {
+	it('type-checks target-authoring imports from one public subpath', () => {
+		const values = [
+			Bash,
+			InMemoryFs,
+			SqliteEventStreamStore,
+			agentStreamPath,
+			assertAgentDispatchAdmissionInput,
+			bashFactoryToSessionEnv,
+			configureFlueRuntime,
+			createDefaultFlueApp,
+			createDirectAgentSubmissionInput,
+			createFlueContext,
+			createSqlRunStore,
+			failRecoveredRun,
+			generateWorkflowRunId,
+			handleAgentRequest,
+			handleRunRouteRequest,
+			handleStreamHead,
+			handleStreamRead,
+			handleWorkflowRequest,
+			hasRegisteredProvider,
+			isStreamExcludedEvent,
+			processSubmission,
+			reconcileInterruptedSubmission,
+			resolveModel,
+			submissionSyntheticRequest,
+		];
+		type Surface = {
+			executionStore: AgentExecutionStore;
+			submission: AgentSubmission;
+			submissionObserver: AgentSubmissionObserver;
+			submissionObservers: AgentSubmissionObserverRegistry;
+			submissionStore: AgentSubmissionStore;
+			createRun: CreateRunInput;
+			directInput: DirectAgentSubmissionInput;
+			readResult: EventStreamReadResult;
+			eventStreamStore: EventStreamStore;
+			router: FlueForwardRouter;
+			runIndex: FlueForwardRunIndex;
+			runStore: RunStore;
+			session: SessionEntry;
+			sessionStore: SessionStore;
+			durability: SubmissionDurability;
+			sessionHandlerFactory: typeof createAgentSubmissionSessionHandler;
+		};
+		const _typeOnly: Surface | undefined = undefined;
+
+		expect(values.length).toBeGreaterThan(20);
+		expect(_typeOnly).toBeUndefined();
+	});
+});

--- a/packages/runtime/test/package-entrypoints.test.ts
+++ b/packages/runtime/test/package-entrypoints.test.ts
@@ -114,4 +114,37 @@ describe('package entrypoints', () => {
 			defineStoreContractTests: expect.any(Function),
 		});
 	});
+
+	it('exposes target-authoring primitives when an adapter imports @flue/runtime/adapter-kit', async () => {
+		const adapterKit = await import('@flue/runtime/adapter-kit');
+
+		expect(adapterKit).toMatchObject({
+			Bash: expect.any(Function),
+			InMemoryFs: expect.any(Function),
+			agentStreamPath: expect.any(Function),
+			assertAgentDispatchAdmissionInput: expect.any(Function),
+			bashFactoryToSessionEnv: expect.any(Function),
+			configureFlueRuntime: expect.any(Function),
+			createDefaultFlueApp: expect.any(Function),
+			createDirectAgentSubmissionInput: expect.any(Function),
+			createFlueContext: expect.any(Function),
+			createSqlRunStore: expect.any(Function),
+			failRecoveredRun: expect.any(Function),
+			generateWorkflowRunId: expect.any(Function),
+			handleAgentRequest: expect.any(Function),
+			handleRunRouteRequest: expect.any(Function),
+			handleStreamHead: expect.any(Function),
+			handleStreamRead: expect.any(Function),
+			handleWorkflowRequest: expect.any(Function),
+			hasRegisteredProvider: expect.any(Function),
+			isStreamExcludedEvent: expect.any(Function),
+			processSubmission: expect.any(Function),
+			reconcileInterruptedSubmission: expect.any(Function),
+			resolveModel: expect.any(Function),
+			SqliteEventStreamStore: expect.any(Function),
+			submissionSyntheticRequest: expect.any(Function),
+		});
+		expect(adapterKit).not.toHaveProperty('FlueRegistry');
+		expect(adapterKit).not.toHaveProperty('createCloudflareRunStore');
+	});
 });

--- a/packages/runtime/tsdown.config.ts
+++ b/packages/runtime/tsdown.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
 	entry: [
 		'src/index.ts',
 		'src/adapter.ts',
+		'src/adapter-kit.ts',
 		'src/routing.ts',
 		'src/tool-entrypoint.ts',
 		'src/internal.ts',


### PR DESCRIPTION
- Add the target authoring API and load custom target packages through Flue configuration.
- Cover custom target builds with an end-to-end CLI test.
- Document the Rivet target and Rivet/Vercel deployment flows.
