### PR TITLE
docs: update Braintrust tooling guidance

### DIFF
--- a/apps/docs/src/content/docs/ecosystem/tooling/braintrust.md
+++ b/apps/docs/src/content/docs/ecosystem/tooling/braintrust.md
@@ -1,81 +1,90 @@
 ---
 title: Braintrust
 description: Trace Flue agent operations, model turns, tools, tasks, and compactions in Braintrust.
-lastReviewedAt: 2026-07-21
+lastReviewedAt: 2026-08-05
 ---
 
 ## Quickstart
 
-Add tracing to an existing Flue project with the [Braintrust](https://www.braintrust.dev) blueprint. Run the following command in your terminal or coding agent of choice:
+Add [Braintrust](https://www.braintrust.dev) tracing to an existing Flue project:
 
 ```sh
 flue add tooling braintrust
 ```
 
-## Overview
+Then set your credentials and start the application normally:
 
-The Braintrust blueprint creates a source-root `braintrust.ts` and imports it once from `app.ts`. The generated module initializes Braintrust when an API key is available, then connects Braintrust's Flue observer to the runtime event stream:
+```sh
+export BRAINTRUST_API_KEY='<braintrust-api-key>'
+export BRAINTRUST_PROJECT_NAME='Flue'
+```
 
-```ts title="src/braintrust.ts (abridged)"
-import { observe } from '@flue/runtime';
-import { braintrustFlueObserver, initLogger } from 'braintrust';
+`BRAINTRUST_PROJECT_NAME` is optional and defaults to `Flue`. Keep the API key in your deployment platform's secret store; on Cloudflare, use a Worker secret rather than a Wrangler `vars` value. EU and self-hosted organizations should also set `BRAINTRUST_API_URL` to the API URL shown under **Settings → Data plane**. See Braintrust's [tracing quickstart](https://www.braintrust.dev/docs/tracing-quickstart) for account and API-key setup.
 
-if (process.env.BRAINTRUST_API_KEY) {
+## How it works
+
+The blueprint installs the Braintrust SDK, creates `braintrust.ts` beside `app.ts`, and imports it once from `app.ts`. The generated module uses the first-class integration provided by current Braintrust releases:
+
+```ts title="src/braintrust.ts"
+import { instrument } from '@flue/runtime';
+import { braintrustFlueInstrumentation, initLogger } from 'braintrust';
+
+const apiKey = process.env.BRAINTRUST_API_KEY;
+
+if (apiKey) {
   initLogger({
     projectName: process.env.BRAINTRUST_PROJECT_NAME ?? 'Flue',
-    apiKey: process.env.BRAINTRUST_API_KEY,
+    apiKey,
   });
 
-  observe((event, ctx) => {
-    const compatible = compatibleEvent(event);
-    if (compatible) braintrustFlueObserver(compatible, ctx);
-  });
+  instrument(braintrustFlueInstrumentation());
 }
 ```
 
-The omitted `compatibleEvent(...)` helper translates current Flue tool and recovery events for the Braintrust version installed by the blueprint. The same module runs on Node.js and Cloudflare; unlike Sentry, Braintrust does not require a separate Cloudflare package or Durable Object wrapper.
+The instrumentation connects Braintrust to both Flue's runtime events and execution context, keeping the active Braintrust span available during model, tool, and task execution. No event adapter, provider wrapper, or Node import hook is needed. When the API key is absent, Braintrust is not initialized and the application continues without exporting traces.
 
-Once configured, agent operations appear as traces with nested spans for model turns, tools, delegated tasks, and compactions.
+The same module works across all Flue runtimes.
 
-## Configure
+## What gets traced
 
-| Variable                  | Purpose                                                                                 |
-| ------------------------- | --------------------------------------------------------------------------------------- |
-| `BRAINTRUST_API_KEY`      | **Required for trace export** — Authenticates trace export to Braintrust.               |
-| `BRAINTRUST_PROJECT_NAME` | **Optional** — Chooses the Braintrust project that receives traces. Defaults to `Flue`. |
+| Flue activity      | Braintrust span                                     |
+| ------------------ | --------------------------------------------------- |
+| Prompt or skill    | `flue.prompt` or `flue.skill` task span             |
+| Model turn         | `flue.turn` LLM span with output, usage, and errors |
+| Tool call          | `tool:<name>` tool span                             |
+| Delegated task     | `task:<agent>` or `flue.task` task span             |
+| Context compaction | `flue.compact` with a `compaction:<reason>` child   |
 
-Never commit the API key; on Cloudflare, store it as a Worker secret rather than a Wrangler `vars` value. When the key is absent, the integration does not initialize or subscribe and the application continues without trace export.
+Spans include the available Flue correlation fields, such as agent, instance, conversation, harness, session, submission, operation, turn, and task identifiers. A prompt with a tool call typically looks like this:
 
-The blueprint installs Braintrust 3.17 and registers its public Flue observer through `observe(...)`. The same source builds on Node.js and Cloudflare through Braintrust's `workerd` export; no separate Cloudflare package or Durable Object wrapper is needed.
+```text
+flue.prompt
+  flue.turn
+  tool:lookup_weather
+  flue.turn
+```
 
-Braintrust also provides a Node import hook for Node-only auto-instrumentation. The generated manual observer is the portable path for projects that may target either runtime.
-
-See [Observability](/docs/guide/observability/#choose-an-observability-provider) to compare Braintrust with OpenTelemetry and Sentry.
-
-## What Braintrust traces
-
-- A prompt, skill, or compaction operation becomes a `flue.<kind>` task span.
-- A model turn becomes an `llm:<model>` span with input, output, errors, and usage metrics.
-- A tool call becomes a nested `tool:<name>` span.
-- A delegated task becomes a nested task span.
-- A context compaction becomes a nested compaction span.
-
-Model spans include token usage and estimated cost where available. Traces retain agent instance, session, operation, and optional `submissionId` correlation. See [Observability](/docs/guide/observability/) for Flue's identity and observer model.
-
-Braintrust 3.17 expects the previous `tool_call` name for terminal tool events, so the generated bridge translates tool events for the installed version. Re-check that translation before upgrading Braintrust.
+Braintrust records production traces in a project's **Logs** view. Tracing and evaluation are complementary: traces show what the application did, while eval cases add datasets, expectations, and scores. To publish [`vitest-evals`](/docs/ecosystem/tooling/vitest-evals/) cases as Braintrust experiments, use Braintrust's `vitest-evals` reporter.
 
 ## Protect sensitive content
 
-Braintrust tracing is content-bearing. Its observer can export model messages and output, reasoning, system prompts, tool definitions and values, task prompts and results, errors, and correlation metadata.
+This integration is content-bearing. It can export messages and model output, reasoning, system prompts, tool definitions, arguments and results, task content, errors, and correlation metadata.
 
-Review retention, access, privacy, and compliance requirements before enabling it in production. Use Braintrust's `setMaskingFunction(...)` before initialization when content requires redaction, and test the application-specific masker against representative prompts, reasoning, tool data, errors, secrets, and personal information.
+Review access and retention requirements before enabling it in production. If content needs redaction, call Braintrust's `setMaskingFunction(...)` before `initLogger(...)`. The function is global and masks `input`, `output`, `expected`, `metadata`, and `context`; test it against representative application data. See Braintrust's guide to [masking sensitive data](https://www.braintrust.dev/docs/instrument/advanced-tracing#mask-sensitive-data).
 
 ## Cloudflare delivery
 
-On Cloudflare, each generated agent Durable Object exports its own activity. Braintrust flushes asynchronously, but Flue observers cannot attach that final upload to the Durable Object execution lifetime. Delivery is therefore best-effort and may lose final spans when an isolate becomes idle immediately after work completes.
+Braintrust buffers and uploads spans in the background. Node.js gets Braintrust's best-effort `beforeExit` flush. In a Cloudflare Worker, the Flue integration cannot attach the SDK's final background upload to the Durable Object's execution lifetime, so the last spans can be lost if an isolate becomes idle immediately after an operation.
 
-Confirm that tradeoff before enabling Cloudflare export and verify delivery in a deployed Worker. Node uses Braintrust's process-exit flush fallback.
+Verify delivery in a deployed Worker before relying on these traces. Braintrust's [background logging guide](https://www.braintrust.dev/docs/instrument/advanced-tracing#background-logging-and-retries) explains its buffering and retry behavior.
 
 ## Verify
 
-Run an agent with a model turn and tool call against a non-production Braintrust project. Confirm the trace hierarchy, closed tool spans, usage data, and Flue correlation. On Cloudflare, separately verify final-span delivery under the deployed isolate lifecycle.
+Run a prompt that calls a tool against a non-production Braintrust project. In **Logs**, confirm that:
+
+- `flue.prompt` contains the model and tool spans;
+- the final model and tool spans close and contain the expected output;
+- token usage and Flue correlation fields are present;
+- the application still starts when `BRAINTRUST_API_KEY` is unset.
+
+See [Observability](/docs/guide/observability/#choose-an-observability-provider) to compare Braintrust with OpenTelemetry and Sentry.

--- a/apps/docs/src/content/docs/ecosystem/tooling/vitest-evals.md
+++ b/apps/docs/src/content/docs/ecosystem/tooling/vitest-evals.md
@@ -1,7 +1,7 @@
 ---
 title: Vitest Evals
 description: Add repeatable agent evals to a Flue project with vitest-evals.
-lastReviewedAt: 2026-07-21
+lastReviewedAt: 2026-08-05
 ---
 
 ## Quickstart
@@ -60,7 +60,25 @@ pnpm exec vitest-evals serve vitest-results.json
 
 The same artifact can be published by the `getsentry/vitest-evals` GitHub Action. Reports can contain prompts, outputs, tool arguments and results, errors, and application metadata; review retention and access requirements before uploading them.
 
-`vitest-evals` does not include a Braintrust reporter. Flue's [Braintrust integration](/docs/ecosystem/tooling/braintrust/) can independently trace the application execution, but those traces do not replace eval cases, assertions, judges, or CI gates.
+To publish the same cases as a Braintrust experiment, install `braintrust` and add its reporter beside the normal `vitest-evals` reporter:
+
+```ts title="vitest.evals.config.ts"
+import BraintrustVitestEvalsReporter from 'braintrust/vitest-evals-reporter';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    reporters: [
+      'vitest-evals/reporter',
+      new BraintrustVitestEvalsReporter({
+        projectName: process.env.BRAINTRUST_PROJECT_NAME ?? 'Flue',
+      }),
+    ],
+  },
+});
+```
+
+Set `BRAINTRUST_API_KEY` in the eval process. The reporter publishes inputs, outputs, pass and judge scores, usage, tool calls, and normalized traces. It is separate from Flue's [Braintrust tracing integration](/docs/ecosystem/tooling/braintrust/): the reporter records eval experiments, while the application integration records production-style traces. Neither replaces eval cases, assertions, judges, or CI gates.
 
 ## Next steps
 

--- a/blueprints/tooling--braintrust.md
+++ b/blueprints/tooling--braintrust.md
@@ -5,69 +5,50 @@
 # Add Braintrust to Flue
 
 You are an AI coding agent adding Braintrust tracing to a Flue project. Use
-Braintrust's public Flue observer with Flue's public `observe(...)` API so the
-same application source works on Node.js and Cloudflare.
-
-The integration traces prompt and skill operations, model turns, tool calls,
-delegated tasks, compactions, errors, token usage, and estimated cost. These
-events are content-bearing; make an explicit data-export decision before
-enabling them in a sensitive environment.
+Braintrust's first-class Flue instrumentation with Flue's `instrument(...)`
+API. The same application source must work across all Flue runtimes.
 
 ## Inspect the project
 
 Read local instructions, detect the package manager, and select the first
-existing source root: `<root>/.flue/`, then `<root>/src/`, then `<root>/`. Inspect
-`app.ts`, `flue.config.ts`, `vite.config.ts`, agent modules, environment types,
-deployment configuration, and secret conventions.
+existing source root: `<root>/.flue/`, then `<root>/src/`, then `<root>/`.
+Inspect `app.ts`, deployment configuration, environment types, and the
+project's secret conventions before editing them.
 
-Install `braintrust@3.17.0` with the project's package manager. Do not change the
-Flue target. The package provides Node and `workerd` exports, and the manual
-observer below uses the same source on both targets. Pin the audited version
-because the compatibility translations below depend on Braintrust's accepted
-Flue event names, which are not a typed public contract. Do not use Braintrust's Node
-`--import braintrust/hook.mjs` setup for a project that must also run on
-Cloudflare.
+Install the latest stable `braintrust` version allowed by the project's
+dependency policies. The integration below requires Braintrust 3.27.0 or
+newer for Flue 2 support. Preserve the Flue target and existing dependency
+conventions.
 
 ## Configure Braintrust
 
-Use these environment variables unless the project already has an established
-Braintrust convention:
+Use these variables unless the project already has a Braintrust convention:
 
 | Variable                  | Purpose                                                                |
 | ------------------------- | ---------------------------------------------------------------------- |
 | `BRAINTRUST_API_KEY`      | Braintrust API key; keep it in the deployment platform's secret store. |
 | `BRAINTRUST_PROJECT_NAME` | Project receiving traces; defaults to `Flue`.                          |
+| `BRAINTRUST_API_URL`      | API URL for EU or self-hosted data planes; omit for the US default.    |
 
 Never invent or commit an API key. Update an existing `.env.example`,
-environment type, or deployment documentation when the project maintains one,
-but preserve its secret-management conventions. For Cloudflare deployment,
-store `BRAINTRUST_API_KEY` as a Worker secret rather than a Wrangler `vars`
-value. Flue's required `nodejs_compat` mode makes environment values available
-through `process.env` in both targets.
+environment type, or deployment guide when the project maintains one. On
+Cloudflare, store `BRAINTRUST_API_KEY` as a Worker secret rather than a
+Wrangler `vars` value.
 
-## Decide what may leave the application
+Braintrust exports model messages and output, reasoning, system prompts, tool
+definitions, tool arguments and results, task content, errors, and correlation
+metadata. Confirm that this data may leave the application. If it requires
+redaction, configure and test Braintrust's global `setMaskingFunction(...)`
+before `initLogger(...)`.
 
-Braintrust's Flue observer exports model-visible messages and output, model
-reasoning, system prompts, tool definitions, tool arguments and results, task
-prompts and results, errors, and correlation metadata. Review the
-application's retention, access, privacy, and compliance requirements before
-registering it.
-
-If any exported content requires redaction, call Braintrust's
-`setMaskingFunction(...)` before `initLogger(...)`. The masking function is
-global and applies to `input`, `output`, `expected`, `metadata`, and `context`.
-Implement and test an application-specific masker; do not assume a generic list
-of secret-shaped field names is sufficient for prompts or personally
-identifiable information.
-
-## Create the Braintrust bridge
+## Add the instrumentation
 
 Create `<source-dir>/braintrust.ts`:
 
 ```ts title="src/braintrust.ts"
 // flue-blueprint: tooling/braintrust@1
-import { type FlueObservation, observe } from '@flue/runtime';
-import { braintrustFlueObserver, initLogger } from 'braintrust';
+import { instrument } from '@flue/runtime';
+import { braintrustFlueInstrumentation, initLogger } from 'braintrust';
 
 const apiKey = process.env.BRAINTRUST_API_KEY;
 
@@ -77,113 +58,53 @@ if (apiKey) {
     apiKey,
   });
 
-  observe((event, ctx) => {
-    const compatible = compatibleEvent(event);
-    if (compatible) braintrustFlueObserver(compatible, ctx);
-  });
-}
-
-/**
- * Forward only the lifecycle events Braintrust 3.17's Flue observer
- * consumes, renaming the terminal tool event to the `tool_call` shape it
- * expects.
- */
-function compatibleEvent(event: FlueObservation): unknown {
-  if (event.type === 'tool') return { ...event, type: 'tool_call' };
-  if (
-    event.type === 'operation_start' ||
-    event.type === 'operation' ||
-    event.type === 'turn_request' ||
-    event.type === 'turn' ||
-    event.type === 'tool_start' ||
-    event.type === 'task_start' ||
-    event.type === 'task' ||
-    event.type === 'compaction_start' ||
-    event.type === 'compaction'
-  ) {
-    return event;
-  }
-  return undefined;
+  instrument(braintrustFlueInstrumentation());
 }
 ```
 
-Braintrust 3.17 expects the previous `tool_call` name for Flue's terminal tool
-event, while current Flue emits `tool`. The compatibility translation closes
-tool spans without changing Flue's event contract. Every other consumed event
-passes through with its current public shape. The observer was written while
-Flue still had workflow runs, so it also accepts run-specific event names; the
-bridge never forwards them because Flue no longer emits them. Re-check the
-current Braintrust observer when upgrading it and remove the `tool_call`
-translation after the SDK accepts the current event directly.
-
-Import the bridge once from source-root `app.ts`:
+Import the module once from source-root `app.ts`:
 
 ```ts
 import './braintrust.ts';
 ```
 
 Preserve the application's existing imports, middleware, routes, and default
-export. If there is no `app.ts`, create one that imports `./braintrust.ts`,
-creates a Hono application, mounts each HTTP-reachable agent with
-`app.route('/agents/<name>', createAgentRouter(<AgentFn>))` (from
-`@flue/runtime/routing`), and default-exports the app.
-Install a direct `hono` dependency when authoring that file.
+export. The explicit Flue instrumentation covers the framework across all Flue
+runtimes. It installs both the observer and an execution interceptor so the
+active Braintrust span follows model, tool, and task execution. Current
+Braintrust releases consume Flue 2 events, including terminal `tool` events,
+directly.
 
-When `BRAINTRUST_API_KEY` is absent, the integration does not initialize or
-subscribe and the application runs without trace export.
+When `BRAINTRUST_API_KEY` is absent, the module leaves Braintrust uninitialized
+and continues without exporting traces.
 
 ## Runtime behavior
 
-The observer produces:
+The instrumentation produces:
 
-| Flue activity                          | Braintrust trace                               |
-| -------------------------------------- | ---------------------------------------------- |
-| Prompt, skill, or compaction operation | Root `flue.<kind>` task span                   |
-| Model turn                             | `llm:<model>` span with usage and cost metrics |
-| Tool call                              | Nested `tool:<name>` span                      |
-| Delegated task                         | Nested task span                               |
-| Context compaction                     | Nested compaction span                         |
+| Flue activity      | Braintrust span                                     |
+| ------------------ | --------------------------------------------------- |
+| Prompt or skill    | `flue.prompt` or `flue.skill` task span             |
+| Model turn         | `flue.turn` LLM span with output, usage, and errors |
+| Tool call          | `tool:<name>` tool span                             |
+| Delegated task     | `task:<agent>` or `flue.task` task span             |
+| Context compaction | `flue.compact` with a `compaction:<reason>` child   |
 
-Each finite operation is a root span. Flue correlation fields — agent instance,
-session, and optional `dispatchId` — connect the spans back to the conversation
-that produced them.
-
-The same bridge runs in one Node process or independently in each Cloudflare
-Durable Object isolate. Braintrust flushes asynchronously. `observe(...)` does
-not await subscriber promises, and its context does not expose Cloudflare's
-`waitUntil(...)`, so the upload cannot be attached to the Durable Object
-execution lifetime through this integration. Node has a process-exit flush
-fallback; Cloudflare delivery is best-effort and may lose final spans when an
-isolate becomes idle immediately after an operation.
-Confirm that tradeoff with the user before enabling Cloudflare export and verify
-it under the deployed application's real isolate lifecycle. Do not add awaited
-network work inside the observer callback.
+Braintrust buffers uploads in the background. Node receives its best-effort
+`beforeExit` flush. On Cloudflare, the integration cannot attach the SDK's
+final background upload to the Durable Object execution lifetime, so final
+span delivery is best-effort. Tell the user about this limitation and verify
+it in a deployed Worker when Cloudflare is a target.
 
 ## Verify
 
-1. Type-check the project.
-2. Build both Node and Cloudflare targets when the project supports both, and
-   confirm the Cloudflare bundle resolves Braintrust's `workerd` export.
-3. Run against a non-production Braintrust project and exercise a plain prompt,
-   a tool call, a delegated task, compaction, and a controlled failure.
-4. Confirm operation, model, tool, task, and compaction spans close and nest
-   correctly. Specifically confirm the terminal tool span closes through the
-   compatibility translation.
-5. Confirm model spans contain expected token, cache-token, and estimated-cost
-   metrics.
-6. On Cloudflare, exercise a deployed agent and allow the request and isolate
-   to finish immediately; measure whether final spans arrive consistently and
-   report any loss as the documented best-effort delivery limitation.
-7. Run without `BRAINTRUST_API_KEY` and confirm the application still starts and
-   does not export traces.
-8. Inspect representative traces and verify the masking and data-retention
-   decision covers prompts, outputs, reasoning, tool data, errors, secrets, and
-   personal information.
-
-When updating an existing integration, inspect and compare it against this
-complete current blueprint, apply every relevant change while preserving
-customizations, and then add or update the marker in `braintrust.ts`.
-This comparison is required when the marker is missing.
+1. Type-check the project and build every supported target.
+2. Exercise a prompt with a tool call in a non-production Braintrust project.
+3. Confirm `flue.prompt` contains closed `flue.turn` and `tool:<name>` spans,
+   token usage, and Flue correlation fields.
+4. Run without `BRAINTRUST_API_KEY` and confirm the application still starts.
+5. Inspect representative trace content and verify the masking, retention, and
+   access decision.
 
 ## Upgrade Guide
 

--- a/blueprints/tooling--vitest-evals.md
+++ b/blueprints/tooling--vitest-evals.md
@@ -213,7 +213,22 @@ FLUE_AGENT_URL=https://preview.example.com/agents/service-status pnpm run evals
 
 Use the project's package-manager equivalents. Provider credentials belong to the Flue server process. Authentication credentials for a protected Flue route belong to the SDK client configuration; do not commit either kind of secret.
 
-`pnpm run evals:json` writes `vitest-results.json`. Inspect it with `pnpm exec vitest-evals serve vitest-results.json`, or publish it with the `getsentry/vitest-evals` GitHub Action. `vitest-evals` has no built-in Braintrust reporter. Flue's Braintrust tooling may be enabled independently to trace the application execution, but it does not replace eval cases, assertions, judges, or CI gates.
+`pnpm run evals:json` writes `vitest-results.json`. Inspect it with `pnpm exec vitest-evals serve vitest-results.json`, or publish it with the `getsentry/vitest-evals` GitHub Action.
+
+If the user wants Braintrust experiment reporting, install Braintrust 3.19.0 or newer and add its Node-only reporter alongside `vitest-evals/reporter`:
+
+```ts
+import BraintrustVitestEvalsReporter from 'braintrust/vitest-evals-reporter';
+
+reporters: [
+  'vitest-evals/reporter',
+  new BraintrustVitestEvalsReporter({
+    projectName: process.env.BRAINTRUST_PROJECT_NAME ?? 'Flue',
+  }),
+],
+```
+
+Keep `BRAINTRUST_API_KEY` in the eval process's secret environment. This reporter publishes eval inputs, outputs, scores, usage, tool calls, and normalized traces as an experiment. It is independent from Flue's Braintrust application instrumentation, which records production-style traces. Neither replaces eval cases, assertions, judges, or CI gates.
 
 ## Verify
 

--- a/examples/braintrust/README.md
+++ b/examples/braintrust/README.md
@@ -1,23 +1,10 @@
 # Braintrust tracing for Flue
 
-This example registers Braintrust's public Flue observer against Flue's public `observe(...)` event stream.
-
-## What it demonstrates
-
-- One observer integration traces prompt and skill operations, model turns, tools, delegated tasks, and compactions.
-- Model spans include content, errors, token usage, and estimated cost where available.
-- Flue correlation fields connect agent activity to Braintrust traces.
-- The application continues without trace export when `BRAINTRUST_API_KEY` is absent.
-
-The integration lives in [`src/app.ts`](src/app.ts). Agents do not import Braintrust.
-
-## Integration
-
-The example pins Braintrust 3.17 and registers only the lifecycle events its Flue observer consumes:
+This example uses Braintrust's first-class Flue instrumentation to trace agent operations. Agents do not import Braintrust; the integration is registered once in [`src/app.ts`](src/app.ts):
 
 ```ts
-import { type FlueObservation, observe } from '@flue/runtime';
-import { braintrustFlueObserver, initLogger } from 'braintrust';
+import { instrument } from '@flue/runtime';
+import { braintrustFlueInstrumentation, initLogger } from 'braintrust';
 
 const apiKey = process.env.BRAINTRUST_API_KEY;
 
@@ -27,59 +14,31 @@ if (apiKey) {
     apiKey,
   });
 
-  observe((event, ctx) => {
-    const compatible = compatibleEvent(event);
-    if (compatible) braintrustFlueObserver(compatible, ctx);
-  });
-}
-
-function compatibleEvent(event: FlueObservation): unknown {
-  if (event.type === 'tool') return { ...event, type: 'tool_call' };
-  if (
-    event.type === 'operation_start' ||
-    event.type === 'operation' ||
-    event.type === 'turn_request' ||
-    event.type === 'turn' ||
-    event.type === 'tool_start' ||
-    event.type === 'task_start' ||
-    event.type === 'task' ||
-    event.type === 'compaction_start' ||
-    event.type === 'compaction'
-  ) {
-    return event;
-  }
-  return undefined;
+  instrument(braintrustFlueInstrumentation());
 }
 ```
 
-Braintrust 3.17 expects `tool_call` for a terminal tool event; every other consumed event passes through with its current public shape. The observer was written while Flue still had workflow runs, so its workflow-specific handling (`run_start`/`run_end`) is simply never exercised here — persistent-agent activity is correlated by operation, instance, session, and optional dispatch fields instead.
+The instrumentation installs an execution interceptor so Braintrust's span
+context stays active during model, tool, and task execution.
 
-## Trace shape
-
-For a tool-using agent turn, the generated structure is:
+For a tool-using prompt, Braintrust records a trace like:
 
 ```text
 flue.prompt
-  llm:<model>
+  flue.turn
   tool:lookup_weather
-  llm:<model>
+  flue.turn
 ```
 
-| Flue activity                          | Braintrust representation |
-| -------------------------------------- | ------------------------- |
-| Prompt, skill, or compaction operation | `task` span               |
-| Model turn                             | Nested `llm` span         |
-| Tool call                              | Nested `tool` span        |
-| Delegated task                         | Nested `task` span        |
-| Context compaction                     | Nested compaction span    |
+The spans include model input and output, errors, token usage, cost when available, and Flue correlation fields. Delegated tasks and context compactions receive their own nested spans.
 
 ## Sensitive content
 
-Braintrust's observer is content-bearing. It can export model messages and output, reasoning, system prompts, tool definitions and values, task content, errors, and correlation metadata. Use Braintrust's masking support and review retention and access requirements before enabling it for sensitive workloads. See the [Braintrust ecosystem guide](https://flueframework.com/docs/ecosystem/tooling/braintrust/).
+This integration can export prompts, output, reasoning, system instructions, tool definitions and values, task content, and errors. Review retention and access requirements before enabling it for sensitive workloads. The [Braintrust ecosystem guide](https://flueframework.com/docs/ecosystem/tooling/braintrust/) covers masking and Cloudflare's best-effort final-span delivery.
 
-## Running it
+## Run the example
 
-From the repository root, install workspace dependencies:
+From the repository root, install dependencies:
 
 ```bash
 pnpm install
@@ -93,13 +52,13 @@ export BRAINTRUST_PROJECT_NAME='Flue'
 export ANTHROPIC_API_KEY='<anthropic-api-key>'
 ```
 
-From this example directory, start the Node dev server:
+Start the Node development server from this directory:
 
 ```bash
 pnpm exec vite dev
 ```
 
-Vite prints the local URL it serves (`http://localhost:5173` by default — substitute yours below). Agent prompts are fire-and-forget: `POST` returns a `202` admission, and a `GET` of the same URL streams the conversation. Trigger each example agent:
+Vite prints the local URL (`http://localhost:5173` by default). Trigger the example agents:
 
 ```bash
 curl -X POST 'http://localhost:5173/agents/prompt/demo-1' \

--- a/examples/braintrust/package.json
+++ b/examples/braintrust/package.json
@@ -8,7 +8,7 @@
 	},
 	"dependencies": {
 		"@flue/runtime": "workspace:*",
-		"braintrust": "3.25.0",
+		"braintrust": "3.27.0",
 		"hono": "^4.7.0",
 		"valibot": "^1.0.0"
 	},

--- a/examples/braintrust/src/app.ts
+++ b/examples/braintrust/src/app.ts
@@ -1,6 +1,6 @@
-import { type FlueObservation, observe } from '@flue/runtime';
+import { instrument } from '@flue/runtime';
 import { createAgentRouter } from '@flue/runtime/routing';
-import { braintrustFlueObserver, initLogger } from 'braintrust';
+import { braintrustFlueInstrumentation, initLogger } from 'braintrust';
 import { Hono } from 'hono';
 import { Prompt } from './agents/prompt.ts';
 import { Task } from './agents/task.ts';
@@ -14,33 +14,7 @@ if (apiKey) {
 		apiKey,
 	});
 
-	observe((event, ctx) => {
-		const compatible = compatibleEvent(event);
-		if (compatible) braintrustFlueObserver(compatible, ctx);
-	});
-}
-
-/**
- * Forward only the lifecycle events Braintrust 3.17's Flue observer
- * consumes, renaming the terminal tool event to the `tool_call` shape it
- * expects.
- */
-function compatibleEvent(event: FlueObservation): unknown {
-	if (event.type === 'tool') return { ...event, type: 'tool_call' };
-	if (
-		event.type === 'operation_start' ||
-		event.type === 'operation' ||
-		event.type === 'turn_request' ||
-		event.type === 'turn' ||
-		event.type === 'tool_start' ||
-		event.type === 'task_start' ||
-		event.type === 'task' ||
-		event.type === 'compaction_start' ||
-		event.type === 'compaction'
-	) {
-		return event;
-	}
-	return undefined;
+	instrument(braintrustFlueInstrumentation());
 }
 
 const app = new Hono();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,8 +212,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/runtime
       braintrust:
-        specifier: 3.25.0
-        version: 3.25.0(@aws-sdk/credential-provider-web-identity@3.972.71)(zod@4.4.3)
+        specifier: 3.27.0
+        version: 3.27.0(@aws-sdk/credential-provider-web-identity@3.972.71)(zod@4.4.3)
       hono:
         specifier: ^4.7.0
         version: 4.12.32
@@ -6120,8 +6120,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  braintrust@3.25.0:
-    resolution: {integrity: sha512-0BIk3RDO9nLcvx4C7zaVJV0NfepZlJGi+K4jjUA/D8M9qq6YpCAP2gnBZr4UHAju8+t2Rl7MINim05K0BfaA9Q==}
+  braintrust@3.27.0:
+    resolution: {integrity: sha512-xtWgk4o8OACq6qPhIQSIBeJErj9POUUDcpTWIIjbPNSgpBPMktNLb1cMbk06YsF3goNnOlKaMcOBgwNhy1OSxQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.34 || ^4.0
@@ -6549,9 +6549,6 @@ packages:
 
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
-
-  dc-browser@1.0.4:
-    resolution: {integrity: sha512-7oEtnzNlcE+hr4OvO3GR6Gndgw8BhW+wKOEwMqSleyY7N29jbAxzyW5BaJl7qBCw+6OIxfMWtY0T+6dxq8RWLw==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -13517,7 +13514,7 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@3.25.0(@aws-sdk/credential-provider-web-identity@3.972.71)(zod@4.4.3):
+  braintrust@3.27.0(@aws-sdk/credential-provider-web-identity@3.972.71)(zod@4.4.3):
     dependencies:
       '@next/env': 14.2.35
       '@vercel/functions': 1.6.0(@aws-sdk/credential-provider-web-identity@3.972.71)
@@ -13530,7 +13527,6 @@ snapshots:
       cli-progress: 3.12.0
       cli-table3: 0.6.5
       cors: 2.8.6
-      dc-browser: 1.0.4
       dotenv: 16.6.1
       esbuild: 0.28.1
       esquery: 1.7.0
@@ -13974,8 +13970,6 @@ snapshots:
   data-uri-to-buffer@4.0.1: {}
 
   dayjs@1.11.21: {}
-
-  dc-browser@1.0.4: {}
 
   debug@4.4.3:
     dependencies:


### PR DESCRIPTION
## Summary

- update the Braintrust example and blueprint to use the Flue 2 instrumentation API from Braintrust 3.27
- simplify the tracing guide and document current spans, configuration, masking, and runtime behavior
- document Braintrust experiment reporting for vitest-evals

## Verification

- pnpm run check:types and pnpm run build in examples/braintrust
- pnpm run build in apps/docs
- pnpm run build in packages/cli
- git diff --check