### PR TITLE
docs: fix clipped scroll area of sidebar and table of contents

### DIFF
--- a/apps/docs/src/components/docs/DocsSidebar.astro
+++ b/apps/docs/src/components/docs/DocsSidebar.astro
@@ -12,6 +12,6 @@ interface Props {
 const { groups, currentSlug, mobile = false, groupHeadingLevel = 2 } = Astro.props;
 ---
 
-<nav class:list={[mobile ? 'static' : 'docs-sidebar-nav sticky top-[calc(var(--docs-header-height)+var(--docs-aside-top))] max-h-[calc(100vh-var(--docs-header-height)-var(--docs-aside-top)-2rem)] overflow-y-auto pr-2']} aria-label="Documentation navigation">
+<nav class:list={[mobile ? 'static' : 'docs-sidebar-nav sticky top-[var(--docs-header-height)] max-h-[calc(100vh-var(--docs-header-height))] overflow-y-auto pt-[var(--docs-aside-top)] pr-2 pb-8']} aria-label="Documentation navigation">
 	{groups.map((group) => <DocsSidebarGroup group={group} currentSlug={currentSlug} mobile={mobile} headingLevel={groupHeadingLevel} />)}
 </nav>

--- a/apps/docs/src/components/docs/DocsTableOfContents.astro
+++ b/apps/docs/src/components/docs/DocsTableOfContents.astro
@@ -15,7 +15,7 @@ const { headings } = Astro.props;
 ---
 
 {headings.length > 1 && (
-	<nav class="sticky top-[calc(var(--docs-header-height)+var(--docs-aside-top))] max-h-[calc(100vh-var(--docs-header-height)-var(--docs-aside-top)-2rem)] overflow-y-auto pr-2" aria-label="On this page">
+	<nav class="sticky top-[var(--docs-header-height)] max-h-[calc(100vh-var(--docs-header-height))] overflow-y-auto pt-[var(--docs-aside-top)] pr-2 pb-8" aria-label="On this page">
 		<p class="mb-3 text-xs font-semibold tracking-wider text-gray-500 uppercase">On this page</p>
 		<ul class="m-0 list-none p-0">
 			{headings.map((heading) => <DocsTocItem depth={heading.depth} slug={heading.slug} text={heading.text} />)}

--- a/apps/docs/src/layouts/DocsLayout.astro
+++ b/apps/docs/src/layouts/DocsLayout.astro
@@ -94,7 +94,7 @@ const formattedReviewedDate = lastReviewedAt?.toLocaleDateString('en-US', {
 					: 'grid-cols-[254px_minmax(0,820px)_16.5rem] max-2xl:grid-cols-[232px_minmax(0,1fr)]',
 			]}
 		>
-			<aside class="border-r border-docs-border pt-[var(--docs-aside-top)] pr-8 pb-8 pl-5 max-docs-desktop:hidden">
+			<aside class="border-r border-docs-border pr-8 pl-5 max-docs-desktop:hidden">
 				<DocsSidebar groups={currentSection.groups} currentSlug={currentSlug} />
 			</aside>
 			<main
@@ -157,7 +157,7 @@ const formattedReviewedDate = lastReviewedAt?.toLocaleDateString('en-US', {
 			</main>
 			{
 				variant === 'default' && (
-					<aside class="pt-[var(--docs-aside-top)] pr-2 pb-8 pl-7 max-2xl:hidden">
+					<aside class="pr-2 pl-7 max-2xl:hidden">
 						{showTableOfContents && <DocsTableOfContents headings={tableOfContents} />}
 					</aside>
 				)


### PR DESCRIPTION
## What

On `/docs/*` pages, the sidebar navigation (and the "On this page" table of contents) is a `sticky` scroll container with `overflow-y-auto`. Its bounds currently start 2rem below the header and end 2rem above the viewport bottom, because the vertical spacing lives as `pt`/`pb` padding on the wrapping `<aside>` — outside the scroll container. As soon as the list is long enough to scroll, items get chopped mid-letter at those floating boundaries, with dead zones above and below.

<img width="5120" height="2716" alt="CleanShot 2026-08-11 at 18 00 17@2x" src="https://github.com/user-attachments/assets/40d3f326-d5cf-4361-b1d1-01b5d562bff1" />

## Fix

Move the vertical spacing inside the scroll containers: the nav now spans the full height below the header (`top: var(--docs-header-height)`, `max-height: calc(100vh - var(--docs-header-height))`) and carries the spacing itself as `pt-[var(--docs-aside-top)] pb-8`. Because overflow clips at the padding edge, scrolled items remain visible while passing through the padding zone and disappear cleanly at the header border and the viewport bottom.

The resting (unscrolled) layout is pixel-identical: the first item still sits 2rem below the header.

## Testing

Verified locally with `astro dev` at various viewport heights and scroll positions on `/docs/guide/channels/`, comparing against production. Both the sidebar and the table of contents scroll their full content and no longer clip items at the floating boundaries.