### PR TITLE
feat: add Blaxel sandbox blueprint

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/sandboxes/blaxel.md
+++ b/apps/docs/src/content/docs/ecosystem/sandboxes/blaxel.md
@@ -1,0 +1,87 @@
+---
+title: Blaxel
+description: Connect a Flue agent to an application-owned Blaxel sandbox.
+lastReviewedAt: 2026-07-22
+---
+
+The Blaxel adapter adapts an initialized `SandboxInstance` from `@blaxel/core` into Flue's sandbox interface. Use it when a Node-hosted application needs a perpetual Blaxel microVM with filesystem and shell operations.
+
+## Quickstart
+
+Add Blaxel sandbox capability to an existing Flue project with the [Blaxel](https://blaxel.ai) blueprint:
+
+```bash
+flue add sandbox blaxel
+```
+
+## Overview
+
+The blueprint installs `@blaxel/core` when needed and creates `sandboxes/blaxel.ts` in your source root. The generated file adapts a sandbox that your application has already created; it does not choose its identity, retention, or cleanup policy.
+
+```ts title="<source-root>/sandboxes/blaxel.ts (abridged)"
+// flue-blueprint: sandbox/blaxel@1
+import { createSandboxSessionEnv } from '@flue/runtime';
+import type { FileStat, SandboxApi, SandboxFactory, SessionEnv } from '@flue/runtime';
+import type { SandboxInstance } from '@blaxel/core';
+
+class BlaxelSandboxApi implements SandboxApi {
+  constructor(private sandbox: SandboxInstance) {}
+
+  /* Uses sandbox.fs for text and binary reads and writes. */
+
+  /* Derives stat and readdir from sandbox.fs.ls directory entries. */
+
+  /* Uses sandbox.process.exec with waitForCompletion and a rounded-up timeout. */
+}
+
+export function blaxel(sandbox: SandboxInstance): SandboxFactory {
+  return {
+    async createSessionEnv(): Promise<SessionEnv> {
+      return createSandboxSessionEnv(new BlaxelSandboxApi(sandbox), '/blaxel');
+    },
+  };
+}
+```
+
+Pass an initialized `SandboxInstance` to `blaxel(...)`, then assign the returned factory to an agent's `sandbox` property. Flue roots sessions at Blaxel's `/blaxel` working directory, exposes text and binary filesystem operations, and executes commands through the sandbox process API. Millisecond Flue deadlines are rounded up to Blaxel's whole-second process timeout. Blaxel supports recursive removal but has no force-delete flag in its filesystem API, so the adapter rejects `force` before mutation. Your application remains responsible for sandbox creation and lifecycle.
+
+## Configure
+
+For local development, authenticate with `bl login <workspace>`. For CI or another non-Blaxel host, provide these runtime variables:
+
+| Variable       | Purpose                                         |
+| -------------- | ----------------------------------------------- |
+| `BL_WORKSPACE` | Selects the Blaxel workspace.                   |
+| `BL_API_KEY`   | Authenticates the SDK outside a Blaxel runtime. |
+
+| Requirement                 | Purpose                                                                                        |
+| --------------------------- | ---------------------------------------------------------------------------------------------- |
+| `@blaxel/core` package      | **Required** — Creates the Blaxel sandbox adapted by Flue.                                     |
+| Application-owned lifecycle | **Required** — Creates, retains, and deletes the sandbox, then passes it to `blaxel(sandbox)`. |
+
+Workloads running on Blaxel authenticate automatically. The generated adapter never stores credentials and never deletes the sandbox when a Flue harness closes.
+
+## Typical use
+
+```ts
+import { SandboxInstance } from '@blaxel/core';
+import { defineAgent } from '@flue/runtime';
+import { blaxel } from '../sandboxes/blaxel';
+
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: 'my-flue-sandbox',
+  image: 'blaxel/base-image:latest',
+  memory: 4096,
+  region: 'us-pdx-1',
+  ttl: '24h',
+});
+
+const agent = defineAgent(() => ({
+  model: 'anthropic/claude-sonnet-4-6',
+  sandbox: blaxel(sandbox),
+}));
+```
+
+Configure images, regions, lifecycle, networking, volumes, and Agent Drive mounts through `@blaxel/core` before passing the instance to `blaxel(...)`. For a narrower working directory, configure `cwd` on the agent definition; Flue resolves it against the adapter's `/blaxel` base directory during initialization.
+
+See [Sandboxes](/docs/guide/sandboxes/#remote-sandboxes), [Sandbox Adapter API](/docs/api/sandbox-api/), and [Blaxel's TypeScript SDK reference](https://docs.blaxel.ai/Sandboxes/Overview).

--- a/blueprints/sandbox--blaxel.md
+++ b/blueprints/sandbox--blaxel.md
@@ -1,0 +1,294 @@
+---
+{
+  "kind": "sandbox",
+  "version": 1,
+  "website": "https://blaxel.ai",
+  "aliases": ["@blaxel/core"]
+}
+---
+
+# Add a Flue Sandbox Adapter: Blaxel
+
+You are an AI coding agent installing the Blaxel sandbox adapter for a
+Flue project. Follow these instructions exactly. Confirm with the user only
+when something is genuinely ambiguous (e.g. an unusual project layout).
+
+## What this adapter does
+
+Wraps an already-initialized Blaxel `SandboxInstance` (created with the
+user's own `@blaxel/core` client) into Flue's `SandboxFactory` interface.
+The user owns sandbox creation, identity, retention, and cleanup; this
+adapter only maps its filesystem and process APIs into Flue.
+
+## Where to write the file
+
+Select the first existing source directory: `<root>/.flue/`, then `<root>/src/`,
+then `<root>/`. Write the adapter to `<source-dir>/sandboxes/blaxel.ts`.
+
+If neither feels right (uncommon layout, multiple workspaces, etc.), ask the
+user before writing.
+
+Create any missing parent directories.
+
+## File contents
+
+Write this file verbatim. Do not "improve" it — it conforms to the published
+`SandboxApi` contract and the published `@blaxel/core` package.
+
+```ts
+// flue-blueprint: sandbox/blaxel@1
+/**
+ * Blaxel adapter for Flue.
+ *
+ * Wraps an initialized Blaxel SandboxInstance into Flue's SandboxFactory
+ * interface. The application creates and owns the sandbox; Flue adapts it.
+ *
+ * @example
+ * ```typescript
+ * import { SandboxInstance } from '@blaxel/core';
+ * import { blaxel } from './sandboxes/blaxel';
+ *
+ * const sandbox = await SandboxInstance.createIfNotExists({
+ *   name: 'my-flue-sandbox',
+ *   image: 'blaxel/base-image:latest',
+ *   memory: 4096,
+ *   region: 'us-pdx-1',
+ *   ttl: '24h',
+ * });
+ * const agent = defineAgent(() => ({ sandbox: blaxel(sandbox), model: 'anthropic/claude-sonnet-4-6' }));
+ * export default defineWorkflow({ agent, async run({ harness }) {
+ *   return await (await harness.session()).prompt('Inspect the workspace.');
+ * }});
+ * ```
+ */
+import { createSandboxSessionEnv, SandboxOperationUnsupportedError } from '@flue/runtime';
+import type { FileStat, SandboxApi, SandboxFactory, SessionEnv } from '@flue/runtime';
+import type { SandboxInstance } from '@blaxel/core';
+
+function parentAndName(path: string): { parent: string; name: string } {
+	const withoutTrailingSlash = path.replace(/\/+$/, '');
+	const normalized = withoutTrailingSlash.length === 0 ? '/' : withoutTrailingSlash;
+	const separator = normalized.lastIndexOf('/');
+	return {
+		parent: separator <= 0 ? '/' : normalized.slice(0, separator),
+		name: normalized.slice(separator + 1),
+	};
+}
+
+function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/** Implements SandboxApi with Blaxel's filesystem and process APIs. */
+class BlaxelSandboxApi implements SandboxApi {
+	constructor(private sandbox: SandboxInstance) {}
+
+	async readFile(path: string): Promise<string> {
+		return this.sandbox.fs.read(path);
+	}
+
+	async readFileBuffer(path: string): Promise<Uint8Array> {
+		const blob = await this.sandbox.fs.readBinary(path);
+		return new Uint8Array(await blob.arrayBuffer());
+	}
+
+	async writeFile(path: string, content: string | Uint8Array): Promise<void> {
+		if (typeof content === 'string') {
+			await this.sandbox.fs.write(path, content);
+			return;
+		}
+		await this.sandbox.fs.writeBinary(path, content);
+	}
+
+	async stat(path: string): Promise<FileStat> {
+		const { parent, name } = parentAndName(path);
+		if (name.length === 0) {
+			await this.sandbox.fs.ls('/');
+			return { isFile: false, isDirectory: true };
+		}
+
+		const directory = await this.sandbox.fs.ls(parent);
+		const file = directory.files.find((entry) => entry.name === name);
+		if (file) {
+			const mtime = new Date(file.lastModified);
+			return {
+				isFile: true,
+				isDirectory: false,
+				size: file.size,
+				...(Number.isNaN(mtime.getTime()) ? {} : { mtime }),
+			};
+		}
+		if (directory.subdirectories.some((entry) => entry.name === name)) {
+			return { isFile: false, isDirectory: true };
+		}
+		throw new Error(`[flue:blaxel] Path not found: ${path}`);
+	}
+
+	async readdir(path: string): Promise<string[]> {
+		const directory = await this.sandbox.fs.ls(path);
+		return [
+			...directory.subdirectories.map((entry) => entry.name),
+			...directory.files.map((entry) => entry.name),
+		];
+	}
+
+	async exists(path: string): Promise<boolean> {
+		try {
+			await this.stat(path);
+			return true;
+		} catch {
+			return false;
+		}
+	}
+
+	async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
+		if (!options?.recursive) {
+			await this.sandbox.fs.mkdir(path);
+			return;
+		}
+		const result = await this.exec(`mkdir -p -- ${shellQuote(path)}`);
+		if (result.exitCode !== 0) {
+			throw new Error(`[flue:blaxel] Could not create ${path}: ${result.stderr}`);
+		}
+	}
+
+	async rm(path: string, options?: { recursive?: boolean; force?: boolean }): Promise<void> {
+		if (options?.force) {
+			throw new SandboxOperationUnsupportedError({
+				operation: 'rm',
+				provider: 'Blaxel',
+				options: ['force'],
+			});
+		}
+		await this.sandbox.fs.rm(path, options?.recursive ?? false);
+	}
+
+	async exec(
+		command: string,
+		options?: {
+			cwd?: string;
+			env?: Record<string, string>;
+			timeoutMs?: number;
+			signal?: AbortSignal;
+		},
+	): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+		const result = await this.sandbox.process.exec({
+			command,
+			workingDir: options?.cwd,
+			env: options?.env,
+			waitForCompletion: true,
+			timeout:
+				typeof options?.timeoutMs === 'number'
+					? Math.ceil(options.timeoutMs / 1000)
+					: undefined,
+		});
+		return {
+			stdout: result.stdout ?? '',
+			stderr: result.stderr ?? '',
+			exitCode: result.exitCode ?? 0,
+		};
+	}
+}
+
+/**
+ * Create a Flue sandbox factory from an initialized Blaxel sandbox.
+ * The application owns the sandbox lifecycle; Flue wraps it into a
+ * SessionEnv rooted at Blaxel's default working directory.
+ */
+export function blaxel(sandbox: SandboxInstance): SandboxFactory {
+	return {
+		async createSessionEnv(): Promise<SessionEnv> {
+			const api = new BlaxelSandboxApi(sandbox);
+			return createSandboxSessionEnv(api, '/blaxel');
+		},
+	};
+}
+```
+
+## Required dependencies
+
+This adapter imports from `@blaxel/core`, so the user's project needs to
+depend on it directly. If their `package.json` does not already list it,
+add it:
+
+```bash
+npm install @blaxel/core@^0.3.6
+```
+
+(Use the user's package manager — `pnpm add`, `yarn add`, etc. if their
+lockfile indicates a different one.)
+
+## Authentication
+
+For local development, the preferred path is to authenticate the Blaxel CLI
+with `bl login <workspace>`; `@blaxel/core` discovers that configuration.
+For CI or another non-Blaxel host, provide `BL_WORKSPACE` and `BL_API_KEY` at
+runtime. Workloads already running on Blaxel authenticate automatically.
+
+Never invent credential values. Follow the project's established secret
+conventions. If no convention exists, ask the user instead of guessing.
+
+For reference: `flue dev --env <file>` and `flue run --env <file>` load any
+`.env`-format file the user points them at.
+
+## Wiring it into an agent
+
+Here's what using this adapter looks like inside a Flue agent. If the user is
+already working on an agent that this adapter is meant to plug into, finish
+that work by wiring the adapter into it. Otherwise, share this snippet so they
+can wire it up themselves.
+
+```ts
+import { SandboxInstance } from '@blaxel/core';
+import { defineAgent, defineWorkflow, type WorkflowRouteHandler } from '@flue/runtime';
+import { blaxel } from '../sandboxes/blaxel'; // adjust for the user's layout
+
+export const route: WorkflowRouteHandler = async (_c, next) => next();
+
+const sandbox = await SandboxInstance.createIfNotExists({
+  name: 'my-flue-sandbox',
+  image: 'blaxel/base-image:latest',
+  memory: 4096,
+  region: 'us-pdx-1',
+  ttl: '24h',
+});
+
+const agent = defineAgent(() => ({
+  sandbox: blaxel(sandbox),
+  model: 'anthropic/claude-sonnet-4-6',
+}));
+
+export default defineWorkflow({
+  agent,
+  run: async ({ harness }) => {
+    const session = await harness.session();
+    return await session.shell('uname -a');
+  },
+});
+```
+
+The application is responsible for deleting or retaining the sandbox. The
+adapter deliberately does not call `sandbox.delete()` when a Flue harness
+closes.
+
+## Verify
+
+1. Run the user's typechecker (`npx tsc --noEmit` is a safe default) and
+   confirm the new file has no errors.
+2. Confirm the import path used for the adapter matches its actual location.
+3. If credentials are required, confirm the application can authenticate
+   without printing them.
+4. Exercise one text write/read, one binary write/read, directory listing,
+   recursive directory creation, removal, and one shell command.
+5. Tell the user that their application owns sandbox cleanup and retention.
+
+When updating an existing integration, inspect and compare it against this
+complete current blueprint, apply every relevant change while preserving
+customizations, and then add or update the marker in the primary marked file.
+This comparison is required when the marker is missing.
+
+## Upgrade Guide
+
+### Version 1 — 2026-07-22
+
+Initial version.

--- a/packages/cli/test/add.test.mjs
+++ b/packages/cli/test/add.test.mjs
@@ -69,6 +69,7 @@ before(async () => {
 			whatsapp: 'channel--whatsapp.md',
 			twilio: 'channel--twilio.md',
 			messenger: 'channel--messenger.md',
+			blaxel: 'sandbox--blaxel.md',
 			daytona: 'sandbox--daytona.md',
 			postgres: 'database--postgres.md',
 			libsql: 'database--libsql.md',
@@ -179,6 +180,7 @@ describe('flue add', () => {
 			result.stderr,
 			/flue add tooling vitest-evals\s+tooling\s+https:\/\/vitest-evals\.sentry\.dev/,
 		);
+		assert.match(result.stderr, /flue add sandbox blaxel\s+sandbox\s+https:\/\/blaxel\.ai/);
 		assert.ok(result.stderr.includes('flue add sandbox <url>'));
 		assert.ok(result.stderr.includes('flue add channel <url>'));
 		assert.ok(result.stderr.includes('flue add database <url>'));
@@ -192,6 +194,18 @@ describe('flue add', () => {
 		assert.ok(result.stdout.includes('<source-dir>/sandboxes/daytona.ts'));
 		assert.ok(result.stdout.includes("'../sandboxes/daytona'"));
 		assert.ok(!result.stdout.includes('/connectors/'));
+	});
+
+	it('prints the Blaxel sandbox blueprint with the supported SDK and lifecycle boundary', async () => {
+		const result = await runCli(['add', 'sandbox', 'blaxel', '--print']);
+
+		assert.equal(result.code, 0);
+		assert.ok(result.stdout.includes('<source-dir>/sandboxes/blaxel.ts'));
+		assert.ok(result.stdout.includes('@blaxel/core@^0.3.6'));
+		assert.ok(result.stdout.includes('SandboxInstance.createIfNotExists'));
+		assert.ok(result.stdout.includes('waitForCompletion: true'));
+		assert.ok(result.stdout.includes('Math.ceil(options.timeoutMs / 1000)'));
+		assert.ok(result.stdout.includes('does not call `sandbox.delete()`'));
 	});
 
 	it('prints the WhatsApp channel blueprint', async () => {

--- a/skills/flue/SKILL.md
+++ b/skills/flue/SKILL.md
@@ -89,6 +89,7 @@ ecosystem/deploy/node -- Deploy Agents on Node.js
 ecosystem/deploy/railway -- Deploy Agents on Railway
 ecosystem/deploy/render -- Deploy Agents on Render
 ecosystem/deploy/sst -- Deploy Agents on SST
+ecosystem/sandboxes/blaxel -- Blaxel
 ecosystem/sandboxes/boxd -- boxd
 ecosystem/sandboxes/cloudflare -- Cloudflare Sandbox
 ecosystem/sandboxes/cloudflare-shell -- Cloudflare Shell
@@ -100,6 +101,7 @@ ecosystem/sandboxes/mirage -- Mirage
 ecosystem/sandboxes/modal -- Modal
 ecosystem/sandboxes/vercel -- Vercel Sandbox
 ecosystem/tooling/braintrust -- Braintrust
+ecosystem/tooling/jetty -- Jetty
 ecosystem/tooling/opentelemetry -- OpenTelemetry
 ecosystem/tooling/sentry -- Sentry
 ecosystem/tooling/vitest-evals -- Vitest Evals


### PR DESCRIPTION
## Summary

- Add a `sandbox/blaxel` blueprint that adapts an application-owned `@blaxel/core` `SandboxInstance` to Flue's `SandboxApi`.
- Add the Blaxel ecosystem guide and agent-readable documentation catalog entry.
- Cover blueprint discovery and printed lifecycle/timeout guidance in the CLI tests.

The catalog update also includes the already-existing Jetty documentation page so the tracked catalog stays synchronized with `flue docs`.

## Why

This is a fresh implementation of the Blaxel sandbox proposal tracked in [Discussion #288](https://github.com/withastro/flue/discussions/288). It gives Flue users a documented adapter for Blaxel's persistent sandboxes while leaving sandbox identity, retention, and deletion under application control.

## Adapter behavior

- Supports text and binary reads and writes, stat, listing, existence checks, directory creation, removal, and command execution.
- Forwards working directory and environment variables to Blaxel processes.
- Rounds Flue millisecond deadlines up to Blaxel's whole-second process timeout.
- Rejects unsupported forced removal before mutation.
- Wraps an initialized sandbox and never deletes application-owned infrastructure when a Flue harness closes.

## Validation

- `pnpm check`: 103/103 build, lint, and type tasks passed; 96/96 test tasks passed.
- CLI Node tests: 94/94 passed.
- CLI Vitest: 83/83 passed.
- Documentation build: 101 pages built, including the Blaxel guide.
- Generated adapter typechecked against the published `@blaxel/core` package.
- Disposable Blaxel sandbox acceptance covered text/binary I/O, stat/list/exists, recursive mkdir/removal, command cwd/env, timeout forwarding, and the application-owned lifecycle boundary.
