### PR TITLE
Record tool payloads of every shape on gen_ai.tool.call.*

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/tooling/opentelemetry.md
+++ b/apps/docs/src/content/docs/ecosystem/tooling/opentelemetry.md
@@ -65,7 +65,7 @@ const instrumentation = createOpenTelemetryInstrumentation({
 
 A detached converted value passes through `transform` once per content type; returning `undefined` omits that content, and a throwing transform emits a `[flue]` failure sentinel instead of the unredacted value. `scope` carries the content type, event type, execution identity, and `traceId`/`spanId`. For byte budgets, slice inside the transform or use the exported `truncateContent(content, { maxBytes })`. After the transform, a 56 KiB per-span content budget is enforced **in-band**: everything content-bearing a span carries — messages, system instructions, tool definitions and payloads, exception message/stack — shares one pool, with a reserve held so response content has room beside large prompts. Payloads stay valid JSON, oldest messages drop first behind a `role: "flue"` sentinel message, and oversized strings are cut with a `[flue:truncated, …]` suffix — there are no side-channel truncation marker attributes; search payloads for `[flue]` instead.
 
-Object-shaped tool arguments/results use standard `gen_ai.tool.call.*` attributes; other shapes use `flue.tool.call.arguments` or `flue.tool.call.result` under the same policy.
+Tool arguments/results use the standard `gen_ai.tool.call.*` attributes for every payload shape: structured payloads (including strings carrying serialized JSON) record as JSON, plain text records as a raw string.
 
 ## Metrics and Logs
 

--- a/packages/opentelemetry/README.md
+++ b/packages/opentelemetry/README.md
@@ -62,7 +62,7 @@ The master `enabled` value is the privacy ceiling. One detached copy passes thro
 
 `externalContent` is a side-effect-only sink for system instructions and input/output messages. It receives a detached, structurally limited clone plus a stable `contentType` scope before inline recording, regardless of sampling or `inline`. Its return value and mutations are ignored, failures only produce safe diagnostics, and tool definitions, descriptions, arguments, and results are never delivered to it.
 
-Set `inline: false` to skip serialization while retaining external delivery. `maxAttributeBytes` applies only to the exact final UTF-8 inline attribute string. Object-shaped tool arguments/results use standard `gen_ai.tool.call.*` attributes; other useful values use `flue.tool.call.arguments` or `flue.tool.call.result` under the same privacy and size policy. Tool descriptions and plain-text fallbacks remain raw strings. Structural truncation and byte omission are marked with bounded `flue.telemetry.content.*` attributes. Flue does not flatten undeclared child keys beneath `gen_ai.*`.
+Set `inline: false` to skip serialization while retaining external delivery. `maxAttributeBytes` applies only to the exact final UTF-8 inline attribute string. Tool arguments/results use the standard `gen_ai.tool.call.*` attributes: structured payloads (including strings carrying serialized JSON) record as JSON, and plain-text payloads record as raw strings, under the same privacy and size policy. Tool descriptions remain raw strings. Structural truncation and byte omission are marked with bounded `flue.telemetry.content.*` attributes. Flue does not flatten undeclared child keys beneath `gen_ai.*`.
 
 ## Metrics and Logs
 

--- a/packages/opentelemetry/src/index.ts
+++ b/packages/opentelemetry/src/index.ts
@@ -713,10 +713,6 @@ function setContent(
 	if (result.value !== undefined) tracked.span.setAttribute(name, result.value);
 }
 
-/**
- * The draw is charged under the semconv key; the raw fallback differs by a
- * few bytes, well inside the pool's slack.
- */
 function setToolContent(
 	tracked: TrackedSpan,
 	kind: 'arguments' | 'result',
@@ -726,21 +722,15 @@ function setToolContent(
 ): void {
 	if (policy === false) return;
 	const spanContext = tracked.span.spanContext();
+	const name = ATTR[kind === 'arguments' ? 'toolArguments' : 'toolResult'];
 	const result = drawContentAttribute(tracked.ledger, policy, () => value, event, {
-		key: ATTR[kind === 'arguments' ? 'toolArguments' : 'toolResult'],
+		key: name,
 		contentType: kind === 'arguments' ? 'tool_arguments' : 'tool_result',
 		rawString: true,
 		traceId: spanContext.traceId,
 		spanId: spanContext.spanId,
 	});
-	if (result.value !== undefined) {
-		tracked.span.setAttribute(
-			result.objectShaped
-				? ATTR[kind === 'arguments' ? 'toolArguments' : 'toolResult']
-				: `flue.tool.call.${kind}`,
-			result.value,
-		);
-	}
+	if (result.value !== undefined) tracked.span.setAttribute(name, result.value);
 }
 
 function complete(

--- a/packages/runtime/src/cloudflare/tracing/index.ts
+++ b/packages/runtime/src/cloudflare/tracing/index.ts
@@ -722,12 +722,7 @@ function contentEntry(
 	return result.value === undefined ? {} : { [name]: result.value };
 }
 
-/**
- * Tool payloads keep the semconv `gen_ai.tool.call.*` keys for plain objects
- * and move to the `flue.tool.call.*` fallback names otherwise, mirroring
- * `@flue/opentelemetry`. The draw is charged under the semconv key; the raw
- * fallback differs by a few bytes, well inside the pool's slack.
- */
+/** Tool payloads ride the semconv `gen_ai.tool.call.*` keys, mirroring `@flue/opentelemetry`. */
 function toolPayloadEntry(
 	ledger: ContentLedger,
 	content: ContentOption | undefined,
@@ -735,21 +730,13 @@ function toolPayloadEntry(
 	kind: 'arguments' | 'result',
 	value: unknown,
 ): AttributeValues {
+	const key = kind === 'arguments' ? CONTENT_ATTR.toolArguments : CONTENT_ATTR.toolResult;
 	const result = drawContentAttribute(ledger, content, () => value, event, {
-		key: kind === 'arguments' ? CONTENT_ATTR.toolArguments : CONTENT_ATTR.toolResult,
+		key,
 		contentType: kind === 'arguments' ? 'tool_arguments' : 'tool_result',
 		rawString: true,
 	});
-	if (result.value === undefined) return {};
-	const key =
-		kind === 'arguments'
-			? result.objectShaped
-				? CONTENT_ATTR.toolArguments
-				: CONTENT_ATTR.toolArgumentsRaw
-			: result.objectShaped
-				? CONTENT_ATTR.toolResult
-				: CONTENT_ATTR.toolResultRaw;
-	return { [key]: result.value };
+	return result.value === undefined ? {} : { [key]: result.value };
 }
 
 /**

--- a/packages/runtime/src/telemetry/content.ts
+++ b/packages/runtime/src/telemetry/content.ts
@@ -95,8 +95,6 @@ export interface ContentAttributeOptions {
 
 export interface ContentAttributeResult {
 	value?: string;
-	/** Post-transform value was a plain object — decides `gen_ai.tool.call.*` vs the `flue.*` raw fallback keys. */
-	objectShaped?: boolean;
 }
 
 const ENCODER = new TextEncoder();
@@ -121,7 +119,16 @@ export function contentAttribute(
 		}
 		if (value === undefined) return {};
 	}
-	const objectShaped = isPlainObject(value);
+	if (
+		typeof value === 'string' &&
+		(options.contentType === 'tool_arguments' || options.contentType === 'tool_result')
+	) {
+		// Best-effort deserialization, per the semconv guidance for
+		// `gen_ai.tool.call.*`: a string carrying serialized JSON records in
+		// structured form; any other string records as-is.
+		const parsed = parseSerializedJson(value);
+		if (parsed !== undefined) value = parsed;
+	}
 	const budget =
 		typeof options.maxBytes === 'number' && Number.isFinite(options.maxBytes)
 			? Math.min(Math.max(Math.floor(options.maxBytes), MIN_BUDGET_BYTES), CONTENT_BUDGET_BYTES)
@@ -132,7 +139,7 @@ export function contentAttribute(
 		serialized = serialize(truncateContent(value, { maxBytes: budget }), options);
 		if (serialized === undefined) return { value: CONTENT_UNSERIALIZABLE };
 	}
-	return { value: serialized, objectShaped };
+	return { value: serialized };
 }
 
 /** Content types that describe the request; everything else records the outcome. */
@@ -226,4 +233,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	if (value === null || typeof value !== 'object') return false;
 	const prototype = Object.getPrototypeOf(value);
 	return prototype === Object.prototype || prototype === null;
+}
+
+function parseSerializedJson(value: string): Record<string, unknown> | unknown[] | undefined {
+	const first = value.trimStart()[0];
+	if (first !== '{' && first !== '[') return undefined;
+	try {
+		const parsed: unknown = JSON.parse(value);
+		return isPlainObject(parsed) || Array.isArray(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
 }

--- a/packages/runtime/src/telemetry/semconv.ts
+++ b/packages/runtime/src/telemetry/semconv.ts
@@ -20,20 +20,21 @@ export const GEN_AI_SEMCONV_REVISION = '4c8addb53718b544134be47e256237026fe88875
 /** Bumped when the role/parts message projection changes shape. */
 export const GEN_AI_PROJECTION_REVISION = 5;
 /**
- * Bumped when the `flue.*` extension vocabulary changes. Revision 4: the
- * `flue.telemetry.content.<type>.truncated/.omitted` marker attributes are
- * gone — truncation and omission are represented in-band, inside the content
- * payload, by `[flue]`-prefixed sentinels (see `./truncate.ts`).
+ * Bumped when the `flue.*` extension vocabulary changes. Revision 5: the
+ * `flue.tool.call.arguments`/`flue.tool.call.result` fallback keys are gone —
+ * tool payloads of every shape record under the semconv `gen_ai.tool.call.*`
+ * keys, which type them `any` and sanction JSON-string form on spans.
+ * (Revision 4 moved truncation/omission markers in-band; see `./truncate.ts`.)
  */
-export const FLUE_TELEMETRY_EXTENSION_REVISION = 4;
+export const FLUE_TELEMETRY_EXTENSION_REVISION = 5;
 
 /**
  * Content-bearing attribute names. `gen_ai.*` keys follow the OpenTelemetry
- * GenAI semantic conventions (Development status). The two `flue.*` keys are
- * the fallback names for tool payloads that are not plain objects — the
- * semconv `gen_ai.tool.call.*` keys are specified as object-shaped, so
- * non-object payloads move to the extension namespace rather than lie about
- * their shape.
+ * GenAI semantic conventions (Development status). The `gen_ai.tool.call.*`
+ * keys are typed `any` there: structured form is preferred, and JSON-string
+ * form is sanctioned on spans when the attribute store cannot hold objects —
+ * which is every span attribute store this runtime writes to. Tool payloads
+ * of every shape therefore ride the semconv keys.
  */
 export const CONTENT_ATTR = {
 	inputMessages: 'gen_ai.input.messages',
@@ -43,6 +44,4 @@ export const CONTENT_ATTR = {
 	toolDescription: 'gen_ai.tool.description',
 	toolArguments: 'gen_ai.tool.call.arguments',
 	toolResult: 'gen_ai.tool.call.result',
-	toolArgumentsRaw: 'flue.tool.call.arguments',
-	toolResultRaw: 'flue.tool.call.result',
 } as const;


### PR DESCRIPTION
## Summary

- Record tool arguments/results on `gen_ai.tool.call.*` for every payload shape; drop the `flue.tool.call.*` fallback keys (`FLUE_TELEMETRY_EXTENSION_REVISION` → 5).
- Best-effort JSON-parse string payloads ([the spec asks for this](https://github.com/open-telemetry/semantic-conventions-genai/blob/4c8addb53718b544134be47e256237026fe88875/docs/registry/attributes/gen-ai.md)) so serialized objects record structured and double-encoded results un-nest.
- Update `@flue/opentelemetry` README and the ecosystem docs page.

## Why

Fixes #568. String tool results — every MCP tool, most local tools — landed on vendor keys no backend reads, so consumers of the semconv keys showed tool inputs with no outputs. The spec types these attributes `any` and sanctions JSON-string form on spans; the adapters already stringify objects, so the object-only fork changed nothing but the key.

**Considered and skipped:** dual-writing `flue.tool.call.*` for a deprecation window. Both keys draw from the same per-span content pool (sized against workerd's 64 KiB span-attribute cap), so duplicating the largest payloads in the system would make truncation kick in twice as early. Easy to switch if you'd rather keep a compat window.

## Verification

- `pnpm exec turbo run build --filter=@flue/runtime --filter=@flue/opentelemetry` — pass
- `pnpm -w exec tsc --noEmit -p packages/runtime` / `-p packages/opentelemetry` — clean
- `biome lint` on the four changed source files — clean (`@flue/runtime` has no vitest files to run)
- Against the built dist: `'hello'` records as-is on `gen_ai.tool.call.result`; `'{"a":1}'` and `{a: 1}` record structured
- Live against Sentry: every successful `execute_tool` span (MCP tools included) carries `gen_ai.tool.call.result` and renders in the AI trace views

🤖 Generated with [Claude Code](https://claude.com/claude-code)
